### PR TITLE
Single-speaker mode: skip LLM script generation (#58)

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -731,8 +731,13 @@ async def upload_file(file: UploadFile = File(...)):
 
     return {"filename": file.filename, "path": file_path}
 
+class GenerateScriptRequest(BaseModel):
+    single_speaker: bool = False
+    speaker_name: str = "Narrator"
+    instruct: str = "Neutral narration."
+
 @app.post("/api/generate_script")
-async def generate_script(background_tasks: BackgroundTasks):
+async def generate_script(background_tasks: BackgroundTasks, request: GenerateScriptRequest = GenerateScriptRequest()):
     # Get input file from state.json
     state_path = os.path.join(ROOT_DIR, "state.json")
     if not os.path.exists(state_path):
@@ -748,7 +753,14 @@ async def generate_script(background_tasks: BackgroundTasks):
     if process_state["script"]["running"]:
          raise HTTPException(status_code=400, detail="Script generation already running")
 
-    background_tasks.add_task(run_process, [sys.executable, "-u", "generate_script.py", input_file], "script")
+    cmd = [sys.executable, "-u", "generate_script.py", input_file]
+    if request.single_speaker:
+        cmd += [
+            "--single-speaker",
+            "--speaker-name", request.speaker_name or "Narrator",
+            "--instruct", request.instruct or "Neutral narration.",
+        ]
+    background_tasks.add_task(run_process, cmd, "script")
     return {"status": "started"}
 
 @app.post("/api/review_script")

--- a/app/generate_script.py
+++ b/app/generate_script.py
@@ -2,8 +2,13 @@ import os
 import sys
 import json
 import re
+import argparse
 from openai import OpenAI
 from default_prompts import DEFAULT_SYSTEM_PROMPT, DEFAULT_USER_PROMPT
+
+# Cap for single-speaker mode: entries at this size pass through
+# group_into_chunks (MAX_CHUNK_CHARS=500) as-is without further splitting.
+SINGLE_SPEAKER_MAX_CHARS = 500
 
 def clean_json_string(text):
     """Clean and extract valid JSON array from LLM response."""
@@ -345,13 +350,54 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
 
     return []
 
-def main():
-    if len(sys.argv) < 2:
-        print("Error: No input file path provided.")
-        print("Usage: python generate_script.py <input_file_path>")
+def _write_script_output(all_entries):
+    """Write annotated_script.json and clear stale chunks.json."""
+    output_path = os.path.join("..", "annotated_script.json")
+    with open(output_path, 'w', encoding='utf-8') as f:
+        json.dump(all_entries, f, indent=2, ensure_ascii=False)
+
+    chunks_path = os.path.join("..", "chunks.json")
+    if os.path.exists(chunks_path):
+        os.remove(chunks_path)
+        print("Cleared old chunks.json")
+
+    speakers = set(entry.get("speaker") or entry.get("type") or "UNKNOWN" for entry in all_entries)
+    print(f"\nGenerated {len(all_entries)} script entries")
+    print(f"Speakers found: {', '.join(sorted(speakers))}")
+    print(f"Output saved to: {output_path}")
+
+
+def run_single_speaker(book_content, speaker_name, instruct):
+    """Bypass the LLM and emit one entry per text segment, all attributed
+    to a single speaker. Used for first-person memoirs, non-fiction, etc.,
+    where character detection is unnecessary."""
+    segments = split_into_chunks(book_content, max_size=SINGLE_SPEAKER_MAX_CHARS)
+    print(f"Split into {len(segments)} narration segments at paragraph/sentence boundaries")
+
+    entries = [
+        {"speaker": speaker_name, "text": segment, "instruct": instruct}
+        for segment in segments
+    ]
+
+    if not entries:
+        print("Error: No script entries generated (input text is empty?)")
         sys.exit(1)
 
-    input_file_path = sys.argv[1]
+    _write_script_output(entries)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate annotated audiobook script.")
+    parser.add_argument("input_file_path", help="Path to the input text/markdown/EPUB text file.")
+    parser.add_argument("--single-speaker", action="store_true",
+                        help="Skip LLM and attribute the whole text to one speaker.")
+    parser.add_argument("--speaker-name", default="Narrator",
+                        help="Speaker name used in single-speaker mode (default: Narrator).")
+    parser.add_argument("--instruct", default="Neutral narration.",
+                        help="Voice direction used in single-speaker mode.")
+    args = parser.parse_args()
+
+    input_file_path = args.input_file_path
     print(f"Processing book from: {input_file_path}")
 
     if not os.path.exists(input_file_path):
@@ -365,6 +411,11 @@ def main():
     book_content = fix_mojibake(book_content)
 
     print(f"Read {len(book_content)} characters")
+
+    if args.single_speaker:
+        print(f"Single-speaker mode: attributing all narration to '{args.speaker_name}'")
+        run_single_speaker(book_content, args.speaker_name, args.instruct)
+        return
 
     # Load LLM config
     config_path = os.path.join(os.path.dirname(__file__), "config.json")
@@ -442,22 +493,7 @@ def main():
         print("Error: No script entries generated")
         sys.exit(1)
 
-    # Save as JSON
-    output_path = os.path.join("..", "annotated_script.json")
-    with open(output_path, 'w', encoding='utf-8') as f:
-        json.dump(all_entries, f, indent=2, ensure_ascii=False)
-
-    # Delete old chunks.json so editor regenerates from new script
-    chunks_path = os.path.join("..", "chunks.json")
-    if os.path.exists(chunks_path):
-        os.remove(chunks_path)
-        print("Cleared old chunks.json")
-
-    # Summary (check both "speaker" and "type" fields)
-    speakers = set(entry.get("speaker") or entry.get("type") or "UNKNOWN" for entry in all_entries)
-    print(f"\nGenerated {len(all_entries)} script entries")
-    print(f"Speakers found: {', '.join(sorted(speakers))}")
-    print(f"Output saved to: {output_path}")
+    _write_script_output(all_entries)
 
 
 if __name__ == '__main__':

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -338,11 +338,31 @@
                         <div id="upload-status" class="mt-2"></div>
                     </div>
 
+                    <div class="mb-3">
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" id="single-speaker-toggle">
+                            <label class="form-check-label" for="single-speaker-toggle">
+                                Single speaker mode <span class="text-muted">— skip the LLM, narrate the whole text with one voice</span>
+                            </label>
+                        </div>
+                        <div id="single-speaker-options" class="mt-2 ps-4" style="display:none;">
+                            <div class="input-group input-group-sm mb-1">
+                                <span class="input-group-text" style="min-width:130px;">Speaker name</span>
+                                <input type="text" class="form-control" id="single-speaker-name" value="Narrator">
+                            </div>
+                            <div class="input-group input-group-sm">
+                                <span class="input-group-text" style="min-width:130px;">Voice direction</span>
+                                <input type="text" class="form-control" id="single-speaker-instruct" value="Neutral narration.">
+                            </div>
+                            <small class="text-muted">Useful for first-person memoirs, non-fiction, or anything without distinct characters.</small>
+                        </div>
+                    </div>
+
                     <div class="d-grid gap-2">
                         <button class="btn btn-success btn-lg" id="btn-gen-script">
                             <i class="fas fa-magic me-2"></i>Generate Annotated Script
                         </button>
-                        <small class="text-muted">Sends the book to your LLM to split it into annotated chunks with speaker labels and voice directions.</small>
+                        <small class="text-muted" id="btn-gen-script-hint">Sends the book to your LLM to split it into annotated chunks with speaker labels and voice directions.</small>
                         <button class="btn btn-outline-secondary btn-lg" id="btn-review-script">
                             <i class="fas fa-check-double me-2"></i>Review Script (Optional)
                         </button>
@@ -1395,6 +1415,14 @@
             }
         });
 
+        document.getElementById('single-speaker-toggle').addEventListener('change', (e) => {
+            const on = e.target.checked;
+            document.getElementById('single-speaker-options').style.display = on ? '' : 'none';
+            document.getElementById('btn-gen-script-hint').textContent = on
+                ? 'Skips the LLM. Splits the book at paragraph boundaries and attributes every chunk to one speaker.'
+                : 'Sends the book to your LLM to split it into annotated chunks with speaker labels and voice directions.';
+        });
+
         document.getElementById('btn-gen-script').addEventListener('click', async () => {
             const fileInput = document.getElementById('file-upload');
             const statusEl = document.getElementById('upload-status');
@@ -1407,8 +1435,15 @@
                 return;
             }
 
+            const singleSpeaker = document.getElementById('single-speaker-toggle').checked;
+            const body = { single_speaker: singleSpeaker };
+            if (singleSpeaker) {
+                body.speaker_name = document.getElementById('single-speaker-name').value.trim() || 'Narrator';
+                body.instruct = document.getElementById('single-speaker-instruct').value.trim() || 'Neutral narration.';
+            }
+
             try {
-                await API.post('/api/generate_script', {});
+                await API.post('/api/generate_script', body);
                 pollLogs('script', 'script-logs');
             } catch (e) {
                 const detail = e.message || 'Unknown error';

--- a/app/test_api.py
+++ b/app/test_api.py
@@ -1060,6 +1060,20 @@ def test_generate_script():
         raise TestFailure(f"Expected status=started, got {data}")
 
 
+def test_generate_script_single_speaker():
+    r = post("/api/generate_script", json={
+        "single_speaker": True,
+        "speaker_name": "Narrator",
+        "instruct": "Neutral narration."
+    })
+    if r.status_code == 400:
+        raise TestFailure("SKIP: prerequisite not met (no uploaded file or already running)")
+    assert_status(r, 200)
+    data = r.json()
+    if data.get("status") != "started":
+        raise TestFailure(f"Expected status=started, got {data}")
+
+
 def test_review_script():
     if not shared.get("has_script"):
         raise TestFailure("SKIP: no annotated script loaded")
@@ -1291,6 +1305,7 @@ def run_all_tests():
 
     section("Generation (TTS/LLM)")
     run_test("generate_script", test_generate_script, requires_full=True)
+    run_test("generate_script_single_speaker", test_generate_script_single_speaker, requires_full=True)
     run_test("review_script", test_review_script, requires_full=True)
     run_test("generate_chunk", test_generate_chunk, requires_full=True)
     run_test("generate_batch", test_generate_batch, requires_full=True)


### PR DESCRIPTION
## Summary
For first-person memoirs, non-fiction, or anything without distinct characters, running the LLM to detect speakers is wasted effort. This adds a mode that bypasses \`generate_script.py\`'s LLM branch entirely and emits chunks tagged with a single, user-configurable speaker.

### Backend
- **\`app/generate_script.py\`** — switched to \`argparse\`. New flags: \`--single-speaker\`, \`--speaker-name\` (default \`Narrator\`), \`--instruct\` (default \`Neutral narration.\`). In single-speaker mode we reuse the existing \`split_into_chunks()\` to segment at paragraph boundaries, capped at 500 chars so entries pass through \`group_into_chunks\` without further splitting. Every entry is written to \`annotated_script.json\` attributed to the one speaker.
- **\`app/app.py\`** — \`/api/generate_script\` now accepts an optional \`GenerateScriptRequest\` body with \`single_speaker\`, \`speaker_name\`, \`instruct\`. When the body is absent (existing callers, including \`test_api.py\`'s bare POST), defaults preserve the old LLM-driven behavior.

### UI
- New toggle on the **Script** tab. When enabled, reveals a compact panel with \`Speaker name\` and \`Voice direction\` inputs pre-filled with the sensible defaults. The button hint text updates to reflect the current mode.

### Tests
- \`test_api.py\`: added \`test_generate_script_single_speaker\` — smoke test that POSTs the new payload variant.

### Downstream flow (unchanged, verified)
- Voice-assignment tab shows one speaker (Narrator) — works fine with N=1.
- \`Generate Personas\` on the Voices tab still generates a persona description for the single speaker — still useful.
- \`Review Script\` button remains available; it's a no-op in single-speaker mode (nothing to correct) but doesn't break.

Closes #58

## Test plan
- [ ] Upload a text/markdown file
- [ ] Toggle \"Single speaker mode\" on, keep defaults, click Generate → \`annotated_script.json\` contains only \`Narrator\` entries
- [ ] Change speaker name to something else, regenerate → new name shows in the script and on the Voices tab
- [ ] Toggle off, click Generate → LLM is called as before
- [ ] Full pipeline: single-speaker → assign a voice → generate audio → merge produces one continuous audiobook