### PR TITLE
Request response_format=json_object for DeepSeek/GLM LLM backends

### DIFF
--- a/app/generate_personas.py
+++ b/app/generate_personas.py
@@ -9,7 +9,7 @@ import tempfile
 from openai import OpenAI
 
 from tts import TTSEngine, sanitize_filename
-from utils import atomic_json_write as _atomic_json_write
+from utils import atomic_json_write as _atomic_json_write, uses_json_mode
 from persona_prompts import PERSONA_SYSTEM_PROMPT, PERSONA_USER_PROMPT, PERSONA_ADVANCED_PROMPT
 
 
@@ -217,6 +217,7 @@ def _resolve_aliases_batch(client, model_name, speakers_info, existing_names):
             ],
             temperature=0.1,
             max_tokens=max(1500, len(speakers_info) * 80),
+            extra_body={"response_format": {"type": "json_object"}} if uses_json_mode(model_name) else {},
         )
         result = extract_json_object(response.choices[0].message.content.strip())
         if isinstance(result, dict):
@@ -543,6 +544,7 @@ def run_advanced_persona_generation(script, selected_speakers, samples, voice_co
                 ],
                 temperature=0.2,
                 max_tokens=4000,
+                extra_body={"response_format": {"type": "json_object"}} if uses_json_mode(model_name) else {},
             )
             raw_content = response.choices[0].message.content.strip()
             parsed = extract_json_object(raw_content)
@@ -597,6 +599,7 @@ def run_advanced_persona_generation(script, selected_speakers, samples, voice_co
                 ],
                 temperature=0.25,
                 max_tokens=600,
+                extra_body={"response_format": {"type": "json_object"}} if uses_json_mode(model_name) else {},
             )
             parsed = extract_json_object(response.choices[0].message.content.strip())
             if parsed:
@@ -838,6 +841,7 @@ def main():
                 ],
                 temperature=0.3,
                 max_tokens=400,
+                extra_body={"response_format": {"type": "json_object"}} if uses_json_mode(model_name) else {},
             )
 
             text = response.choices[0].message.content.strip()

--- a/app/generate_script.py
+++ b/app/generate_script.py
@@ -5,6 +5,7 @@ import re
 import argparse
 from openai import OpenAI
 from default_prompts import DEFAULT_SYSTEM_PROMPT, DEFAULT_USER_PROMPT
+from utils import uses_json_mode
 
 # Cap for single-speaker mode: entries at this size pass through
 # group_into_chunks (MAX_CHUNK_CHARS=500) as-is without further splitting.
@@ -280,6 +281,7 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
                         "top_k": top_k if top_k else None,
                         "min_p": min_p if min_p else None,
                         "banned_tokens": banned_tokens if banned_tokens else None,
+                        "response_format": {"type": "json_object"} if uses_json_mode(model_name) else None,
                     }.items() if v is not None
                 }
             )

--- a/app/review_script.py
+++ b/app/review_script.py
@@ -6,6 +6,7 @@ import argparse
 from openai import OpenAI
 from review_prompts import REVIEW_SYSTEM_PROMPT, REVIEW_USER_PROMPT
 from generate_script import clean_json_string, repair_json_array, salvage_json_entries
+from utils import uses_json_mode
 
 
 def _is_section_break(text):
@@ -116,6 +117,7 @@ def review_batch(client, model_name, batch_entries, batch_num, total_batches,
                         "top_k": top_k,
                         "min_p": min_p,
                         "banned_tokens": banned_tokens if banned_tokens else None,
+                        "response_format": {"type": "json_object"} if uses_json_mode(model_name) else None,
                     }.items() if v is not None
                 }
             )

--- a/app/utils.py
+++ b/app/utils.py
@@ -4,6 +4,20 @@ import time
 import tempfile
 
 
+def uses_json_mode(model_name):
+    """Return True when the LLM provider needs response_format=json_object.
+
+    DeepSeek (and Zhipu/GLM) APIs require the explicit
+    response_format={"type": "json_object"} parameter to reliably produce
+    valid JSON — prompt-only hints are not enough and the model may emit
+    prose, markdown fences, or whitespace instead. Local servers (Ollama,
+    LM Studio, etc.) may reject unknown response_format values, so this is
+    gated on the model name rather than applied globally.
+    """
+    name = (model_name or "").lower()
+    return "deepseek" in name or "glm" in name
+
+
 def atomic_json_write(data, target_path, max_retries=5):
     """Atomically write JSON data using a temp file and os.replace.
 


### PR DESCRIPTION
DeepSeek (and Zhipu/GLM) OpenAI-compatible APIs require the explicit response_format={"type": "json_object"} request parameter to reliably return valid JSON; prompt-only instructions are not enough, and the model can emit prose, markdown fences, or whitespace instead, causing script/review/persona generation to fail JSON parsing after retries.

- utils.py: add uses_json_mode(model_name) helper — True when the model name contains "deepseek" or "glm" (case-insensitive), False for local backends (Ollama, LM Studio, etc.) that may reject unknown response_format values.
- generate_script.py / review_script.py: append response_format to the existing extra_body in process_chunk / review_batch.
- generate_personas.py: pass response_format via extra_body at all four persona LLM call sites (alias resolution, batch discovery, persona compile, single persona).

The existing prompts already satisfy DeepSeek's companion requirement that the word "json" appears in the messages.

## Summary

When the configured LLM model is DeepSeek (or Zhipu/GLM), all LLM requests (script generation, script review, and all four persona-generation calls) now send `response_format={"type": "json_object"}` in the request body, which forces these APIs to return valid JSON instead of occasionally emitting prose, markdown fences, or whitespace. Local backends such as Ollama and LM Studio are unaffected, since the parameter is only added when the model name contains "deepseek" or "glm".

## Changes

- **`app/utils.py`**: added `uses_json_mode(model_name)` helper — returns `True` when the model name contains `"deepseek"` or `"glm"` (case-insensitive), `False` otherwise, so local backends that may reject unknown `response_format` values are never sent it.
- **`app/generate_script.py`** (`process_chunk`): added `"response_format": {"type": "json_object"}` to the existing `extra_body` when `uses_json_mode(model_name)` is true.
- **`app/review_script.py`** (`review_batch`): same `response_format` addition to `extra_body` for the script-review pass.
- **`app/generate_personas.py`**: added `extra_body={"response_format": {"type": "json_object"}}` (when applicable) at all four persona LLM call sites — alias resolution, advanced batch discovery, persona compile, and single-persona generation.
- No frontend or config changes: `model_name` flows from `config.json` into each call site, so the behavior switches on automatically for DeepSeek/GLM users and off for everyone else.

## Testing

- `python -m py_compile app/utils.py app/generate_script.py app/review_script.py app/generate_personas.py` — all four files compile cleanly.
- **Unit-tested `uses_json_mode`** (10/10 pass): `deepseek-v4-flash`, `DeepSeek-R1`, `deepseek-chat`, `glm-4`, `GLM-4-Flash` → `True`; `richardyoung/qwen3-14b-abliterated:Q8_0`, `gpt-4o`, `qwen2.5-14b`, empty string, `None` → `False`.
- **Verified the `extra_body` construction** for both paths: DeepSeek model → `{'response_format': {'type': 'json_object'}}` (plus `banned_tokens` when configured); local model → `{}` (request body unchanged).
- Grep audit: all 7 `chat.completions.create` call sites across the three LLM files now include the `response_format` switch; no other files modified.
- Not exercised against the live DeepSeek API in this environment (requires the API key/network); the change is a standard OpenAI-compatible request parameter that DeepSeek's documented API accepts, and the existing prompts already contain the word "json" as required by DeepSeek's json_object mode.
