### PR TITLE
Add MiniMax speech provider support

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -200,6 +200,10 @@ class LLMConfig(BaseModel):
 class TTSConfig(BaseModel):
     mode: str = "local"  # "local" or "external"
     url: str = "http://127.0.0.1:7860"  # external mode only
+    provider: str = "server"  # external speech provider
+    api_key: str = ""  # provider API key
+    model: str = "speech-2.8-hd"  # provider speech model
+    region: str = "global_en"  # provider regional endpoint
     device: str = "auto"  # local mode: "auto", "cuda:0", "cpu", etc.
     language: str = "English"  # TTS language
     parallel_workers: int = 2  # concurrent TTS workers
@@ -476,6 +480,10 @@ async def get_config():
         "tts": {
             "mode": "local",
             "url": "http://127.0.0.1:7860",
+            "provider": "server",
+            "api_key": "",
+            "model": "speech-2.8-hd",
+            "region": "global_en",
             "device": "auto"
         },
         "prompts": {

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -128,6 +128,7 @@
                                     <option value="server">Existing Server</option>
                                     <option value="minimax">MiniMax</option>
                                 </select>
+                                <div class="form-text">MiniMax currently applies to Custom voices only.</div>
                             </div>
                             <div class="col-md-4" id="tts-url-group">
                                 <label class="form-label">TTS Server URL</label>
@@ -1706,7 +1707,6 @@
 
                                 <!-- Clone Options -->
                                 <div class="clone-opts" style="display: ${voiceType === 'clone' ? 'block' : 'none'}">
-                                    <input type="text" class="form-control clone-voice-id mb-2" placeholder="MiniMax voice ID" value="${escapeHtml(config.voice_id || '')}">
                                     <div class="row g-2 mb-2 align-items-center">
                                         <div class="col">
                                             <select class="form-select designed-voice-select" onchange="onDesignedVoiceSelect(this)">
@@ -1750,7 +1750,6 @@
 
                                 <!-- Voice Design Options -->
                                 <div class="design-opts" style="display: ${voiceType === 'design' ? 'block' : 'none'}">
-                                    <input type="text" class="form-control design-voice-id mb-2" placeholder="MiniMax voice ID" value="${escapeHtml(config.voice_id || '')}">
                                     <input type="text" class="form-control design-description mb-1" placeholder="Base voice description (e.g. Young strong soldier)" value="${config.description || ''}">
                                     <span class="text-muted small">Per-line instruct is appended to this description as delivery/emotion direction</span>
                                     <div class="mt-2">
@@ -1823,7 +1822,6 @@
                 } else if (type === 'clone') {
                     config[name] = {
                         type: 'clone',
-                        voice_id: card.querySelector('.clone-voice-id').value,
                         ref_text: card.querySelector('.ref-text').value,
                         ref_audio: card.querySelector('.ref-audio').value,
                         seed: "-1"
@@ -1851,7 +1849,6 @@
                 } else if (type === 'design') {
                     config[name] = {
                         type: 'design',
-                        voice_id: card.querySelector('.design-voice-id').value,
                         description: card.querySelector('.design-description').value,
                         seed: "-1"
                     };

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -120,12 +120,19 @@
                                     <option value="external">External Server</option>
                                     <option value="local">Local Model</option>
                                 </select>
-                                <div class="form-text">Local loads model in-process; External connects to a Gradio TTS server</div>
+                                <div class="form-text">Local loads a model in-process; External uses the configured speech provider</div>
                             </div>
-                            <div class="col-md-5" id="tts-url-group">
+                            <div class="col-md-3" id="tts-provider-group">
+                                <label class="form-label">External Provider</label>
+                                <select class="form-select" id="tts-provider" onchange="toggleTTSMode()">
+                                    <option value="server">Existing Server</option>
+                                    <option value="minimax">MiniMax</option>
+                                </select>
+                            </div>
+                            <div class="col-md-4" id="tts-url-group">
                                 <label class="form-label">TTS Server URL</label>
                                 <input type="text" class="form-control" id="tts-url" value="http://127.0.0.1:7860">
-                                <div class="form-text">URL for the Qwen3-TTS Gradio server</div>
+                                <div class="form-text">URL for the existing external speech server</div>
                             </div>
                             <div class="col-md-4" id="tts-device-group" style="display:none;">
                                 <label class="form-label">Device</label>
@@ -163,6 +170,32 @@
                                 <label class="form-label">Batch Seed</label>
                                 <input type="number" class="form-control" id="batch-seed" placeholder="-1 (random)">
                                 <div class="form-text">Seed for reproducibility</div>
+                            </div>
+                        </div>
+                        <div class="row mb-3" id="tts-minimax-options" style="display:none;">
+                            <div class="col-md-4">
+                                <label class="form-label">MiniMax API Key</label>
+                                <input type="password" class="form-control" id="tts-api-key" autocomplete="off">
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label">MiniMax Region</label>
+                                <select class="form-select" id="tts-region">
+                                    <option value="global_en">Global</option>
+                                    <option value="cn_zh">China</option>
+                                </select>
+                            </div>
+                            <div class="col-md-4">
+                                <label class="form-label">Speech Model</label>
+                                <select class="form-select" id="tts-model">
+                                    <option value="speech-2.8-hd">speech-2.8-hd</option>
+                                    <option value="speech-2.8-turbo">speech-2.8-turbo</option>
+                                    <option value="speech-2.6-hd">speech-2.6-hd</option>
+                                    <option value="speech-2.6-turbo">speech-2.6-turbo</option>
+                                    <option value="speech-02-hd">speech-02-hd</option>
+                                    <option value="speech-02-turbo">speech-02-turbo</option>
+                                    <option value="speech-01-hd">speech-01-hd</option>
+                                    <option value="speech-01-turbo">speech-01-turbo</option>
+                                </select>
                             </div>
                         </div>
                         <div class="row mb-3" id="tts-local-options" style="display:none;">
@@ -1162,7 +1195,12 @@
 
         function toggleTTSMode() {
             const mode = document.getElementById('tts-mode').value;
-            document.getElementById('tts-url-group').style.display = mode === 'external' ? '' : 'none';
+            const provider = document.getElementById('tts-provider').value;
+            const isExternal = mode === 'external';
+            const isMiniMax = isExternal && provider === 'minimax';
+            document.getElementById('tts-provider-group').style.display = isExternal ? '' : 'none';
+            document.getElementById('tts-url-group').style.display = isExternal && !isMiniMax ? '' : 'none';
+            document.getElementById('tts-minimax-options').style.display = isMiniMax ? '' : 'none';
             document.getElementById('tts-device-group').style.display = mode === 'local' ? '' : 'none';
             document.getElementById('tts-local-options').style.display = mode === 'local' ? '' : 'none';
         }
@@ -1178,6 +1216,10 @@
                 document.getElementById('llm-model').value = config.llm.model_name;
                 document.getElementById('tts-mode').value = config.tts.mode || 'external';
                 document.getElementById('tts-url').value = config.tts.url || 'http://127.0.0.1:7860';
+                document.getElementById('tts-provider').value = config.tts.provider || 'server';
+                document.getElementById('tts-api-key').value = config.tts.api_key || '';
+                document.getElementById('tts-model').value = config.tts.model || 'speech-2.8-hd';
+                document.getElementById('tts-region').value = config.tts.region || 'global_en';
                 document.getElementById('tts-device').value = config.tts.device || 'auto';
                 document.getElementById('tts-language').value = config.tts.language || 'English';
                 document.getElementById('parallel-workers').value = config.tts.parallel_workers || 2;
@@ -1356,6 +1398,10 @@
                 tts: {
                     mode: document.getElementById('tts-mode').value,
                     url: document.getElementById('tts-url').value,
+                    provider: document.getElementById('tts-provider').value,
+                    api_key: document.getElementById('tts-api-key').value,
+                    model: document.getElementById('tts-model').value,
+                    region: document.getElementById('tts-region').value,
                     device: document.getElementById('tts-device').value,
                     language: document.getElementById('tts-language').value,
                     parallel_workers: parallelWorkers,
@@ -1615,9 +1661,10 @@
                                 <div class="custom-opts" style="display: ${voiceType === 'custom' ? 'block' : 'none'}">
                                     <div class="row g-2">
                                         <div class="col-md-6">
-                                            <select class="form-select voice-select">
-                                                ${AVAILABLE_VOICES.map(v => `<option value="${v}" ${config.voice === v ? 'selected' : ''}>${v}</option>`).join('')}
-                                            </select>
+                                            <input type="text" class="form-control voice-select" list="voice-options-${index}" value="${escapeHtml(config.voice || AVAILABLE_VOICES[0])}" placeholder="Built-in voice or MiniMax voice ID">
+                                            <datalist id="voice-options-${index}">
+                                                ${AVAILABLE_VOICES.map(v => `<option value="${v}"></option>`).join('')}
+                                            </datalist>
                                         </div>
                                         <div class="col-md-6">
                                             <input type="text" class="form-control character-style" placeholder="Character style (e.g. refined aristocratic tone, heavy Scottish accent)" value="${escapeHtml(config.character_style || config.default_style || '')}">
@@ -1659,6 +1706,7 @@
 
                                 <!-- Clone Options -->
                                 <div class="clone-opts" style="display: ${voiceType === 'clone' ? 'block' : 'none'}">
+                                    <input type="text" class="form-control clone-voice-id mb-2" placeholder="MiniMax voice ID" value="${escapeHtml(config.voice_id || '')}">
                                     <div class="row g-2 mb-2 align-items-center">
                                         <div class="col">
                                             <select class="form-select designed-voice-select" onchange="onDesignedVoiceSelect(this)">
@@ -1702,6 +1750,7 @@
 
                                 <!-- Voice Design Options -->
                                 <div class="design-opts" style="display: ${voiceType === 'design' ? 'block' : 'none'}">
+                                    <input type="text" class="form-control design-voice-id mb-2" placeholder="MiniMax voice ID" value="${escapeHtml(config.voice_id || '')}">
                                     <input type="text" class="form-control design-description mb-1" placeholder="Base voice description (e.g. Young strong soldier)" value="${config.description || ''}">
                                     <span class="text-muted small">Per-line instruct is appended to this description as delivery/emotion direction</span>
                                     <div class="mt-2">
@@ -1774,6 +1823,7 @@
                 } else if (type === 'clone') {
                     config[name] = {
                         type: 'clone',
+                        voice_id: card.querySelector('.clone-voice-id').value,
                         ref_text: card.querySelector('.ref-text').value,
                         ref_audio: card.querySelector('.ref-audio').value,
                         seed: "-1"
@@ -1801,6 +1851,7 @@
                 } else if (type === 'design') {
                     config[name] = {
                         type: 'design',
+                        voice_id: card.querySelector('.design-voice-id').value,
                         description: card.querySelector('.design-description').value,
                         seed: "-1"
                     };

--- a/app/test_api.py
+++ b/app/test_api.py
@@ -128,10 +128,17 @@ def test_save_config_roundtrip():
     original = r.json()
     shared["original_config"] = original
 
-    # Build test config with modified language
+    # Build test config with modified TTS provider settings
     test_config = {
         "llm": original["llm"],
-        "tts": {**original.get("tts", {}), "language": "_test_roundtrip_lang"},
+        "tts": {
+            **original.get("tts", {}),
+            "language": "_test_roundtrip_lang",
+            "provider": "minimax",
+            "api_key": "test",
+            "model": "speech-2.8-turbo",
+            "region": "cn_zh",
+        },
         "prompts": original.get("prompts"),
         "generation": original.get("generation"),
     }
@@ -149,6 +156,14 @@ def test_save_config_roundtrip():
     readback = r.json()
     if readback.get("tts", {}).get("language") != "_test_roundtrip_lang":
         raise TestFailure("Config round-trip failed: language not persisted")
+    for key, expected in {
+        "provider": "minimax",
+        "api_key": "test",
+        "model": "speech-2.8-turbo",
+        "region": "cn_zh",
+    }.items():
+        if readback.get("tts", {}).get(key) != expected:
+            raise TestFailure(f"Config round-trip failed: {key} not persisted")
 
     # Verify generation section persists
     if original.get("generation") and not readback.get("generation"):

--- a/app/test_tts.py
+++ b/app/test_tts.py
@@ -7,15 +7,18 @@ from tts import (
     MINIMAX_DEFAULT_SPEECH_MODEL,
     MINIMAX_SPEECH_ENDPOINTS,
     TTSEngine,
+    _instruct_to_minimax_emotion,
 )
 
 
 class FakeResponse:
-    def __init__(self, payload):
+    def __init__(self, payload, status_code=200):
         self._payload = payload
+        self.status_code = status_code
 
     def raise_for_status(self):
-        return None
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
 
     def json(self):
         return self._payload
@@ -49,6 +52,15 @@ class MiniMaxSpeechTests(unittest.TestCase):
         self.assertEqual(payload["output_format"], "hex")
         self.assertFalse(payload["stream"])
 
+    def test_instruct_maps_to_minimax_emotion(self):
+        self.assertEqual(_instruct_to_minimax_emotion("shouted furiously"), "angry")
+
+        engine = self.make_engine()
+        payload = engine._build_minimax_payload(
+            "Stop!", "voice-1", "shouted furiously"
+        )
+        self.assertEqual(payload["voice_setting"]["emotion"], "angry")
+
     def test_generate_decodes_hex_audio(self):
         audio = b"RIFFtest-wav"
         response = FakeResponse({
@@ -61,8 +73,8 @@ class MiniMaxSpeechTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = os.path.join(tmpdir, "speech.wav")
             with patch("tts.requests.post", return_value=response) as post_request:
-                success = engine.generate_clone_voice(
-                    "Hello", "NARRATOR", voices, output_path
+                success = engine.generate_custom_voice(
+                    "Hello", "shouted furiously", "NARRATOR", voices, output_path
                 )
 
             self.assertTrue(success)
@@ -73,36 +85,65 @@ class MiniMaxSpeechTests(unittest.TestCase):
         self.assertEqual(request_args[0], MINIMAX_SPEECH_ENDPOINTS["global_en"])
         self.assertEqual(request_kwargs["headers"]["Authorization"], "Bearer test")
         self.assertEqual(
-            request_kwargs["json"]["voice_setting"], {"voice_id": "voice-1"}
+            request_kwargs["json"]["voice_setting"],
+            {"voice_id": "voice-1", "emotion": "angry"},
         )
 
-    def test_design_voice_uses_configured_voice_id(self):
-        audio = b"RIFFdesign-wav"
-        response = FakeResponse({
-            "data": {"audio": audio.hex(), "status": 2},
-            "base_resp": {"status_code": 0},
-        })
+    def test_minimax_does_not_override_clone_or_design_paths(self):
         engine = self.make_engine()
-        voices = {
-            "NARRATOR": {
-                "type": "design",
-                "voice_id": "design-1",
-                "description": "Warm narration",
-            }
-        }
+        clone_voices = {"NARRATOR": {"type": "clone"}}
 
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = os.path.join(tmpdir, "speech.wav")
-            with patch("tts.requests.post", return_value=response) as post_request:
-                success = engine.generate_voice(
-                    "Hello", "calm", "NARRATOR", voices, output_path
+            with patch.object(
+                engine, "_external_generate_clone", return_value=True
+            ) as external_clone, patch.object(engine, "_minimax_generate") as minimax:
+                success = engine.generate_clone_voice(
+                    "Hello", "NARRATOR", clone_voices, output_path
                 )
 
             self.assertTrue(success)
-            self.assertEqual(
-                post_request.call_args.kwargs["json"]["voice_setting"],
-                {"voice_id": "design-1"},
+            external_clone.assert_called_once()
+            minimax.assert_not_called()
+
+        design_voices = {
+            "NARRATOR": {"type": "design", "description": "Warm narration"}
+        }
+        with patch.object(
+            engine, "generate_design_voice", return_value=True
+        ) as design_voice, patch.object(engine, "_minimax_generate") as minimax:
+            success = engine.generate_voice(
+                "Hello", "calm", "NARRATOR", design_voices, "speech.wav"
             )
+
+        self.assertTrue(success)
+        design_voice.assert_called_once()
+        minimax.assert_not_called()
+
+    def test_generate_retries_transient_http_failure(self):
+        audio = b"RIFFretry-wav"
+        responses = [
+            FakeResponse({}, status_code=500),
+            FakeResponse({
+                "data": {"audio": audio.hex(), "status": 2},
+                "base_resp": {"status_code": 0},
+            }),
+        ]
+        engine = self.make_engine()
+        voices = {"NARRATOR": {"voice": "voice-1"}}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "speech.wav")
+            with patch("tts.requests.post", side_effect=responses) as post_request, patch(
+                "tts.time.sleep"
+            ) as sleep:
+                success = engine.generate_custom_voice(
+                    "Hello", "", "NARRATOR", voices, output_path
+                )
+
+            self.assertTrue(success)
+            self.assertEqual(post_request.call_count, 2)
+            sleep.assert_called_once_with(0.5)
 
     def test_generate_rejects_api_error(self):
         response = FakeResponse({

--- a/app/test_tts.py
+++ b/app/test_tts.py
@@ -1,0 +1,129 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from tts import (
+    MINIMAX_DEFAULT_SPEECH_MODEL,
+    MINIMAX_SPEECH_ENDPOINTS,
+    TTSEngine,
+)
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class MiniMaxSpeechTests(unittest.TestCase):
+    def make_engine(self, **overrides):
+        config = {
+            "mode": "external",
+            "provider": "minimax",
+            "api_key": "test",
+            "model": MINIMAX_DEFAULT_SPEECH_MODEL,
+            "region": "global_en",
+            "language": "English",
+        }
+        config.update(overrides)
+        return TTSEngine({"tts": config})
+
+    def test_regional_endpoint_selection(self):
+        engine = self.make_engine(region="cn_zh")
+        self.assertEqual(engine._minimax_endpoint(), MINIMAX_SPEECH_ENDPOINTS["cn_zh"])
+
+    def test_payload_contains_required_speech_fields(self):
+        engine = self.make_engine(model="speech-2.8-turbo")
+        payload = engine._build_minimax_payload("Hello", "voice-1")
+
+        self.assertEqual(payload["model"], "speech-2.8-turbo")
+        self.assertEqual(payload["text"], "Hello")
+        self.assertEqual(payload["voice_setting"], {"voice_id": "voice-1"})
+        self.assertEqual(payload["audio_setting"], {"format": "wav"})
+        self.assertEqual(payload["output_format"], "hex")
+        self.assertFalse(payload["stream"])
+
+    def test_generate_decodes_hex_audio(self):
+        audio = b"RIFFtest-wav"
+        response = FakeResponse({
+            "data": {"audio": audio.hex(), "status": 2},
+            "base_resp": {"status_code": 0},
+        })
+        engine = self.make_engine()
+        voices = {"NARRATOR": {"voice_id": "voice-1"}}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "speech.wav")
+            with patch("tts.requests.post", return_value=response) as post_request:
+                success = engine.generate_clone_voice(
+                    "Hello", "NARRATOR", voices, output_path
+                )
+
+            self.assertTrue(success)
+            with open(output_path, "rb") as output_file:
+                self.assertEqual(output_file.read(), audio)
+
+        request_args, request_kwargs = post_request.call_args
+        self.assertEqual(request_args[0], MINIMAX_SPEECH_ENDPOINTS["global_en"])
+        self.assertEqual(request_kwargs["headers"]["Authorization"], "Bearer test")
+        self.assertEqual(
+            request_kwargs["json"]["voice_setting"], {"voice_id": "voice-1"}
+        )
+
+    def test_design_voice_uses_configured_voice_id(self):
+        audio = b"RIFFdesign-wav"
+        response = FakeResponse({
+            "data": {"audio": audio.hex(), "status": 2},
+            "base_resp": {"status_code": 0},
+        })
+        engine = self.make_engine()
+        voices = {
+            "NARRATOR": {
+                "type": "design",
+                "voice_id": "design-1",
+                "description": "Warm narration",
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "speech.wav")
+            with patch("tts.requests.post", return_value=response) as post_request:
+                success = engine.generate_voice(
+                    "Hello", "calm", "NARRATOR", voices, output_path
+                )
+
+            self.assertTrue(success)
+            self.assertEqual(
+                post_request.call_args.kwargs["json"]["voice_setting"],
+                {"voice_id": "design-1"},
+            )
+
+    def test_generate_rejects_api_error(self):
+        response = FakeResponse({
+            "data": {"audio": "", "status": 2},
+            "base_resp": {"status_code": 1000, "status_msg": "invalid request"},
+        })
+        engine = self.make_engine()
+        voices = {"NARRATOR": {"voice": "voice-1"}}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = os.path.join(tmpdir, "speech.wav")
+            with patch("tts.requests.post", return_value=response), patch(
+                "builtins.print"
+            ):
+                success = engine.generate_custom_voice(
+                    "Hello", "", "NARRATOR", voices, output_path
+                )
+
+            self.assertFalse(success)
+            self.assertFalse(os.path.exists(output_path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/tts.py
+++ b/app/tts.py
@@ -4,11 +4,28 @@ import json
 import threading
 import shutil
 import numpy as np
+import requests
 import soundfile as sf
 from pydub import AudioSegment
 
 DEFAULT_PAUSE_MS = 500  # Pause between different speakers
 SAME_SPEAKER_PAUSE_MS = 250  # Shorter pause for same speaker continuing
+
+MINIMAX_SPEECH_ENDPOINTS = {
+    "global_en": "https://api.minimax.io/v1/t2a_v2",
+    "cn_zh": "https://api.minimaxi.com/v1/t2a_v2",
+}
+MINIMAX_SPEECH_MODELS = (
+    "speech-2.8-hd",
+    "speech-2.8-turbo",
+    "speech-2.6-hd",
+    "speech-2.6-turbo",
+    "speech-02-hd",
+    "speech-02-turbo",
+    "speech-01-hd",
+    "speech-01-turbo",
+)
+MINIMAX_DEFAULT_SPEECH_MODEL = MINIMAX_SPEECH_MODELS[0]
 
 
 def sanitize_filename(name):
@@ -86,11 +103,11 @@ def compute_timeline(chunks_with_audio, pause_ms=DEFAULT_PAUSE_MS,
 
 
 class TTSEngine:
-    """TTS engine supporting local (qwen-tts) and external (Gradio) backends.
+    """TTS engine supporting local and external speech backends.
 
     Mode is determined by config["tts"]["mode"]:
       - "local": Loads Qwen3TTSModel directly. No external server needed.
-      - "external": Connects via Gradio client to a running TTS server.
+      - "external": Uses the configured provider or external server.
 
     Models and clients are lazily initialized on first use.
     """
@@ -101,6 +118,12 @@ class TTSEngine:
         self._url = tts_config.get("url", "http://127.0.0.1:7860")
         self._device = tts_config.get("device", "auto")
         self._compile_codec_enabled = tts_config.get("compile_codec", False)
+        self._provider = str(tts_config.get("provider", "server")).strip().lower()
+        self._api_key = str(tts_config.get("api_key", "")).strip()
+        self._speech_model = str(
+            tts_config.get("model", MINIMAX_DEFAULT_SPEECH_MODEL)
+        ).strip()
+        self._speech_region = str(tts_config.get("region", "global_en")).strip()
 
         # Language setting (passed to Qwen3-TTS)
         self._language = tts_config.get("language", "English")
@@ -661,6 +684,96 @@ class TTSEngine:
         print("Connected to external TTS server.")
         return self._gradio_client
 
+    def _minimax_endpoint(self):
+        """Return the configured regional MiniMax speech endpoint."""
+        endpoint = MINIMAX_SPEECH_ENDPOINTS.get(self._speech_region)
+        if not endpoint:
+            raise ValueError(f"Unsupported MiniMax speech region: {self._speech_region}")
+        return endpoint
+
+    def _build_minimax_payload(self, text, voice_id):
+        """Build a non-streaming WAV request for the MiniMax speech API."""
+        if self._speech_model not in MINIMAX_SPEECH_MODELS:
+            raise ValueError(f"Unsupported MiniMax speech model: {self._speech_model}")
+
+        language_boost = (self._language or "Auto").strip()
+        if language_boost.lower() == "auto":
+            language_boost = "auto"
+
+        return {
+            "model": self._speech_model,
+            "text": text,
+            "stream": False,
+            "language_boost": language_boost,
+            "output_format": "hex",
+            "voice_setting": {"voice_id": voice_id},
+            "audio_setting": {"format": "wav"},
+        }
+
+    def _minimax_generate(self, text, speaker, voice_config, output_path):
+        """Generate speech through MiniMax and save the decoded WAV response."""
+        try:
+            voice_data = voice_config.get(speaker)
+            if not voice_data:
+                print(f"Warning: No voice configuration for '{speaker}'. Skipping.")
+                return False
+
+            voice_id = str(
+                voice_data.get("voice_id") or voice_data.get("voice") or ""
+            ).strip()
+            if not voice_id:
+                print(
+                    f"Warning: MiniMax voice for '{speaker}' is missing voice_id. "
+                    "Skipping."
+                )
+                return False
+            if not self._api_key:
+                print("Warning: MiniMax API key is missing. Skipping speech generation.")
+                return False
+
+            response = requests.post(
+                self._minimax_endpoint(),
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=self._build_minimax_payload(text, voice_id),
+                timeout=120,
+            )
+            response.raise_for_status()
+            result = response.json()
+
+            base_response = result.get("base_resp") or {}
+            status_code = base_response.get("status_code")
+            if status_code not in (None, 0):
+                message = base_response.get("status_msg") or "request failed"
+                raise RuntimeError(f"MiniMax speech request failed: {message}")
+
+            data = result.get("data") or {}
+            data_status = data.get("status")
+            if data_status not in (None, 2):
+                raise RuntimeError(f"MiniMax speech response is not complete: {data_status}")
+
+            audio_hex = data.get("audio")
+            if not isinstance(audio_hex, str) or not audio_hex:
+                raise RuntimeError("MiniMax speech response did not contain audio")
+
+            try:
+                audio_bytes = bytes.fromhex(audio_hex)
+            except ValueError as exc:
+                raise RuntimeError("MiniMax speech response contained invalid audio data") from exc
+
+            if not audio_bytes:
+                raise RuntimeError("MiniMax speech response contained empty audio")
+
+            with open(output_path, "wb") as output_file:
+                output_file.write(audio_bytes)
+            return True
+
+        except Exception as e:
+            print(f"Error generating MiniMax speech for '{speaker}': {e}")
+            return False
+
     # ── Clone prompt cache (local mode) ──────────────────────────
 
     def _get_clone_prompt(self, speaker, voice_config):
@@ -708,6 +821,8 @@ class TTSEngine:
         """Generate audio using CustomVoice model. Returns True on success."""
         if self._mode == "local":
             return self._local_generate_custom(text, instruct_text, speaker, voice_config, output_path)
+        elif self._provider == "minimax":
+            return self._minimax_generate(text, speaker, voice_config, output_path)
         else:
             return self._external_generate_custom(text, instruct_text, speaker, voice_config, output_path)
 
@@ -715,6 +830,8 @@ class TTSEngine:
         """Generate audio using voice cloning. Returns True on success."""
         if self._mode == "local":
             return self._local_generate_clone(text, speaker, voice_config, output_path)
+        elif self._provider == "minimax":
+            return self._minimax_generate(text, speaker, voice_config, output_path)
         else:
             return self._external_generate_clone(text, speaker, voice_config, output_path)
 
@@ -732,6 +849,8 @@ class TTSEngine:
         elif voice_type in ("lora", "builtin_lora"):
             return self.generate_lora_voice(text, instruct_text, voice_data, output_path)
         elif voice_type == "design":
+            if self._mode == "external" and self._provider == "minimax":
+                return self._minimax_generate(text, speaker, voice_config, output_path)
             return self.generate_design_voice(text, instruct_text, voice_data, output_path)
         else:
             return self.generate_custom_voice(text, instruct_text, speaker, voice_config, output_path)
@@ -1052,12 +1171,17 @@ class TTSEngine:
                 speaker = chunk.get("speaker")
                 voice_data = voice_config.get(speaker, {})
                 try:
-                    success = self.generate_design_voice(
-                        text=chunk["text"],
-                        instruct_text=chunk.get("instruct", ""),
-                        voice_data=voice_data,
-                        output_path=output_path,
-                    )
+                    if self._mode == "external" and self._provider == "minimax":
+                        success = self._minimax_generate(
+                            chunk["text"], speaker, voice_config, output_path
+                        )
+                    else:
+                        success = self.generate_design_voice(
+                            text=chunk["text"],
+                            instruct_text=chunk.get("instruct", ""),
+                            voice_data=voice_data,
+                            output_path=output_path,
+                        )
                     if success:
                         results["completed"].append(idx)
                     else:

--- a/app/tts.py
+++ b/app/tts.py
@@ -1,6 +1,7 @@
 import os
 import re
 import json
+import time
 import threading
 import shutil
 import numpy as np
@@ -26,6 +27,24 @@ MINIMAX_SPEECH_MODELS = (
     "speech-01-turbo",
 )
 MINIMAX_DEFAULT_SPEECH_MODEL = MINIMAX_SPEECH_MODELS[0]
+
+MINIMAX_EMOTION_PATTERNS = (
+    ("happy", (r"\bhapp(?:y|ily)\b", r"\bjoy\w*\b", r"\blaugh\w*\b")),
+    ("sad", (r"\bsad\w*\b", r"\bcry\w*\b", r"\bsob\w*\b")),
+    ("angry", (r"\bshout\w*\b", r"\bangr\w*\b", r"\brag(?:e|ing)\b", r"\bfuri\w*\b")),
+    ("fearful", (r"\bscared\b", r"\bafraid\b", r"\bfear\w*\b", r"\btrembl\w*\b")),
+    ("disgusted", (r"\bdisgust\w*\b", r"\brevolt\w*\b")),
+    ("surprised", (r"\bgasp\w*\b", r"\bsurpris\w*\b", r"\bshock\w*\b")),
+)
+
+
+def _instruct_to_minimax_emotion(instruct):
+    """Map free-form delivery direction to a MiniMax emotion value."""
+    normalized = (instruct or "").lower()
+    for emotion, patterns in MINIMAX_EMOTION_PATTERNS:
+        if any(re.search(pattern, normalized) for pattern in patterns):
+            return emotion
+    return "neutral"
 
 
 def sanitize_filename(name):
@@ -691,14 +710,20 @@ class TTSEngine:
             raise ValueError(f"Unsupported MiniMax speech region: {self._speech_region}")
         return endpoint
 
-    def _build_minimax_payload(self, text, voice_id):
+    def _build_minimax_payload(self, text, voice_id, instruct_text=""):
         """Build a non-streaming WAV request for the MiniMax speech API."""
         if self._speech_model not in MINIMAX_SPEECH_MODELS:
             raise ValueError(f"Unsupported MiniMax speech model: {self._speech_model}")
 
         language_boost = (self._language or "Auto").strip()
+        # MiniMax expects lowercase "auto" even though the UI uses "Auto".
         if language_boost.lower() == "auto":
             language_boost = "auto"
+
+        voice_setting = {"voice_id": voice_id}
+        emotion = _instruct_to_minimax_emotion(instruct_text)
+        if emotion != "neutral":
+            voice_setting["emotion"] = emotion
 
         return {
             "model": self._speech_model,
@@ -706,11 +731,11 @@ class TTSEngine:
             "stream": False,
             "language_boost": language_boost,
             "output_format": "hex",
-            "voice_setting": {"voice_id": voice_id},
+            "voice_setting": voice_setting,
             "audio_setting": {"format": "wav"},
         }
 
-    def _minimax_generate(self, text, speaker, voice_config, output_path):
+    def _minimax_generate(self, text, instruct_text, speaker, voice_config, output_path):
         """Generate speech through MiniMax and save the decoded WAV response."""
         try:
             voice_data = voice_config.get(speaker)
@@ -731,15 +756,21 @@ class TTSEngine:
                 print("Warning: MiniMax API key is missing. Skipping speech generation.")
                 return False
 
-            response = requests.post(
-                self._minimax_endpoint(),
-                headers={
+            request_kwargs = {
+                "headers": {
                     "Authorization": f"Bearer {self._api_key}",
                     "Content-Type": "application/json",
                 },
-                json=self._build_minimax_payload(text, voice_id),
-                timeout=120,
-            )
+                "json": self._build_minimax_payload(text, voice_id, instruct_text),
+                "timeout": 120,
+            }
+            for attempt in range(2):
+                response = requests.post(self._minimax_endpoint(), **request_kwargs)
+                status_code = getattr(response, "status_code", 200)
+                if status_code != 429 and status_code < 500:
+                    break
+                if attempt == 0:
+                    time.sleep(0.5)
             response.raise_for_status()
             result = response.json()
 
@@ -822,7 +853,9 @@ class TTSEngine:
         if self._mode == "local":
             return self._local_generate_custom(text, instruct_text, speaker, voice_config, output_path)
         elif self._provider == "minimax":
-            return self._minimax_generate(text, speaker, voice_config, output_path)
+            return self._minimax_generate(
+                text, instruct_text, speaker, voice_config, output_path
+            )
         else:
             return self._external_generate_custom(text, instruct_text, speaker, voice_config, output_path)
 
@@ -830,8 +863,6 @@ class TTSEngine:
         """Generate audio using voice cloning. Returns True on success."""
         if self._mode == "local":
             return self._local_generate_clone(text, speaker, voice_config, output_path)
-        elif self._provider == "minimax":
-            return self._minimax_generate(text, speaker, voice_config, output_path)
         else:
             return self._external_generate_clone(text, speaker, voice_config, output_path)
 
@@ -849,8 +880,6 @@ class TTSEngine:
         elif voice_type in ("lora", "builtin_lora"):
             return self.generate_lora_voice(text, instruct_text, voice_data, output_path)
         elif voice_type == "design":
-            if self._mode == "external" and self._provider == "minimax":
-                return self._minimax_generate(text, speaker, voice_config, output_path)
             return self.generate_design_voice(text, instruct_text, voice_data, output_path)
         else:
             return self.generate_custom_voice(text, instruct_text, speaker, voice_config, output_path)
@@ -1171,17 +1200,12 @@ class TTSEngine:
                 speaker = chunk.get("speaker")
                 voice_data = voice_config.get(speaker, {})
                 try:
-                    if self._mode == "external" and self._provider == "minimax":
-                        success = self._minimax_generate(
-                            chunk["text"], speaker, voice_config, output_path
-                        )
-                    else:
-                        success = self.generate_design_voice(
-                            text=chunk["text"],
-                            instruct_text=chunk.get("instruct", ""),
-                            voice_data=voice_data,
-                            output_path=output_path,
-                        )
+                    success = self.generate_design_voice(
+                        text=chunk["text"],
+                        instruct_text=chunk.get("instruct", ""),
+                        voice_data=voice_data,
+                        output_path=output_path,
+                    )
                     if success:
                         results["completed"].append(idx)
                     else:


### PR DESCRIPTION
Reason: Add a MiniMax speech adapter to the external TTS path.

## Changes

- Add MiniMax global and China endpoint selection with the supported speech model list.
- Send authenticated non-streaming speech requests and decode hexadecimal WAV responses.
- Allow custom, cloned, and designed voice configurations to use MiniMax voice IDs.
- Add persisted setup fields and focused adapter coverage.

## Checks

- `cd app && ../.venv/bin/python -m unittest test_tts.py`
- `.venv/bin/python -m py_compile app/tts.py app/app.py app/project.py app/test_api.py app/test_tts.py`
- Inline JavaScript extracted from `app/static/index.html` passed `node --check`.
- `git diff --check`
