### PR TITLE
Fix hardcoded "Auto" language on external clone-voice path (#69)

### DIFF
--- a/app/tts.py
+++ b/app/tts.py
@@ -1692,7 +1692,7 @@ class TTSEngine:
                 handle_file(ref_audio),
                 ref_text,
                 text,
-                "Auto",
+                self._language,
                 False,       # use_xvector_only
                 "1.7B",
                 200,         # max_chunk_chars


### PR DESCRIPTION
## Summary
Reported in #69: when using **External TTS mode + Clone Voice** with a non-English language (specifically German), some segments come out in English regardless of the user's language setting.

Root cause is in \`app/tts.py:1695\` — \`_external_generate_clone\` hardcodes \`\"Auto\"\` as the language argument to the Gradio server's \`/generate_voice_clone\` endpoint, ignoring \`self._language\`. When the server auto-detects per chunk, short or English-cognate German text gets misclassified as English.

The fix passes \`self._language\` through — matching the pattern used everywhere else that hits the TTS engine (\`_external_generate_custom\`, warmup, \`_local_batch_custom\`, design). Users who explicitly want auto-detect can still select "Auto" in the Setup tab.

**Other clone paths are unaffected:**
- \`_local_generate_clone\` and \`_local_batch_clone\` don't pass a language argument — \`qwen-tts\`'s clone method infers language from the reference audio, so they've been correct all along.

Closes #69.

## Test plan
- [ ] External Gradio mode + Clone Voice + language set to \"German\" in Setup: run a German book and confirm every segment is spoken in German (not just the ones the server auto-detected correctly).
- [ ] External Gradio mode + Clone Voice + language set to \"Auto\": confirm the previous auto-detect behavior still works when explicitly requested.
- [ ] External Gradio mode + Custom Voice: no regression (this path wasn't touched).
- [ ] Local TTS + Clone Voice: no regression (this path wasn't touched).