### PR TITLE
feat: add cancel button for script generation

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -333,7 +333,7 @@ class GeneratePersonasRequest(BaseModel):
 
 # Global state for process tracking
 process_state = {
-    "script": {"running": False, "logs": []},
+    "script": {"running": False, "logs": [], "cancel": False, "process": None},
     "voices": {"running": False, "logs": []},
     "persona": {"running": False, "logs": [], "cancel": False, "process": None},
     "audio": {"running": False, "logs": [], "cancel": False},
@@ -367,6 +367,13 @@ def run_process(command: List[str], task_name: str):
         )
         process_state[task_name]["process"] = process
 
+        # Handle cancel queued before Popen completed
+        if process_state[task_name].get("cancel"):
+            try:
+                process.terminate()
+            except OSError:
+                pass
+
         for line in process.stdout:
             log_line = line.strip()
             if log_line:
@@ -389,6 +396,25 @@ def run_process(command: List[str], task_name: str):
     finally:
         process_state[task_name]["process"] = None
         process_state[task_name]["running"] = False
+        if "cancel" in process_state[task_name]:
+            process_state[task_name]["cancel"] = False
+
+
+def _cancel_task(state_key: str, not_running_msg: str, exited_msg: str):
+    """Terminate a running subprocess task, or queue cancel if Popen hasn't fired yet."""
+    state = process_state[state_key]
+    if not state["running"]:
+        raise HTTPException(status_code=400, detail=not_running_msg)
+    proc = state.get("process")
+    if proc is None:
+        # Pre-Popen race: run_process will check the flag immediately after Popen
+        state["cancel"] = True
+        return {"status": "cancel queued"}
+    try:
+        proc.terminate()
+    except OSError:
+        raise HTTPException(status_code=400, detail=exited_msg)
+    return {"status": "cancel signal sent"}
 
 
 def _atomic_json_write(data, target_path):
@@ -473,7 +499,8 @@ async def get_config():
             except RuntimeError:
                 pass  # review_prompts.txt missing or malformed — leave fields empty
 
-    # Include current input file info if available
+    # Include current input file info (always present; null if no file loaded)
+    config["current_file"] = None
     state_path = os.path.join(ROOT_DIR, "state.json")
     if os.path.exists(state_path):
         try:
@@ -663,6 +690,15 @@ async def generate_script(background_tasks: BackgroundTasks):
 
     background_tasks.add_task(run_process, [sys.executable, "-u", "generate_script.py", input_file], "script")
     return {"status": "started"}
+
+
+@app.post("/api/generate_script/cancel")
+async def generate_script_cancel():
+    return _cancel_task(
+        "script",
+        "No script generation is currently running.",
+        "Script generation process already exited.",
+    )
 
 @app.post("/api/review_script")
 async def review_script(background_tasks: BackgroundTasks):

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -324,6 +324,9 @@
                         <button class="btn btn-success btn-lg" id="btn-gen-script">
                             <i class="fas fa-magic me-2"></i>Generate Annotated Script
                         </button>
+                        <button class="btn btn-outline-danger" id="btn-cancel-script" style="display:none;" onclick="cancelScript()">
+                            <i class="fas fa-stop me-1"></i>Cancel
+                        </button>
                         <small class="text-muted">Sends the book to your LLM to split it into annotated chunks with speaker labels and voice directions.</small>
                         <button class="btn btn-outline-secondary btn-lg" id="btn-review-script">
                             <i class="fas fa-check-double me-2"></i>Review Script (Optional)
@@ -1265,9 +1268,16 @@
                 return;
             }
 
+            const genBtn = document.getElementById('btn-gen-script');
+            const cancelBtn = document.getElementById('btn-cancel-script');
             try {
                 await API.post('/api/generate_script', {});
-                pollLogs('script', 'script-logs');
+                genBtn.disabled = true;
+                cancelBtn.style.display = 'inline-block';
+                pollLogs('script', 'script-logs', () => {
+                    genBtn.disabled = false;
+                    cancelBtn.style.display = 'none';
+                });
             } catch (e) {
                 const detail = e.message || 'Unknown error';
                 if (detail.includes('No input file')) {
@@ -1277,6 +1287,14 @@
                 }
             }
         });
+
+        window.cancelScript = async () => {
+            try {
+                await API.post('/api/generate_script/cancel', {});
+            } catch (e) {
+                showToast('Cancel failed: ' + (e.message || 'unknown error'), 'warning');
+            }
+        };
 
         document.getElementById('btn-review-script').addEventListener('click', async () => {
             try {
@@ -2437,7 +2455,7 @@
         };
 
         // --- Polling Logic ---
-        async function pollLogs(taskName, elementId) {
+        async function pollLogs(taskName, elementId, onDone) {
             const el = document.getElementById(elementId);
             const interval = setInterval(async () => {
                 try {
@@ -2447,6 +2465,7 @@
 
                     if (!status.running) {
                         clearInterval(interval);
+                        if (onDone) onDone(status);
                         if (taskName === 'audio' && status.logs.some(l => l.includes("complete"))) {
                             // Load audio player
                             const audio = document.getElementById('main-audio');


### PR DESCRIPTION
## Summary

- Script generation had no way to stop once started — could run for 30+ minutes on a large book
- Adds a **Cancel** button that appears next to Generate Script while a run is active, hides when it finishes
- Generate button is disabled during a run to prevent double-starts
- Uses `subprocess.Popen.terminate()` — cross-platform (TerminateProcess on Windows, SIGTERM on POSIX)

**Backend changes (`app.py`):**
- Add `cancel` and `process` fields to `process_state["script"]`
- Add `_cancel_task()` helper — terminates the subprocess or queues a cancel flag if Popen hasn't fired yet (handles the pre-Popen race window); shared with future cancel endpoints
- Add `POST /api/generate_script/cancel`
- `run_process()` checks the cancel flag immediately after Popen and resets it in `finally` so re-runs start clean
- Fix `/api/config` to always include `current_file` key (was conditionally omitted, causing the quick test suite to fail on a clean install)

**Frontend changes (`index.html`):**
- Cancel button added next to Generate Script; hidden until generation starts
- `pollLogs()` gains an optional `onDone` callback to restore button state on completion or cancellation
- `cancelScript()` calls the endpoint and surfaces failures as a toast

## Test plan

- [x] `python test_api.py` — 55 passed, 0 failed, 13 skipped
- [ ] Start a script generation run on a large book — Cancel button appears
- [ ] Click Cancel — generation stops, button hides, Generate re-enables
- [ ] Start a new generation immediately after cancelling — works cleanly (no stale cancel flag)
- [ ] Let generation complete normally — Cancel button hides, Generate re-enables

🤖 Generated with [Claude Code](https://claude.com/claude-code)