### PR TITLE
fix: correct CUDA device property name from total_mem to total_memory

### DIFF
--- a/alexandria_colab.ipynb
+++ b/alexandria_colab.ipynb
@@ -42,7 +42,7 @@
     "    )\n",
     "\n",
     "gpu_name = torch.cuda.get_device_name(0)\n",
-    "vram_gb = torch.cuda.get_device_properties(0).total_mem / 1e9\n",
+    "vram_gb = torch.cuda.get_device_properties(0).total_memory / 1e9\n",
     "print(f\"GPU: {gpu_name}\")\n",
     "print(f\"VRAM: {vram_gb:.1f} GB\")\n",
     "print(f\"PyTorch: {torch.__version__}\")\n",


### PR DESCRIPTION
torch.cuda.get_device_properties() returns a _CudaDeviceProperties object with attribute 'total_memory', not 'total_mem'. This fixes AttributeError when querying GPU VRAM on Kaggle/Colab.

Affected line:
- vram_gb = torch.cuda.get_device_properties(0).total_mem / 1e9
+ vram_gb = torch.cuda.get_device_properties(0).total_memory / 1e9

Tested on: Kaggle T4, CUDA 12.8, torch 2.8.0