### PR TITLE
feat: Night and Super Night theme modes

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -7,26 +7,172 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     <style>
-        body { background-color: #f8f9fa; }
+        /* ── Theme tokens ──────────────────────────────────────────────── */
+        :root {
+            --bg-page:        #f8f9fa;
+            --bg-card:        #ffffff;
+            --bg-card-header: #f8f9fa;
+            --bg-input:       #ffffff;
+            --bg-navbar:      #212529;
+            --bg-modal:       #ffffff;
+            --text-primary:   #212529;
+            --text-muted:     #6c757d;
+            --text-heading:   #212529;
+            --border-color:   rgba(0,0,0,0.125);
+            --border-input:   #dee2e6;
+            --shadow:         rgba(0,0,0,0.1);
+            --step-bg:        #e9ecef;
+            --step-color:     #6c757d;
+            --hr-color:       rgba(0,0,0,0.1);
+            --badge-muted-bg: #6c757d;
+            --log-bg:         #1e1e1e;
+            --log-color:      #00ff00;
+            --theme-transition: background-color 0.25s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        /* ── Night mode ────────────────────────────────────────────────── */
+        html[data-theme="night"] {
+            --bg-page:        #1a1d24;
+            --bg-card:        #252a35;
+            --bg-card-header: #2c3040;
+            --bg-input:       #2c3040;
+            --bg-navbar:      #111419;
+            --bg-modal:       #252a35;
+            --text-primary:   #dde3ed;
+            --text-muted:     #8896a8;
+            --text-heading:   #e8edf5;
+            --border-color:   rgba(255,255,255,0.08);
+            --border-input:   #3d4558;
+            --shadow:         rgba(0,0,0,0.35);
+            --step-bg:        #363d50;
+            --step-color:     #8896a8;
+            --hr-color:       rgba(255,255,255,0.08);
+            --badge-muted-bg: #4a5568;
+            --log-bg:         #111419;
+            --log-color:      #4ade80;
+        }
+
+        /* ── Super Night mode ─────────────────────────────────────────── */
+        html[data-theme="super-night"] {
+            --bg-page:        #000000;
+            --bg-card:        #0c0c0c;
+            --bg-card-header: #111111;
+            --bg-input:       #0f0f0f;
+            --bg-navbar:      #000000;
+            --bg-modal:       #0c0c0c;
+            --text-primary:   #999999;
+            --text-muted:     #555555;
+            --text-heading:   #bbbbbb;
+            --border-color:   rgba(255,255,255,0.05);
+            --border-input:   #222222;
+            --shadow:         rgba(0,0,0,0.7);
+            --step-bg:        #1a1a1a;
+            --step-color:     #555555;
+            --hr-color:       rgba(255,255,255,0.05);
+            --badge-muted-bg: #2a2a2a;
+            --log-bg:         #000000;
+            --log-color:      #336633;
+        }
+
+        /* ── Base styles using tokens ──────────────────────────────────── */
+        body {
+            background-color: var(--bg-page);
+            color: var(--text-primary);
+            transition: var(--theme-transition);
+        }
         .container-wide { max-width: 85%; margin-left: auto; margin-right: auto; padding-left: 12px; padding-right: 12px; }
         .nav-link { cursor: pointer; }
+
+        /* Cards */
+        .card {
+            margin-bottom: 20px;
+            box-shadow: 0 2px 4px var(--shadow);
+            background-color: var(--bg-card);
+            border-color: var(--border-color);
+            transition: var(--theme-transition);
+        }
+        .card-header {
+            background-color: var(--bg-card-header);
+            border-bottom-color: var(--border-color);
+            color: var(--text-heading);
+        }
+        .card-body { color: var(--text-primary); }
+
+        /* Inputs */
+        .form-control, .form-select {
+            background-color: var(--bg-input);
+            border-color: var(--border-input);
+            color: var(--text-primary);
+            transition: var(--theme-transition);
+        }
+        .form-control:focus, .form-select:focus {
+            background-color: var(--bg-input);
+            color: var(--text-primary);
+            border-color: #0d6efd;
+            box-shadow: 0 0 0 0.2rem rgba(13,110,253,0.2);
+        }
+        .form-control::placeholder { color: var(--text-muted); opacity: 0.7; }
+        .form-control[readonly] { background-color: var(--bg-card-header); }
+        .form-text, label.form-label { color: var(--text-muted); }
+        .input-group-text {
+            background-color: var(--bg-card-header);
+            border-color: var(--border-input);
+            color: var(--text-muted);
+        }
+
+        /* Tables */
+        .table {
+            color: var(--text-primary);
+            border-color: var(--border-color);
+        }
+        .table th, .table td { border-color: var(--border-color); }
+        .table thead th { background-color: var(--bg-card-header); color: var(--text-heading); }
+        .table-striped > tbody > tr:nth-of-type(odd) > * { background-color: rgba(0,0,0,0.03); }
+        html[data-theme="night"] .table-striped > tbody > tr:nth-of-type(odd) > * { background-color: rgba(255,255,255,0.03); }
+        html[data-theme="super-night"] .table-striped > tbody > tr:nth-of-type(odd) > * { background-color: rgba(255,255,255,0.02); }
+
+        /* Modals */
+        .modal-content {
+            background-color: var(--bg-modal);
+            border-color: var(--border-color);
+            color: var(--text-primary);
+        }
+        .modal-header, .modal-footer { border-color: var(--border-color); }
+
+        /* Misc */
+        hr { border-color: var(--hr-color); opacity: 1; }
+        .text-muted { color: var(--text-muted) !important; }
+        h1,h2,h3,h4,h5,h6 { color: var(--text-heading); }
+        .list-group-item {
+            background-color: var(--bg-card);
+            border-color: var(--border-color);
+            color: var(--text-primary);
+        }
+        .collapse-header, [data-bs-toggle="collapse"] { color: var(--text-primary); }
+
+        /* Navbar */
+        .navbar { background-color: var(--bg-navbar) !important; transition: background-color 0.25s ease; }
+
+        /* Log window */
         .log-window {
-            background-color: #1e1e1e;
-            color: #00ff00;
+            background-color: var(--log-bg);
+            color: var(--log-color);
             font-family: 'Courier New', Courier, monospace;
             height: 300px;
             overflow-y: auto;
             padding: 10px;
             border-radius: 5px;
             font-size: 0.9em;
+            transition: background-color 0.25s ease, color 0.2s ease;
         }
-        .card { margin-bottom: 20px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+
+        /* Step indicator */
         .step-indicator {
             display: inline-block;
             width: 25px;
             height: 25px;
-            background-color: #e9ecef;
-            color: #6c757d;
+            background-color: var(--step-bg);
+            color: var(--step-color);
             border-radius: 50%;
             text-align: center;
             line-height: 25px;
@@ -35,19 +181,19 @@
         }
         .step-active { background-color: #0d6efd; color: white; }
         .voice-card { border-left: 4px solid #0d6efd; }
+
         /* Editor row expand/collapse */
         .chunk-action-btn {
             border: none;
             background: none;
             padding: 2px 4px;
             cursor: pointer;
-            color: #6c757d;
+            color: var(--text-muted);
             font-size: 0.85em;
             transition: transform 0.2s ease;
         }
-        .chunk-row.expanded .chunk-toggle-btn {
-            transform: rotate(180deg);
-        }
+        .chunk-row.expanded .chunk-toggle-btn { transform: rotate(180deg); }
+
         /* Core pipeline tabs - green */
         .nav-link.nav-pipeline { color: rgba(125, 227, 161, 0.7); }
         .nav-link.nav-pipeline:hover { color: #7de3a1; }
@@ -56,7 +202,142 @@
         .nav-link.nav-advanced { color: rgba(130, 177, 255, 0.7); }
         .nav-link.nav-advanced:hover { color: #82b1ff; }
         .nav-link.nav-advanced.active { color: #fff; background-color: #0d6efd; border-radius: 4px; }
+
+        /* ── Theme toggle button ───────────────────────────────────────── */
+        #theme-toggle {
+            background: none;
+            border: 1px solid rgba(255,255,255,0.25);
+            border-radius: 20px;
+            color: rgba(255,255,255,0.75);
+            padding: 3px 11px;
+            font-size: 0.82em;
+            cursor: pointer;
+            white-space: nowrap;
+            transition: border-color 0.2s, color 0.2s, background 0.2s;
+            display: flex;
+            align-items: center;
+            gap: 5px;
+        }
+        #theme-toggle:hover {
+            border-color: rgba(255,255,255,0.6);
+            color: #fff;
+            background: rgba(255,255,255,0.08);
+        }
+        html[data-theme="night"] #theme-toggle {
+            border-color: rgba(100,160,255,0.4);
+            color: rgba(150,190,255,0.9);
+        }
+        html[data-theme="super-night"] #theme-toggle {
+            border-color: rgba(80,80,80,0.6);
+            color: rgba(120,120,120,0.9);
+        }
+
+        /* Tinted card headers in night modes */
+        html[data-theme="night"] .bg-success.bg-opacity-10,
+        html[data-theme="super-night"] .bg-success.bg-opacity-10 { background-color: rgba(25,135,84,0.12) !important; }
+        html[data-theme="night"] .bg-info.bg-opacity-10,
+        html[data-theme="super-night"] .bg-info.bg-opacity-10 { background-color: rgba(13,202,240,0.08) !important; }
+        html[data-theme="night"] .bg-warning.bg-opacity-10,
+        html[data-theme="super-night"] .bg-warning.bg-opacity-10 { background-color: rgba(255,193,7,0.08) !important; }
+        html[data-theme="night"] .bg-primary.bg-opacity-10,
+        html[data-theme="super-night"] .bg-primary.bg-opacity-10 { background-color: rgba(13,110,253,0.1) !important; }
+
+        /* Select option backgrounds (browser-rendered, needs explicit override) */
+        html[data-theme="night"] select option,
+        html[data-theme="super-night"] select option {
+            background-color: var(--bg-input);
+            color: var(--text-primary);
+        }
+
+        /* ── Bootstrap CSS variable overrides for dark themes ─────────── */
+        html[data-theme="night"],
+        html[data-theme="super-night"] {
+            --bs-body-bg: var(--bg-page);
+            --bs-body-color: var(--text-primary);
+            --bs-border-color: var(--border-color);
+            --bs-card-bg: var(--bg-card);
+            --bs-card-cap-bg: var(--bg-card-header);
+            --bs-modal-bg: var(--bg-modal);
+        }
+
+        /* ── Bootstrap contextual table class overrides ────────────────── */
+        html[data-theme="night"] .table-light,
+        html[data-theme="super-night"] .table-light {
+            --bs-table-color: var(--text-primary);
+            --bs-table-bg: var(--bg-card-header);
+            --bs-table-border-color: var(--border-color);
+            color: var(--text-primary);
+        }
+        html[data-theme="night"] .table-primary,
+        html[data-theme="super-night"] .table-primary {
+            --bs-table-color: var(--text-primary);
+            --bs-table-bg: rgba(13,110,253,0.18);
+            --bs-table-border-color: var(--border-color);
+            color: var(--text-primary);
+        }
+        html[data-theme="night"] .table-info,
+        html[data-theme="super-night"] .table-info {
+            --bs-table-color: var(--text-primary);
+            --bs-table-bg: rgba(13,202,240,0.12);
+            --bs-table-border-color: var(--border-color);
+            color: var(--text-primary);
+        }
+        html[data-theme="night"] .table-warning,
+        html[data-theme="super-night"] .table-warning {
+            --bs-table-color: var(--text-primary);
+            --bs-table-bg: rgba(255,193,7,0.14);
+            --bs-table-border-color: var(--border-color);
+            color: var(--text-primary);
+        }
+        html[data-theme="night"] .table-secondary,
+        html[data-theme="super-night"] .table-secondary {
+            --bs-table-color: var(--text-primary);
+            --bs-table-bg: var(--bg-card-header);
+            --bs-table-border-color: var(--border-color);
+            color: var(--text-primary);
+        }
+
+        /* ── Bootstrap bg utility overrides ────────────────────────────── */
+        html[data-theme="night"] .bg-white,
+        html[data-theme="super-night"] .bg-white { background-color: var(--bg-card) !important; }
+        html[data-theme="night"] .bg-light,
+        html[data-theme="super-night"] .bg-light { background-color: var(--bg-card-header) !important; }
+        html[data-theme="night"] .bg-body,
+        html[data-theme="super-night"] .bg-body { background-color: var(--bg-page) !important; }
+
+        /* ── Bootstrap alert overrides ─────────────────────────────────── */
+        html[data-theme="night"] .alert-info,
+        html[data-theme="super-night"] .alert-info {
+            background-color: rgba(13,202,240,0.1);
+            border-color: rgba(13,202,240,0.25);
+            color: var(--text-primary);
+        }
+        html[data-theme="night"] .alert-warning,
+        html[data-theme="super-night"] .alert-warning {
+            background-color: rgba(255,193,7,0.1);
+            border-color: rgba(255,193,7,0.25);
+            color: var(--text-primary);
+        }
+        html[data-theme="night"] .alert-success,
+        html[data-theme="super-night"] .alert-success {
+            background-color: rgba(25,135,84,0.1);
+            border-color: rgba(25,135,84,0.25);
+            color: var(--text-primary);
+        }
+        html[data-theme="night"] .alert-danger,
+        html[data-theme="super-night"] .alert-danger {
+            background-color: rgba(220,53,69,0.1);
+            border-color: rgba(220,53,69,0.25);
+            color: var(--text-primary);
+        }
     </style>
+    <script>
+        /* Anti-flash: apply saved theme before first paint */
+        (function() {
+            const t = localStorage.getItem('alex-theme');
+            if (t && t !== 'light') document.documentElement.setAttribute('data-theme', t);
+        })();
+    </script>
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
@@ -76,7 +357,13 @@
                     <li class="nav-item"><a class="nav-link nav-advanced" data-tab="dataset-builder">Dataset</a></li>
                     <li class="nav-item"><a class="nav-link nav-advanced" data-tab="training">Training</a></li>
                 </ul>
-                <ul class="navbar-nav ms-auto align-items-center">
+                <ul class="navbar-nav ms-auto align-items-center gap-2">
+                    <li class="nav-item">
+                        <button id="theme-toggle" onclick="cycleTheme()" title="Toggle theme">
+                            <i id="theme-icon" class="fas fa-sun"></i>
+                            <span id="theme-label">Light</span>
+                        </button>
+                    </li>
                     <li class="nav-item small d-flex align-items-center" title="System Status">
                         <span id="sys-gpu" class="text-light d-flex align-items-center me-3"><i class="fas fa-microchip me-1 text-secondary"></i><span id="sys-gpu-val" style="font-family: monospace;">N/A</span></span>
                         <span id="sys-disk" class="text-light d-flex align-items-center"><i class="fas fa-hdd me-1 text-secondary"></i><span id="sys-disk-val" style="font-family: monospace;">N/A</span></span>
@@ -826,7 +1113,7 @@
                                 <i class="fas fa-book-reader me-1"></i>M4B Export Options <i class="fas fa-chevron-down fa-xs ms-1"></i>
                             </a>
                             <div class="collapse mt-2" id="m4b-options">
-                                <div class="border rounded p-3" style="background: var(--bs-light, #f8f9fa);">
+                                <div class="border rounded p-3" style="background: var(--bg-card-header);">
                                     <div class="row g-2">
                                         <div class="col-md-6">
                                             <label class="form-label small mb-1">Title</label>
@@ -988,6 +1275,39 @@
                 }
             });
         });
+
+        // --- Theme ---
+        const THEMES = [
+            { key: 'light',       icon: 'fa-sun',      label: 'Light'      },
+            { key: 'night',       icon: 'fa-moon',     label: 'Night'      },
+            { key: 'super-night', icon: 'fa-circle',   label: 'Super Night'},
+        ];
+
+        function applyTheme(key) {
+            const html = document.documentElement;
+            if (key === 'light') {
+                html.removeAttribute('data-theme');
+            } else {
+                html.setAttribute('data-theme', key);
+            }
+            const t = THEMES.find(t => t.key === key) || THEMES[0];
+            document.getElementById('theme-icon').className = `fas ${t.icon}`;
+            document.getElementById('theme-label').textContent = t.label;
+            localStorage.setItem('alex-theme', key);
+        }
+
+        function cycleTheme() {
+            const current = document.documentElement.getAttribute('data-theme') || 'light';
+            const idx = THEMES.findIndex(t => t.key === current);
+            const next = THEMES[(idx + 1) % THEMES.length];
+            applyTheme(next.key);
+        }
+
+        // Sync button label/icon with whatever the anti-flash snippet already applied
+        (function() {
+            const saved = localStorage.getItem('alex-theme') || 'light';
+            applyTheme(saved);
+        })();
 
         // --- API Helpers ---
         const API = {


### PR DESCRIPTION
## Summary

- Adds **Night** and **Super Night** dark theme modes alongside the existing light theme, toggled via a new `#theme-toggle` button in the navbar that cycles through all three modes
- Cherry-picks 22 commits from `origin/main` that had diverged from this branch, integrating: batch multi-file text/EPUB → script generation, cancellable single-file script gen, GPU/disk navbar monitor, TTS VRAM benchmark, Auto-Configure TTS batch button, Dataset Preparer tab, ROCm 7.x fixes, and thread+Queue non-blocking subprocess refactor
- All conflicts from the cherry-pick were manually reviewed and resolved (no blind ours/theirs decisions)

## Test plan

- [x] Server starts cleanly from `app/` directory (`uvicorn app:app`)
- [x] `GET /api/system/stats` returns live GPU + disk data
- [x] Batch script generation (`POST /api/generate_script/batch/start`) runs a real .txt file through the LLM pipeline end-to-end and saves output to `scripts/`
- [x] Double-submit guard returns 400 correctly
- [x] Empty tasks array returns 400 correctly
- [x] Missing file in batch skips gracefully (status: failed, no crash)
- [x] Single-file cancel endpoint returns correct 400 when nothing is running
- [x] Night and Super Night CSS present in served HTML (45 theme-related matches)
- [ ] Manual browser test: cycle theme button, batch file picker, GPU monitor refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)