### PR TITLE
Use lossless audio throughout: FLAC voicelines/final, ALAC M4B

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Transform any book or novel into a fully-voiced audiobook using AI-powered scrip
 - **Script Library** - Save and load annotated scripts with voice configurations
 
 ### Export Options
-- **Combined Audiobook** - Single MP3 with all voices and natural pauses
-- **Individual Voicelines** - Separate MP3 per line for DAW editing (Audacity, etc.)
+- **Combined Audiobook** - Single lossless FLAC file with all voices and natural pauses
+- **Individual Voicelines** - Separate lossless FLAC per line for DAW editing (Audacity, etc.)
 - **Audacity Export** - One-click zip with per-speaker WAV tracks, LOF project file, and labels for automatic multi-track import into Audacity
 - **M4B Audiobook** - Chaptered M4B (AAC) with per-chunk or auto-detected chapter markers for audiobook players (Audiobookshelf, Apple Books, VLC, etc.)
 
@@ -211,7 +211,7 @@ Each character detected in the script gets a voice card. For each speaker:
 
 **Step 5 — Result**
 - Listen to the finished audiobook in the browser
-- Download as MP3, or click **Export to Audacity** for per-speaker WAV tracks
+- Download as FLAC (lossless), or click **Export to Audacity** for per-speaker WAV tracks
 
 ### Advanced Tools (Optional)
 
@@ -366,9 +366,9 @@ High-speed rendering that sends multiple lines to the TTS engine in a single bat
 - **Parallel Workers** setting controls batch size (higher values use more VRAM)
 
 ### Result Tab
-Download your completed audiobook as MP3, export as **M4B** with chapter markers for audiobook players, or click **Export to Audacity** for per-speaker WAV tracks.
+Download your completed audiobook as lossless **FLAC**, export as **M4B** (Apple Lossless/ALAC) with chapter markers for audiobook players, or click **Export to Audacity** for per-speaker WAV tracks.
 
-- **Download MP3** - Standard merged audiobook
+- **Download FLAC** - Lossless merged audiobook
 - **Export M4B** - AAC audiobook with chapter markers. By default, chapters are auto-detected from headings in the script (e.g. "Chapter 1", "Prologue"). Toggle **Per-chunk chapters** for fine-grained navigation where every line becomes a chapter.
 - **Export to Audacity** - Zip with per-speaker WAV tracks. Unzip and open `project.lof` in Audacity to load all tracks, then import `labels.txt` via File > Import > Labels for chunk annotations.
 
@@ -447,14 +447,14 @@ Vocalizations are written as real pronounceable text that the TTS speaks directl
 ## Output Files
 
 **Final Audiobook:**
-- `cloned_audiobook.mp3` - Combined audiobook with natural pauses
+- `cloned_audiobook.flac` - Combined audiobook with natural pauses (lossless FLAC)
 
 **Individual Voicelines (for DAW editing):**
 ```
 voicelines/
-├── voiceline_0001_narrator.mp3
-├── voiceline_0002_elena.mp3
-├── voiceline_0003_marcus.mp3
+├── voiceline_0001_narrator.flac
+├── voiceline_0002_elena.flac
+├── voiceline_0003_marcus.flac
 └── ...
 ```
 
@@ -474,7 +474,7 @@ audacity_export.zip
 └── ...
 ```
 
-Each WAV track is padded to the same total duration with silence where other speakers are talking. Playing all tracks simultaneously sounds identical to the merged MP3.
+Each WAV track is padded to the same total duration with silence where other speakers are talking. Playing all tracks simultaneously sounds identical to the merged FLAC.
 
 **M4B Audiobook (chaptered):**
 - `audiobook.m4b` - AAC audiobook with embedded chapter markers
@@ -713,7 +713,7 @@ curl -X DELETE http://127.0.0.1:4200/api/dataset_builder/my_voice_dataset
 ### Audio Download
 ```bash
 # Download audiobook (after merging in editor)
-curl http://127.0.0.1:4200/api/audiobook --output audiobook.mp3
+curl http://127.0.0.1:4200/api/audiobook --output audiobook.flac
 
 # Export to Audacity (per-speaker tracks + LOF + labels)
 curl -X POST http://127.0.0.1:4200/api/export_audacity
@@ -868,11 +868,11 @@ For script generation, non-thinking models work best:
 - Close other GPU-intensive applications
 - Try `device: cpu` as a fallback (much slower)
 
-### Broken or tiny MP3 files (428 bytes)
-Conda's bundled ffmpeg on Windows often lacks the MP3 encoder (libmp3lame). Alexandria now detects this and automatically falls back to WAV, but if you want MP3 output:
-- Install ffmpeg with MP3 support: `conda install -c conda-forge ffmpeg`
+### Broken or tiny audio files (428 bytes)
+Per-line segments and the final audiobook are now written as **FLAC** (lossless) instead of MP3. Alexandria validates the output and falls back to raw **WAV** (also lossless) if ffmpeg/libsndfile can't write FLAC for some reason. If you see the fallback firing or want FLAC specifically:
+- Install ffmpeg with FLAC support: `conda install -c conda-forge ffmpeg`
 - Or remove conda's ffmpeg to use your system one: `conda remove ffmpeg`
-- Verify with: `ffmpeg -encoders 2>/dev/null | grep mp3`
+- Verify with: `ffmpeg -encoders 2>/dev/null | grep flac`
 
 ### Audio quality issues
 - Use 5-15 second clear reference audio for cloning

--- a/app/app.py
+++ b/app/app.py
@@ -41,7 +41,7 @@ ROOT_DIR = os.path.dirname(BASE_DIR)
 CONFIG_PATH = os.environ.get("ALEXANDRIA_CONFIG_PATH") or os.path.join(BASE_DIR, "config.json")
 VOICE_CONFIG_PATH = os.path.join(ROOT_DIR, "voice_config.json")
 SCRIPT_PATH = os.path.join(ROOT_DIR, "annotated_script.json")
-AUDIOBOOK_PATH = os.path.join(ROOT_DIR, "cloned_audiobook.mp3")
+AUDIOBOOK_PATH = os.path.join(ROOT_DIR, "cloned_audiobook.flac")
 M4B_PATH = os.path.join(ROOT_DIR, "audiobook.m4b")
 UPLOADS_DIR = os.path.join(BASE_DIR, "uploads")
 SCRIPTS_DIR = os.path.join(ROOT_DIR, "scripts")
@@ -944,7 +944,7 @@ async def save_voice_config(config_data: Dict[str, VoiceConfigItem]):
 async def get_audiobook():
     if not os.path.exists(AUDIOBOOK_PATH):
         raise HTTPException(status_code=404, detail="Audiobook not found")
-    return FileResponse(AUDIOBOOK_PATH, filename="audiobook.mp3", media_type="audio/mpeg")
+    return FileResponse(AUDIOBOOK_PATH, filename="audiobook.flac", media_type="audio/flac")
 
 # --- Chunk Management Endpoints ---
 

--- a/app/project.py
+++ b/app/project.py
@@ -349,7 +349,11 @@ class ProjectManager:
 
                 print(f"Generated WAV size: {os.path.getsize(temp_path)} bytes")
 
-                # Try to convert to mp3, fallback to wav if ffmpeg missing
+                # Store segments losslessly as FLAC. This avoids the generation
+                # loss caused by re-encoding MP3 at segment-save time and again
+                # at merge time. FLAC is lossless, ~50% the size of WAV, and
+                # decodes back to identical PCM. If ffmpeg/libsndfile can't
+                # write FLAC for some reason, fall back to raw WAV (also lossless).
                 filename_base = f"voiceline_{index+1:04d}_{sanitize_filename(speaker_to_use)}"
                 audio_path = None
 
@@ -357,29 +361,27 @@ class ProjectManager:
                     segment = AudioSegment.from_wav(temp_path)
 
                     if len(segment) == 0:
-                         self._update_chunk_fields(index, status="error")
-                         return False, "Generated audio has 0 duration"
+                        self._update_chunk_fields(index, status="error")
+                        return False, "Generated audio has 0 duration"
 
-                    mp3_filename = f"{filename_base}.mp3"
-                    mp3_filepath = os.path.join(self.voicelines_dir, mp3_filename)
+                    flac_filename = f"{filename_base}.flac"
+                    flac_filepath = os.path.join(self.voicelines_dir, flac_filename)
 
-                    # This might fail if ffmpeg is missing or lacks MP3 encoder
-                    segment.export(mp3_filepath, format="mp3")
+                    segment.export(flac_filepath, format="flac")
 
-                    # Validate: conda ffmpeg often lacks libmp3lame, producing
-                    # a tiny (~428 byte) header-only file without raising an error
-                    mp3_size = os.path.getsize(mp3_filepath) if os.path.exists(mp3_filepath) else 0
-                    if mp3_size < 1024:
-                        print(f"MP3 export produced invalid file ({mp3_size} bytes) — ffmpeg likely lacks MP3 encoder (libmp3lame). Falling back to WAV.")
-                        os.remove(mp3_filepath)
-                        raise RuntimeError("MP3 export produced invalid file")
+                    # Validate that a real file was produced
+                    flac_size = os.path.getsize(flac_filepath) if os.path.exists(flac_filepath) else 0
+                    if flac_size < 1024:
+                        print(f"FLAC export produced invalid file ({flac_size} bytes) — ffmpeg/libsndfile issue. Falling back to WAV.")
+                        os.remove(flac_filepath)
+                        raise RuntimeError("FLAC export produced invalid file")
 
-                    audio_path = f"voicelines/{mp3_filename}"
+                    audio_path = f"voicelines/{flac_filename}"
 
                 except Exception as e:
                     if "invalid file" not in str(e).lower():
-                        print(f"MP3 conversion failed (ffmpeg missing?): {e}")
-                    # Fallback: copy WAV
+                        print(f"FLAC conversion failed (ffmpeg missing?): {e}")
+                    # Fallback: copy the raw WAV (still lossless)
                     wav_filename = f"{filename_base}.wav"
                     wav_filepath = os.path.join(self.voicelines_dir, wav_filename)
                     shutil.copy(temp_path, wav_filepath)
@@ -454,9 +456,9 @@ class ProjectManager:
         final_audio = combine_audio_with_pauses(
             audio_segments, speakers, pause_ms, same_speaker_pause_ms, pause_overrides
         )
-        output_filename = "cloned_audiobook.mp3"
+        output_filename = "cloned_audiobook.flac"
         output_path = os.path.join(self.root_dir, output_filename)
-        final_audio.export(output_path, format="mp3")
+        final_audio.export(output_path, format="flac")
 
         return True, output_filename
 
@@ -602,7 +604,7 @@ class ProjectManager:
             with open(meta_path, "w", encoding="utf-8") as f:
                 f.write("\n".join(meta_lines))
 
-            # Phase 5 — FFmpeg: WAV + chapters → M4B (AAC)
+            # Phase 5 — FFmpeg: WAV + chapters → M4B (ALAC, lossless)
             cover_path = metadata.get("cover_path") or ""
             has_cover = cover_path and os.path.exists(cover_path)
 
@@ -616,8 +618,7 @@ class ProjectManager:
                 # Map cover as attached picture
                 cmd += ["-map", "1:v", "-c:v", "copy", "-disposition:v:0", "attached_pic"]
             cmd += [
-                "-c:a", "aac",
-                "-b:a", "128k",
+                "-c:a", "alac",
                 "-movflags", "+faststart",
                 output_path
             ]
@@ -918,7 +919,7 @@ class ProjectManager:
             # Call batch TTS with single seed
             batch_results = engine.generate_batch(batch_chunks, voice_config, self.root_dir, batch_seed)
 
-            # Process completed chunks - convert to MP3 and update status
+            # Process completed chunks - convert to FLAC and update status
             chunks = self.load_chunks()  # Reload for each batch
 
             for idx in batch_results["completed"]:
@@ -946,23 +947,22 @@ class ProjectManager:
                             chunks[idx]["status"] = "error"
                             continue
 
-                        mp3_filename = f"{filename_base}.mp3"
-                        mp3_filepath = os.path.join(self.voicelines_dir, mp3_filename)
-                        segment.export(mp3_filepath, format="mp3")
+                        flac_filename = f"{filename_base}.flac"
+                        flac_filepath = os.path.join(self.voicelines_dir, flac_filename)
+                        segment.export(flac_filepath, format="flac")
 
-                        # Validate: conda ffmpeg often lacks libmp3lame, producing
-                        # a tiny (~428 byte) header-only file without raising an error
-                        mp3_size = os.path.getsize(mp3_filepath) if os.path.exists(mp3_filepath) else 0
-                        if mp3_size < 1024:
-                            print(f"MP3 export produced invalid file ({mp3_size} bytes) for chunk {idx} — ffmpeg likely lacks MP3 encoder (libmp3lame). Falling back to WAV.")
-                            os.remove(mp3_filepath)
-                            raise RuntimeError("MP3 export produced invalid file")
+                        # Validate that a real file was produced
+                        flac_size = os.path.getsize(flac_filepath) if os.path.exists(flac_filepath) else 0
+                        if flac_size < 1024:
+                            print(f"FLAC export produced invalid file ({flac_size} bytes) for chunk {idx} — ffmpeg/libsndfile issue. Falling back to WAV.")
+                            os.remove(flac_filepath)
+                            raise RuntimeError("FLAC export produced invalid file")
 
-                        chunks[idx]["audio_path"] = f"voicelines/{mp3_filename}"
+                        chunks[idx]["audio_path"] = f"voicelines/{flac_filename}"
 
                     except Exception as e:
                         if "invalid file" not in str(e).lower():
-                            print(f"MP3 conversion failed for chunk {idx}: {e}")
+                            print(f"FLAC conversion failed for chunk {idx}: {e}")
                         wav_filename = f"{filename_base}.wav"
                         wav_filepath = os.path.join(self.voicelines_dir, wav_filename)
                         shutil.copy(temp_path, wav_filepath)

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -942,11 +942,11 @@
                     <div id="audio-player-container" class="text-center" style="display:none;">
                         <h5>Your Audiobook</h5>
                         <audio id="main-audio" controls class="w-100 mt-2">
-                            <source src="" type="audio/mpeg">
+                            <source src="" type="audio/flac">
                             Your browser does not support the audio element.
                         </audio>
-                        <a id="download-link" href="#" class="btn btn-outline-dark mt-3" download="audiobook.mp3">
-                            <i class="fas fa-download me-2"></i>Download MP3
+                        <a id="download-link" href="#" class="btn btn-outline-dark mt-3" download="audiobook.flac">
+                            <i class="fas fa-download me-2"></i>Download FLAC
                         </a>
                         <button class="btn btn-outline-primary mt-3 ms-2" onclick="exportAudacity()">
                             <i class="fas fa-headphones me-2"></i>Export to Audacity

--- a/pinokio.js
+++ b/pinokio.js
@@ -4,7 +4,7 @@ const path = require('path')
 module.exports = {
   version: "5.0",
   title: "Alexandria",
-  description: "A tool that takes a text document containing a book or a novel, ingests it with an LLM to produce an annotated script, and then uses a TTS API to generate the voice lines, finally stitching them together into an audiobook in MP3 format.",
+  description: "A tool that takes a text document containing a book or a novel, ingests it with an LLM to produce an annotated script, and then uses a TTS API to generate the voice lines, finally stitching them together into a lossless audiobook.",
   icon: "icon.png",
   menu: async (kernel, info) => {
     // Check running states

--- a/pinokio.json
+++ b/pinokio.json
@@ -1,6 +1,6 @@
 {
   "title": "Alexandria",
-  "description": "A multi-voice AI audiobook generator built on Qwen3-TTS — annotate scripts with an LLM, assign unique voices to each character, per-line style instructions for delivery, clone voices from reference audio, design new voices from text descriptions, train custom voices with LoRA fine-tuning, and export to MP3 or Audacity multi-track projects ",
+  "description": "A multi-voice AI audiobook generator built on Qwen3-TTS — annotate scripts with an LLM, assign unique voices to each character, per-line style instructions for delivery, clone voices from reference audio, design new voices from text descriptions, train custom voices with LoRA fine-tuning, and export to lossless FLAC (or ALAC M4B) or Audacity multi-track projects",
   "icon": "icon.png",
   "plugin": {
     "menu": []

--- a/reset.js
+++ b/reset.js
@@ -42,6 +42,11 @@ module.exports = {
   }, {
     method: "fs.rm",
     params: {
+      path: "cloned_audiobook.flac"
+    }
+  }, {
+    method: "fs.rm",
+    params: {
       path: "voicelines"
     }
   }]


### PR DESCRIPTION
Replace the lossy MP3 pipeline (segment + final) with lossless formats:

- Store per-line voicelines as FLAC instead of MP3; fall back to raw WAV (also lossless) if FLAC encoding is unavailable. Avoids the generation loss from encoding each segment twice (once at save, again at merge).
- Export the final merged audiobook as cloned_audiobook.flac instead of MP3, removing the second lossy pass entirely.
- Encode M4B exports with ALAC (Apple Lossless) instead of AAC 128k, so the M4B path is lossless too; drop the now-meaningless bitrate argument (lossless bitrate is content-determined).
- Update web API (app.py), frontend player/download (index.html), and README/pinokio.js descriptions to match the new formats.

Existing projects with legacy .mp3 voiceline paths in chunks.json continue to load: segments are read via AudioSegment.from_file, which decodes MP3 and FLAC alike.

## Summary

Per-line voicelines and the final merged audiobook are now produced in **lossless formats** — FLAC for segments and the main output, ALAC for M4B exports — instead of being MP3-encoded twice (once at segment save, once at merge). This eliminates the generation loss and low-bitrate degradation caused by the old pipeline, with no user-facing workflow changes.

## Changes

- **Segment storage (`app/project.py`)**: per-line voicelines are exported as `voiceline_NNNN_{speaker}.flac` via `segment.export(..., format="flac")` (both single-chunk and batch paths). Falls back to the raw WAV (still lossless) if FLAC encoding is unavailable.
- **Final audiobook (`app/project.py` `merge_audio()`)**: the merged output is now `cloned_audiobook.flac` (`format="flac"`) instead of MP3, removing the second lossy pass entirely.
- **M4B export (`app/project.py`)**: ffmpeg now encodes with `-c:a alac` (Apple Lossless) instead of `-c:a aac -b:a 128k`; the bitrate argument was dropped since lossless bitrate is content-determined, not user-set.
- **Web API (`app/app.py`)**: `AUDIOBOOK_PATH` → `cloned_audiobook.flac`; `/api/audiobook` serves `audiobook.flac` with `media_type="audio/flac"`.
- **Frontend (`app/static/index.html`)**: player `<source type="audio/flac">`, download filename `audiobook.flac`, button label "Download FLAC".
- **Docs/misc**: README (features, output files, project structure, curl example, troubleshooting note) and the `pinokio.js` description updated to reflect the lossless output.
- **Backward compatibility**: `_load_chunks_with_audio()` uses `AudioSegment.from_file`, which decodes MP3 and FLAC alike, so existing projects with `.mp3` paths in `chunks.json` continue to load.

## Testing

- `python -m py_compile app/project.py app/app.py` — both files compile cleanly.
- **M4B ALAC path validated end-to-end**: ran the exact ffmpeg command shape (`-i in.wav -i meta.txt -map_metadata 1 -map 0:a -c:a alac -movflags +faststart out.m4b`) against a 24 kHz mono WAV with FFMETADATA chapters; output probes as `Audio: alac, 24000 Hz, mono, s16p` (lossless) with chapter metadata intact.
- ffmpeg encoder availability confirmed: `alac` and `flac` encoders both present in the ffmpeg build the project installs (Dockerfile apt `ffmpeg` + `libsndfile1`).
- Residual audit: no `format="mp3"`, `cloned_audiobook.mp3`, `mp3_filename`, `-c:a aac`, `128k`, or `libmp3lame` references remain in the changed code paths.
- Manual: FLAC segment export uses the same pydub `export(format=...)` API previously used for MP3 (only the codec string changed), and legacy MP3 segment loading is unaffected.