### PR TITLE
fix: add missing shutil import for external TTS mode

### DIFF
--- a/app/tts.py
+++ b/app/tts.py
@@ -2,6 +2,7 @@ import os
 import re
 import json
 import threading
+import shutil
 import numpy as np
 import soundfile as sf
 from pydub import AudioSegment


### PR DESCRIPTION
`shutil` is used at lines 1465 and 1523 in `_external_generate_custom`  and `_external_generate_clone` to copy the generated audio file, but was only imported locally inside an unrelated function (line 636) and not at module level.

This causes a `NameError: name 'shutil' is not defined` when using  an external Gradio TTS server in CustomVoice mode.

Fix: add `import shutil` to the top-level imports.