### PR TITLE
Colab: Drive-first storage, drop ngrok for inline iframe (#59, #60)

### DIFF
--- a/alexandria_colab.ipynb
+++ b/alexandria_colab.ipynb
@@ -1,25 +1,32 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "colab": {
-   "provenance": [],
-   "gpuType": "T4"
-  },
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3"
-  },
-  "language_info": {
-   "name": "python"
-  },
-  "accelerator": "GPU"
- },
  "cells": [
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Alexandria Audiobook Generator — Google Colab\n\nRun [Alexandria](https://github.com/Finrandojin/alexandria-audiobook) on a free Google Colab GPU. No local installation required.\n\n> **Note:** This Colab notebook is provided for convenience so you can try Alexandria without local installation. It is not the primary focus of the project — for the best experience, install Alexandria locally via [Pinokio](https://pinokio.computer).\n\n**What this notebook does:**\n1. Checks your GPU runtime\n2. Installs Alexandria and all dependencies\n3. (Optional) Mounts Google Drive to cache TTS models across sessions\n4. Starts the Alexandria server and creates a public URL via ngrok\n\n**Before you start:**\n- Make sure you've selected a **GPU runtime**: Runtime → Change runtime type → T4 GPU\n- You need a free [ngrok account](https://dashboard.ngrok.com/signup) for the tunnel\n- You need an LLM server for script generation (see Cell 5 for options)\n\n**Colab T4 GPU (15 GB VRAM) recommended settings:**\n- Parallel Workers: 5-10\n- Max Chars/Batch: 1500-2000\n- Compile Codec: enabled (recommended for speed)\n\n---"
+   "source": [
+    "# Alexandria Audiobook Generator \u2014 Google Colab\n",
+    "\n",
+    "Run [Alexandria](https://github.com/Finrandojin/alexandria-audiobook) on a free Google Colab GPU. No local installation required.\n",
+    "\n",
+    "> **Note:** This Colab notebook is provided for convenience so you can try Alexandria without local installation. It is not the primary focus of the project \u2014 for the best experience, install Alexandria locally via [Pinokio](https://pinokio.computer).\n",
+    "\n",
+    "**What this notebook does:**\n",
+    "1. Checks your GPU runtime\n",
+    "2. Mounts Google Drive so Alexandria's files, output, and TTS models persist across sessions\n",
+    "3. Installs Alexandria and all dependencies\n",
+    "4. Starts the Alexandria server and opens the web UI inline (no ngrok needed)\n",
+    "\n",
+    "**Before you start:**\n",
+    "- Make sure you've selected a **GPU runtime**: Runtime \u2192 Change runtime type \u2192 T4 GPU\n",
+    "- You need a Google account (for Drive) and an LLM server for script generation (see Cell 5 for options)\n",
+    "\n",
+    "**Colab T4 GPU (15 GB VRAM) recommended settings:**\n",
+    "- Parallel Workers: 5-10\n",
+    "- Max Chars/Batch: 1500-2000\n",
+    "- Compile Codec: enabled (recommended for speed)\n",
+    "\n",
+    "---"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -27,7 +34,7 @@
    "source": [
     "## 1. Check GPU Runtime\n",
     "\n",
-    "Verify that a GPU is available. If this cell fails, go to **Runtime → Change runtime type → T4 GPU**."
+    "Verify that a GPU is available. If this cell fails, go to **Runtime \u2192 Change runtime type \u2192 T4 GPU**."
    ]
   },
   {
@@ -38,7 +45,7 @@
     "\n",
     "if not torch.cuda.is_available():\n",
     "    raise RuntimeError(\n",
-    "        \"No GPU detected! Go to Runtime → Change runtime type → T4 GPU, then re-run this cell.\"\n",
+    "        \"No GPU detected! Go to Runtime \u2192 Change runtime type \u2192 T4 GPU, then re-run this cell.\"\n",
     "    )\n",
     "\n",
     "gpu_name = torch.cuda.get_device_name(0)\n",
@@ -63,9 +70,66 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2. Install Alexandria\n",
+    "## 2. Mount Google Drive\n",
     "\n",
-    "Clones the repository and installs all Python dependencies. This takes 2-3 minutes."
+    "Alexandria stores its code, generated audio, uploaded books, voice configs, and TTS models on Google Drive so **everything persists across Colab sessions**. TTS models alone are ~3.5 GB each; without Drive, they re-download every time.\n",
+    "\n",
+    "This cell:\n",
+    "- Mounts your Drive at `/content/drive`\n",
+    "- Creates `MyDrive/Alexandria` (if it doesn't exist)\n",
+    "- Symlinks `/content/Alexandria` \u2192 the Drive folder, so the rest of the notebook just uses the local path\n",
+    "- Points HuggingFace's cache at Drive too, so downloaded models persist\n",
+    "\n",
+    "You'll be prompted to authorize Colab to access your Drive."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import os\n",
+    "from google.colab import drive\n",
+    "\n",
+    "drive_path = \"/content/drive/MyDrive/Alexandria\"\n",
+    "local_path = \"/content/Alexandria\"\n",
+    "\n",
+    "drive.mount(\"/content/drive\")\n",
+    "\n",
+    "# Create the Drive directory on first use\n",
+    "if not os.path.exists(drive_path):\n",
+    "    os.makedirs(drive_path)\n",
+    "    print(f\"Created Drive directory: {drive_path}\")\n",
+    "\n",
+    "# Symlink /content/Alexandria -> Drive so subsequent cells just use the local path\n",
+    "if not os.path.exists(local_path):\n",
+    "    os.symlink(drive_path, local_path)\n",
+    "    print(f\"Symlink: {local_path} -> {drive_path}\")\n",
+    "elif os.path.islink(local_path):\n",
+    "    print(f\"Symlink already in place: {local_path} -> {os.readlink(local_path)}\")\n",
+    "else:\n",
+    "    print(\n",
+    "        f\"WARNING: {local_path} already exists and is not a symlink. \"\n",
+    "        \"Delete it manually if you want Drive-backed storage.\"\n",
+    "    )\n",
+    "\n",
+    "# Persist HuggingFace model cache on Drive too\n",
+    "hf_cache = \"/content/drive/MyDrive/.cache/huggingface\"\n",
+    "os.makedirs(hf_cache, exist_ok=True)\n",
+    "os.environ[\"HF_HOME\"] = hf_cache\n",
+    "\n",
+    "print(f\"HuggingFace cache: {hf_cache}\")\n",
+    "print(\"Alexandria files and TTS models will persist across sessions.\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Install Alexandria\n",
+    "\n",
+    "Clones the repository into your Drive-backed Alexandria folder and installs all Python dependencies. First run takes 2-3 minutes; subsequent runs are much faster since the clone already exists on Drive."
    ]
   },
   {
@@ -76,17 +140,16 @@
     "\n",
     "ALEXANDRIA_DIR = \"/content/Alexandria\"\n",
     "\n",
-    "# Clone the repository\n",
-    "if not os.path.exists(ALEXANDRIA_DIR):\n",
+    "# Clone or update the repository (the target is symlinked to Drive)\n",
+    "if not os.path.exists(os.path.join(ALEXANDRIA_DIR, \".git\")):\n",
     "    !git clone https://github.com/Finrandojin/alexandria-audiobook.git {ALEXANDRIA_DIR}\n",
     "else:\n",
     "    print(f\"Alexandria already cloned at {ALEXANDRIA_DIR}\")\n",
     "    !cd {ALEXANDRIA_DIR} && git pull\n",
     "\n",
-    "# Install dependencies (skip torch — Colab already has it)\n",
+    "# Install dependencies (skip torch \u2014 Colab already has it)\n",
     "!pip install -q -r {ALEXANDRIA_DIR}/app/requirements.txt\n",
     "!pip install -q qwen-tts==0.1.1\n",
-    "!pip install -q pyngrok\n",
     "\n",
     "print()\n",
     "print(\"Installation complete.\")"
@@ -98,79 +161,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3. Mount Google Drive (Optional)\n",
-    "\n",
-    "TTS models are **~3.5 GB each** and download on first use. By default, they're lost when the Colab session ends.\n",
-    "\n",
-    "Mounting Google Drive caches models persistently so you don't re-download them every session.\n",
-    "\n",
-    "**Skip this cell** if you don't want to use Drive storage (models will re-download each session)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [
-    "import os\n",
-    "from google.colab import drive\n",
-    "\n",
-    "drive.mount(\"/content/drive\")\n",
-    "\n",
-    "# Set HuggingFace cache to Google Drive\n",
-    "hf_cache = \"/content/drive/MyDrive/.cache/huggingface\"\n",
-    "os.makedirs(hf_cache, exist_ok=True)\n",
-    "os.environ[\"HF_HOME\"] = hf_cache\n",
-    "\n",
-    "print(f\"HuggingFace cache set to: {hf_cache}\")\n",
-    "print(\"Models will persist across Colab sessions.\")"
-   ],
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 4. Configure ngrok Tunnel\n",
-    "\n",
-    "ngrok creates a public URL so you can access the Alexandria web UI from your browser.\n",
-    "\n",
-    "1. Sign up for a free account at [ngrok.com](https://dashboard.ngrok.com/signup)\n",
-    "2. Copy your auth token from [dashboard.ngrok.com/get-started/your-authtoken](https://dashboard.ngrok.com/get-started/your-authtoken)\n",
-    "3. Paste it below and run the cell"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [
-    "NGROK_AUTH_TOKEN = \"\"  # @param {type:\"string\"}\n",
-    "\n",
-    "if not NGROK_AUTH_TOKEN:\n",
-    "    raise ValueError(\n",
-    "        \"Please set your ngrok auth token above.\\n\"\n",
-    "        \"Get one free at: https://dashboard.ngrok.com/get-started/your-authtoken\"\n",
-    "    )\n",
-    "\n",
-    "from pyngrok import ngrok\n",
-    "ngrok.set_auth_token(NGROK_AUTH_TOKEN)\n",
-    "print(\"ngrok configured.\")"
-   ],
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 5. Start Alexandria\n",
+    "## 4. Start Alexandria\n",
     "\n",
     "This cell:\n",
-    "1. Writes a default config (local TTS mode, auto GPU device)\n",
+    "1. Writes a default config if none exists (local TTS mode, auto GPU device)\n",
     "2. Starts the Alexandria server in the background\n",
-    "3. Opens an ngrok tunnel to the web UI\n",
+    "3. Displays the web UI inline via Colab's built-in port forwarding \u2014 **no ngrok, no auth token, no signup**\n",
     "\n",
-    "**After running this cell**, click the ngrok URL to open the Alexandria web UI.\n",
+    "After the server starts, an inline iframe appears below with the Alexandria UI. If you'd rather open it in its own tab, use the \"Open in new tab\" link that also prints below.\n",
     "\n",
     "### LLM Setup\n",
     "\n",
@@ -189,44 +187,184 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "source": "import json\nimport os\nimport subprocess\nimport time\nimport requests\nfrom pyngrok import ngrok\n\nALEXANDRIA_DIR = \"/content/Alexandria\"\nAPP_DIR = os.path.join(ALEXANDRIA_DIR, \"app\")\nCONFIG_PATH = os.path.join(APP_DIR, \"config.json\")\n\n# Write default config if none exists\nif not os.path.exists(CONFIG_PATH):\n    config = {\n        \"llm\": {\n            \"base_url\": \"http://localhost:11434/v1\",\n            \"api_key\": \"local\",\n            \"model_name\": \"\"\n        },\n        \"tts\": {\n            \"mode\": \"local\",\n            \"device\": \"auto\",\n            \"language\": \"English\",\n            \"parallel_workers\": 8,\n            \"compile_codec\": True,\n            \"sub_batch_enabled\": True,\n            \"sub_batch_min_size\": 4,\n            \"sub_batch_ratio\": 5,\n            \"sub_batch_max_chars\": 2000\n        }\n    }\n    with open(CONFIG_PATH, \"w\") as f:\n        json.dump(config, f, indent=2)\n    print(\"Default config written (local TTS, auto GPU).\")\nelse:\n    print(\"Existing config.json found, keeping it.\")\n\n# Start the server\nprint(\"Starting Alexandria server...\")\nserver_process = subprocess.Popen(\n    [\"python\", \"app.py\"],\n    cwd=APP_DIR,\n    stdout=subprocess.PIPE,\n    stderr=subprocess.STDOUT,\n    text=True,\n    bufsize=1\n)\n\n# Wait for server to start\nfor i in range(30):\n    try:\n        r = requests.get(\"http://127.0.0.1:4200/api/config\", timeout=2)\n        if r.status_code == 200:\n            print(\"Server is running.\")\n            break\n    except:\n        pass\n    time.sleep(2)\nelse:\n    print(\"WARNING: Server may not have started. Check output below.\")\n\n# Open ngrok tunnel\npublic_url = ngrok.connect(4200)\nprint()\nprint(\"=\" * 60)\nprint(f\"Alexandria is running at: {public_url}\")\nprint(\"=\" * 60)\nprint()\nprint(\"Open the URL above in your browser.\")\nprint(\"Configure your LLM in the Setup tab before generating scripts.\")\nprint()\nprint(\"First TTS generation will download the model (~3.5 GB).\")\nprint(\"Check this cell's output for download progress.\")",
+   "source": [
+    "import json\n",
+    "import os\n",
+    "import subprocess\n",
+    "import time\n",
+    "import requests\n",
+    "from google.colab import output\n",
+    "\n",
+    "ALEXANDRIA_DIR = \"/content/Alexandria\"\n",
+    "APP_DIR = os.path.join(ALEXANDRIA_DIR, \"app\")\n",
+    "CONFIG_PATH = os.path.join(APP_DIR, \"config.json\")\n",
+    "\n",
+    "# Write default config if none exists (persists on Drive)\n",
+    "if not os.path.exists(CONFIG_PATH):\n",
+    "    config = {\n",
+    "        \"llm\": {\n",
+    "            \"base_url\": \"http://localhost:11434/v1\",\n",
+    "            \"api_key\": \"local\",\n",
+    "            \"model_name\": \"\"\n",
+    "        },\n",
+    "        \"tts\": {\n",
+    "            \"mode\": \"local\",\n",
+    "            \"device\": \"auto\",\n",
+    "            \"language\": \"English\",\n",
+    "            \"parallel_workers\": 8,\n",
+    "            \"compile_codec\": True,\n",
+    "            \"sub_batch_enabled\": True,\n",
+    "            \"sub_batch_min_size\": 4,\n",
+    "            \"sub_batch_ratio\": 5,\n",
+    "            \"sub_batch_max_chars\": 2000\n",
+    "        }\n",
+    "    }\n",
+    "    with open(CONFIG_PATH, \"w\") as f:\n",
+    "        json.dump(config, f, indent=2)\n",
+    "    print(\"Default config written (local TTS, auto GPU).\")\n",
+    "else:\n",
+    "    print(\"Existing config.json found on Drive, keeping it.\")\n",
+    "\n",
+    "# Start the server\n",
+    "print(\"Starting Alexandria server...\")\n",
+    "server_process = subprocess.Popen(\n",
+    "    [\"python\", \"app.py\"],\n",
+    "    cwd=APP_DIR,\n",
+    "    stdout=subprocess.PIPE,\n",
+    "    stderr=subprocess.STDOUT,\n",
+    "    text=True,\n",
+    "    bufsize=1\n",
+    ")\n",
+    "\n",
+    "# Wait for server to start\n",
+    "for i in range(30):\n",
+    "    try:\n",
+    "        r = requests.get(\"http://127.0.0.1:4200/api/config\", timeout=2)\n",
+    "        if r.status_code == 200:\n",
+    "            print(\"Server is running.\")\n",
+    "            break\n",
+    "    except:\n",
+    "        pass\n",
+    "    time.sleep(2)\n",
+    "else:\n",
+    "    print(\"WARNING: Server may not have started. Check output below.\")\n",
+    "\n",
+    "# Show a \"open in new tab\" link and the embedded iframe below it\n",
+    "print()\n",
+    "print(\"=\" * 60)\n",
+    "print(\"Alexandria is ready. Use the inline iframe below, or:\")\n",
+    "output.serve_kernel_port_as_window(4200, anchor_text=\"\u2197 Open Alexandria in a new tab\")\n",
+    "print(\"=\" * 60)\n",
+    "print()\n",
+    "print(\"First TTS generation will download the model (~3.5 GB).\")\n",
+    "print(\"It's cached to Drive so future sessions skip the download.\")\n",
+    "print(\"Check this cell's output for progress.\")\n",
+    "\n",
+    "# Inline embed\n",
+    "output.serve_kernel_port_as_iframe(4200, height=800)"
+   ],
    "execution_count": null,
    "outputs": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "## 6. (Optional) Install Ollama for Local LLM\n\nIf you don't have a cloud LLM API, you can run Ollama on Colab for script generation.\n\n**Important — VRAM sharing:** Ollama and TTS both use the T4 GPU. A 7B model uses ~5 GB VRAM, leaving only ~10 GB for TTS. This **will cause out-of-memory crashes** during batch generation, especially with LoRA voices.\n\n**Workflow:** Use Ollama for script generation, then **run Cell 6b to stop Ollama** before starting TTS batch generation. The LLM is only needed during script generation.\n\n**Skip this cell** if you're using a cloud API (OpenAI, DeepSeek, etc.) — that's the easiest option on Colab."
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": "import subprocess\nimport time\n\nOLLAMA_MODEL = \"qwen2.5:7b\"  # @param {type:\"string\"}\n\n# Install zstd (required by Ollama installer)\n!apt-get install -y -qq zstd\n\n# Install Ollama\nprint(\"Installing Ollama...\")\n!curl -fsSL https://ollama.com/install.sh | sh\n\n# Start Ollama server in background\nprint(\"Starting Ollama server...\")\nollama_process = subprocess.Popen(\n    [\"ollama\", \"serve\"],\n    stdout=subprocess.DEVNULL,\n    stderr=subprocess.DEVNULL\n)\ntime.sleep(3)\n\n# Pull the model\nprint(f\"Pulling {OLLAMA_MODEL} (this may take a few minutes)...\")\n!ollama pull {OLLAMA_MODEL}\n\nprint()\nprint(f\"Ollama is running with {OLLAMA_MODEL}.\")\nprint()\nprint(\"In Alexandria Setup tab, configure:\")\nprint(f\"  LLM Base URL: http://localhost:11434/v1\")\nprint(f\"  API Key: local\")\nprint(f\"  Model Name: {OLLAMA_MODEL}\")",
-   "execution_count": null,
-   "outputs": []
-  },
-  {
-   "cell_type": "markdown",
-   "source": "## 6b. Stop Ollama (Free VRAM for TTS)\n\n**Run this cell after script generation is complete**, before starting batch TTS generation. This frees ~5 GB of VRAM that Ollama was using for the LLM.\n\nYou do NOT need to run this if you used a cloud LLM API instead of Ollama.",
-   "metadata": {}
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 7. View Server Logs\n",
+    "## 5. (Optional) Install Ollama for Local LLM\n",
+    "\n",
+    "If you don't have a cloud LLM API, you can run Ollama on Colab for script generation.\n",
+    "\n",
+    "**Important \u2014 VRAM sharing:** Ollama and TTS both use the T4 GPU. A 7B model uses ~5 GB VRAM, leaving only ~10 GB for TTS. This **will cause out-of-memory crashes** during batch generation, especially with LoRA voices.\n",
+    "\n",
+    "**Workflow:** Use Ollama for script generation, then **run Cell 5b to stop Ollama** before starting TTS batch generation. The LLM is only needed during script generation.\n",
+    "\n",
+    "**Skip this cell** if you're using a cloud API (OpenAI, DeepSeek, etc.) \u2014 that's the easiest option on Colab."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import subprocess\n",
+    "import time\n",
+    "\n",
+    "OLLAMA_MODEL = \"qwen2.5:7b\"  # @param {type:\"string\"}\n",
+    "\n",
+    "# Install zstd (required by Ollama installer)\n",
+    "!apt-get install -y -qq zstd\n",
+    "\n",
+    "# Install Ollama\n",
+    "print(\"Installing Ollama...\")\n",
+    "!curl -fsSL https://ollama.com/install.sh | sh\n",
+    "\n",
+    "# Start Ollama server in background\n",
+    "print(\"Starting Ollama server...\")\n",
+    "ollama_process = subprocess.Popen(\n",
+    "    [\"ollama\", \"serve\"],\n",
+    "    stdout=subprocess.DEVNULL,\n",
+    "    stderr=subprocess.DEVNULL\n",
+    ")\n",
+    "time.sleep(3)\n",
+    "\n",
+    "# Pull the model\n",
+    "print(f\"Pulling {OLLAMA_MODEL} (this may take a few minutes)...\")\n",
+    "!ollama pull {OLLAMA_MODEL}\n",
+    "\n",
+    "print()\n",
+    "print(f\"Ollama is running with {OLLAMA_MODEL}.\")\n",
+    "print()\n",
+    "print(\"In Alexandria Setup tab, configure:\")\n",
+    "print(f\"  LLM Base URL: http://localhost:11434/v1\")\n",
+    "print(f\"  API Key: local\")\n",
+    "print(f\"  Model Name: {OLLAMA_MODEL}\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5b. Stop Ollama (Free VRAM for TTS)\n",
+    "\n",
+    "**Run this cell after script generation is complete**, before starting batch TTS generation. This frees ~5 GB of VRAM that Ollama was using for the LLM.\n",
+    "\n",
+    "You do NOT need to run this if you used a cloud LLM API instead of Ollama."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import subprocess\n",
+    "\n",
+    "# Stop Ollama server to free GPU memory for TTS\n",
+    "try:\n",
+    "    subprocess.run([\"pkill\", \"-f\", \"ollama\"], timeout=5)\n",
+    "    print(\"Ollama stopped. GPU memory freed for TTS.\")\n",
+    "except:\n",
+    "    print(\"Ollama was not running.\")\n",
+    "\n",
+    "# Verify VRAM is freed\n",
+    "import torch\n",
+    "if torch.cuda.is_available():\n",
+    "    free_mem = torch.cuda.mem_get_info()[0] / 1e9\n",
+    "    total_mem = torch.cuda.mem_get_info()[1] / 1e9\n",
+    "    print(f\"VRAM: {free_mem:.1f} GB free / {total_mem:.1f} GB total\")"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. View Server Logs\n",
     "\n",
     "Run this cell to see real-time server output (model loading, generation progress, errors).\n",
     "\n",
     "**Interrupt the cell** (stop button) to stop viewing logs. The server keeps running."
    ]
-  },
-  {
-   "cell_type": "code",
-   "source": "import subprocess\n\n# Stop Ollama server to free GPU memory for TTS\ntry:\n    subprocess.run([\"pkill\", \"-f\", \"ollama\"], timeout=5)\n    print(\"Ollama stopped. GPU memory freed for TTS.\")\nexcept:\n    print(\"Ollama was not running.\")\n\n# Verify VRAM is freed\nimport torch\nif torch.cuda.is_available():\n    free_mem = torch.cuda.mem_get_info()[0] / 1e9\n    total_mem = torch.cuda.mem_get_info()[1] / 1e9\n    print(f\"VRAM: {free_mem:.1f} GB free / {total_mem:.1f} GB total\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
   },
   {
    "cell_type": "code",
@@ -246,7 +384,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 8. Stop Server\n",
+    "## 7. Stop Server\n",
     "\n",
     "Run this cell when you're done to clean up."
    ]
@@ -255,13 +393,7 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "from pyngrok import ngrok\n",
-    "\n",
-    "# Kill ngrok tunnels\n",
-    "ngrok.kill()\n",
-    "print(\"ngrok tunnel closed.\")\n",
-    "\n",
-    "# Kill server\n",
+    "# Stop the Alexandria server\n",
     "try:\n",
     "    server_process.terminate()\n",
     "    server_process.wait(timeout=5)\n",
@@ -270,7 +402,7 @@
     "    server_process.kill()\n",
     "    print(\"Server killed.\")\n",
     "\n",
-    "# Kill Ollama if running\n",
+    "# Stop Ollama if it was running\n",
     "try:\n",
     "    ollama_process.terminate()\n",
     "    print(\"Ollama stopped.\")\n",
@@ -280,5 +412,21 @@
    "execution_count": null,
    "outputs": []
   }
- ]
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "gpuType": "T4"
+  },
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  },
+  "language_info": {
+   "name": "python"
+  },
+  "accelerator": "GPU"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
## Summary
Two Colab-notebook improvements bundled into one PR:

### #60 — Google Drive persistence for all Alexandria state
- New **Cell 2 (formerly Cell 3, optional)** mounts Drive, creates `MyDrive/Alexandria`, and symlinks `/content/Alexandria` to it before anything else runs.
- `HF_HOME` also points to Drive, so ~3.5 GB TTS models cache persistently.
- Everything downstream — repo clone, `config.json`, `voicelines/`, `chunks.json`, uploaded books, generated audio — lands on Drive automatically because the local path is a symlink. No app-side changes required.

### #59 — Remove ngrok, use Colab's built-in port forwarding
- Removed the ngrok configuration cell (auth token param + `pyngrok` install).
- `output.serve_kernel_port_as_iframe(4200, height=800)` embeds the Alexandria UI inline in the "Start Alexandria" cell.
- `output.serve_kernel_port_as_window(4200, anchor_text="↗ Open Alexandria in a new tab")` prints a companion link for users who prefer a separate tab.
- Cleanup cell no longer calls `ngrok.kill()`.

### Housekeeping
- Renumbered sections since two cells went away (was 8 numbered steps, now 7).
- Fixed a subtle misordering where the "Stop Ollama" markdown was sandwiched between "View Server Logs" markdown headers and their code cells.

Closes #59, closes #60.

## Test plan
Not directly runnable outside Colab. Reviewer checks:
- [ ] Open the notebook in Colab with a fresh runtime
- [ ] Cell 2: Drive auth flow works; `/content/Alexandria` becomes a symlink to `MyDrive/Alexandria`; `HF_HOME` set to Drive
- [ ] Cell 3: git clone lands on Drive (verify a file appears in `MyDrive/Alexandria` from the browser)
- [ ] Cell 4: server starts; iframe renders the UI inline; "Open in new tab" link works
- [ ] Refresh Colab, re-run cells 1-4: no re-download of models; repo is already there
- [ ] Cell 7 (stop): no ngrok-related errors