### PR TITLE
Hide Preparer tab until preparer script is present (#71)

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -2370,6 +2370,17 @@ async def dataset_builder_delete(name: str):
 
 # ── Preparer ─────────────────────────────────────────────────────────────────
 
+@app.get("/api/features")
+async def feature_availability():
+    """Report which optional features are usable in this install.
+
+    The Preparer UI depends on app/alexandria_preparer.py being present;
+    when it isn't, the frontend hides the tab so users don't upload audio
+    only to hit a 503.
+    """
+    return {"preparer": os.path.exists(PREPARER_SCRIPT_PATH)}
+
+
 @app.post("/api/preparer/start")
 async def preparer_start(
     background_tasks: BackgroundTasks,

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -73,7 +73,7 @@
                     <li class="nav-item"><a class="nav-link nav-pipeline" data-tab="editor">4. Editor</a></li>
                     <li class="nav-item"><a class="nav-link nav-pipeline" data-tab="audio">5. Result</a></li>
                     <li class="nav-item ms-3 border-start border-secondary ps-3"><a class="nav-link nav-advanced" data-tab="designer">Designer</a></li>
-                    <li class="nav-item"><a class="nav-link nav-advanced" data-tab="preparer">Preparer</a></li>
+                    <li class="nav-item" id="nav-preparer" style="display:none;"><a class="nav-link nav-advanced" data-tab="preparer">Preparer</a></li>
                     <li class="nav-item"><a class="nav-link nav-advanced" data-tab="dataset-builder">Dataset</a></li>
                     <li class="nav-item"><a class="nav-link nav-advanced" data-tab="training">Training</a></li>
                 </ul>
@@ -3927,12 +3927,24 @@
             } catch (e) { console.error('Failed to update system stats', e); }
         }
 
+        // Reveal optional feature tabs that depend on files not always present
+        // (e.g. the Preparer tab needs app/alexandria_preparer.py on disk).
+        async function initOptionalFeatures() {
+            try {
+                const features = await API.get('/api/features');
+                if (features.preparer) {
+                    document.getElementById('nav-preparer').style.display = '';
+                }
+            } catch (e) { console.error('Failed to load feature availability', e); }
+        }
+
         // Init
         loadConfig();
         loadVoices();
         loadSavedScripts();
         loadDesignedVoices();
         dsbLoadProjects();
+        initOptionalFeatures();
         updateSystemStats();
         setInterval(updateSystemStats, 10000); // Update every 10s
 

--- a/app/test_api.py
+++ b/app/test_api.py
@@ -696,6 +696,16 @@ def test_status_unknown_task():
 
 # ── Section: Preparer ─────────────────────────────────────────
 
+def test_features_endpoint():
+    r = get("/api/features")
+    assert_status(r, 200)
+    data = r.json()
+    # Preparer flag must exist and be a boolean so the frontend can
+    # decide whether to show the tab.
+    if not isinstance(data.get("preparer"), bool):
+        raise TestFailure(f"features.preparer must be bool, got {data}")
+
+
 def test_preparer_status():
     r = get("/api/status/preparer")
     assert_status(r, 200)
@@ -1251,6 +1261,7 @@ def run_all_tests():
     run_test("status_unknown_task", test_status_unknown_task)
 
     section("Preparer")
+    run_test("features_endpoint", test_features_endpoint)
     run_test("preparer_status", test_preparer_status)
     run_test("batch_preparer_status", test_batch_preparer_status)
     run_test("preparer_cancel_when_idle", test_preparer_cancel_when_idle)


### PR DESCRIPTION
## Summary
PR #47 landed the **Preparer UI and endpoints** while intentionally not shipping the underlying `app/alexandria_preparer.py`, gating every endpoint behind a `503`. The UX consequence — reported in #71 — is that users see a "Preparer" tab, upload audio, click Start, and only then hit a `503` pointing to a file they can't obtain. That's advertising a feature that doesn't work.

This PR fixes the discoverability half: **the tab is hidden by default and revealed only when the script is actually present.**

### Backend
- New `GET /api/features` returns `{"preparer": bool}` based on whether `PREPARER_SCRIPT_PATH` exists on disk. Cheap to compute, no state.
- The existing `503` guards on the preparer endpoints stay — defense in depth if the script disappears mid-session.

### Frontend
- Preparer nav item gets `id="nav-preparer"` and starts hidden (`style="display:none;"`).
- New `initOptionalFeatures()` runs at page load, fetches `/api/features`, reveals the nav item only if `preparer === true`. As soon as anyone drops `app/alexandria_preparer.py` into the tree, the tab lights up on next page load with no further code changes.

### Tests
- New `test_features_endpoint` asserts the endpoint returns a JSON object with a boolean `preparer` field.

Refs #71.

## Test plan
- [ ] With no `app/alexandria_preparer.py`: reload the UI → Preparer tab is not in the nav; `curl /api/features` returns `{"preparer": false}`.
- [ ] Drop any executable file at `app/alexandria_preparer.py` (a `#!/usr/bin/env python3` stub is enough for the availability check) → reload → Preparer tab appears; `/api/features` returns `{"preparer": true}`.
- [ ] `python test_api.py` — `features_endpoint` passes; existing preparer tests still pass.
