### PR TITLE
Merge dev into main — issue #62 fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN pip install --no-cache-dir -r app/requirements.txt && \
 
 # Copy application code
 COPY app/ /alexandria/app/
-COPY default_prompts.txt review_prompts.txt /alexandria/
+COPY default_prompts.txt review_prompts.txt persona_prompts.txt /alexandria/
 COPY builtin_lora/ /alexandria/builtin_lora/
 
 # Create directories for runtime data

--- a/app/app.py
+++ b/app/app.py
@@ -37,7 +37,7 @@ app = FastAPI(title="Alexandria Audiobook")
 # Paths
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 ROOT_DIR = os.path.dirname(BASE_DIR)
-CONFIG_PATH = os.path.join(BASE_DIR, "config.json")
+CONFIG_PATH = os.environ.get("ALEXANDRIA_CONFIG_PATH") or os.path.join(BASE_DIR, "config.json")
 VOICES_PATH = os.path.join(ROOT_DIR, "voices.json")
 VOICE_CONFIG_PATH = os.path.join(ROOT_DIR, "voice_config.json")
 SCRIPT_PATH = os.path.join(ROOT_DIR, "annotated_script.json")
@@ -504,6 +504,7 @@ async def get_default_prompts():
 
 @app.post("/api/config")
 async def save_config(config: AppConfig):
+    os.makedirs(os.path.dirname(CONFIG_PATH) or ".", exist_ok=True)
     with open(CONFIG_PATH, "w", encoding="utf-8") as f:
         json.dump(config.model_dump(), f, indent=2, ensure_ascii=False)
     # Reset engine so it picks up new TTS settings on next use
@@ -933,10 +934,26 @@ async def merge_audio_endpoint(background_tasks: BackgroundTasks):
         except Exception as e:
             process_state["audio"]["logs"].append(f"Merge error: {e}")
         finally:
+            # Full conversion is done — free TTS models from VRAM
+            engine = project_manager.engine
+            if engine is not None:
+                try:
+                    engine.unload_models()
+                except Exception as e:
+                    process_state["audio"]["logs"].append(f"Model unload warning: {e}")
             process_state["audio"]["running"] = False
 
     background_tasks.add_task(task)
     return {"status": "started"}
+
+@app.post("/api/unload")
+async def unload_models_endpoint():
+    """Manually free cached TTS models from VRAM."""
+    engine = project_manager.engine
+    if engine is None:
+        return {"status": "noop", "unloaded": []}
+    unloaded = engine.unload_models()
+    return {"status": "ok", "unloaded": unloaded}
 
 @app.post("/api/export_audacity")
 async def export_audacity_endpoint(background_tasks: BackgroundTasks):

--- a/app/project.py
+++ b/app/project.py
@@ -96,7 +96,7 @@ class ProjectManager:
         self.chunks_path = os.path.join(root_dir, "chunks.json")
         self.voicelines_dir = os.path.join(root_dir, "voicelines")
         self.voice_config_path = os.path.join(root_dir, "voice_config.json")
-        self.config_path = os.path.join(root_dir, "app", "config.json")
+        self.config_path = os.environ.get("ALEXANDRIA_CONFIG_PATH") or os.path.join(root_dir, "app", "config.json")
 
         # Ensure voicelines dir exists
         os.makedirs(self.voicelines_dir, exist_ok=True)

--- a/app/tts.py
+++ b/app/tts.py
@@ -538,6 +538,29 @@ class TTSEngine:
             print(f"LoRA adapter loaded from {adapter_path}")
             return model
 
+    def unload_models(self):
+        """Free all cached local TTS models and clear GPU cache.
+
+        Called after a full conversion finishes (or via /api/unload) so
+        Qwen3-TTS base/clone/design/LoRA weights don't sit in VRAM
+        indefinitely. Next TTS call re-loads on demand.
+        """
+        with self._model_lock:
+            unloaded = []
+            for attr in ("_local_custom_model", "_local_clone_model",
+                         "_local_design_model", "_local_lora_model"):
+                if getattr(self, attr) is not None:
+                    setattr(self, attr, None)
+                    unloaded.append(attr)
+            self._lora_adapter_path = None
+            self._lora_prompt_cache.clear()
+            self._clone_prompt_cache.clear()
+            self._warmup_needed = True
+            if unloaded:
+                print(f"Unloaded TTS models: {', '.join(unloaded)}")
+                self._clear_gpu_cache()
+            return unloaded
+
     def _init_external(self):
         """Create Gradio client on demand."""
         if self._gradio_client is not None:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
     build: .
     ports:
       - "4200:4200"
+    environment:
+      # Store WebUI settings on a mounted volume so they survive container restarts
+      - ALEXANDRIA_CONFIG_PATH=/alexandria/config/config.json
     volumes:
       # Persist HuggingFace model cache (~3.5 GB per model, downloaded on first use)
       - hf_cache:/root/.cache/huggingface
@@ -14,6 +17,8 @@ services:
       - ./data/lora_datasets:/alexandria/lora_datasets
       - ./data/dataset_builder:/alexandria/dataset_builder
       - ./data/scripts:/alexandria/scripts
+      # Persist WebUI settings (OpenAI endpoint, prompts, TTS mode, etc.)
+      - ./data/config:/alexandria/config
       # Persist audiobook output
       - ./data/output:/alexandria/voicelines
     deploy:


### PR DESCRIPTION
## Summary
Brings the single new commit on `dev` into `main`:

- **0a149ad** Fix Docker packaging, config persistence, and VRAM cleanup (#62) — merged via PR #64. Closes issue #62.

Details of what that squashed commit contains are on PR #64. TL;DR:
- Dockerfile: adds missing `persona_prompts.txt` (fixes container startup)
- `ALEXANDRIA_CONFIG_PATH` env override + docker-compose mount for `config.json` (fixes settings persistence)
- `TTSEngine.unload_models()` + auto-call after merge + `POST /api/unload` (fixes VRAM never releasing)

No other commits on `dev` are ahead of `main`, so this brings in exactly the #62 fix and nothing else.

## Test plan
- Covered by PR #64's test plan; verify same on `main` post-merge.