### PR TITLE
Add MiniMax voice-clone and voice-design flow

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -200,6 +200,10 @@ class LLMConfig(BaseModel):
 class TTSConfig(BaseModel):
     mode: str = "local"  # "local" or "external"
     url: str = "http://127.0.0.1:7860"  # external mode only
+    provider: str = "server"  # external speech provider ("server" or "minimax")
+    api_key: str = ""  # MiniMax API key
+    region: str = "global_en"  # MiniMax region ("global_en" or "cn_zh")
+    voice_clone_model: str = "speech-2.8-hd"  # MiniMax voice-clone model
     device: str = "auto"  # local mode: "auto", "cuda:0", "cpu", etc.
     language: str = "English"  # TTS language
     parallel_workers: int = 2  # concurrent TTS workers
@@ -250,6 +254,11 @@ class VoiceConfigItem(BaseModel):
     adapter_id: Optional[str] = None
     adapter_path: Optional[str] = None
     description: Optional[str] = ""  # voice description (for design type)
+    voice_id: Optional[str] = None  # provider voice ID (e.g. MiniMax)
+
+class MiniMaxVoiceDesignRequest(BaseModel):
+    prompt: str  # voice description prompt for MiniMax voice design
+    voice_id: str  # self-defined MiniMax voice ID
 
 class ChunkUpdate(BaseModel):
     text: Optional[str] = None
@@ -476,6 +485,10 @@ async def get_config():
         "tts": {
             "mode": "local",
             "url": "http://127.0.0.1:7860",
+            "provider": "server",
+            "api_key": "",
+            "region": "global_en",
+            "voice_clone_model": "speech-2.8-hd",
             "device": "auto"
         },
         "prompts": {
@@ -1524,6 +1537,72 @@ async def clone_voices_delete(voice_id: str):
 
     logger.info(f"Clone voice deleted: {voice_id}")
     return {"status": "deleted", "voice_id": voice_id}
+
+## ── MiniMax Voice Clone / Voice Design ─────────────────────────
+
+MINIMAX_TMP_DIR = os.path.join(UPLOADS_DIR, "minimax")
+MINIMAX_UPLOAD_EXTS = {".mp3", ".m4a", ".wav"}
+
+@app.post("/api/minimax/voice_clone")
+async def minimax_voice_clone(file: UploadFile = File(...),
+                              voice_id: str = Form(...),
+                              model: Optional[str] = Form(None)):
+    """Clone a voice on MiniMax from an uploaded reference audio file.
+
+    The audio is uploaded to MiniMax (purpose "voice_clone") and then
+    POST /v1/voice_clone creates the cloned voice. Returns the resulting
+    MiniMax voice_id.
+    """
+    engine = project_manager.get_engine()
+    if not engine:
+        raise HTTPException(status_code=500, detail="Failed to initialize TTS engine")
+
+    ext = os.path.splitext(file.filename)[1].lower()
+    if ext not in MINIMAX_UPLOAD_EXTS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported format. Use: {', '.join(sorted(MINIMAX_UPLOAD_EXTS))}",
+        )
+
+    os.makedirs(MINIMAX_TMP_DIR, exist_ok=True)
+    base_name = _sanitize_name(os.path.splitext(file.filename)[0]) or "voice"
+    tmp_path = os.path.join(MINIMAX_TMP_DIR, f"{int(time.time())}_{base_name}{ext}")
+
+    try:
+        content = await file.read()
+        with open(tmp_path, "wb") as out_file:
+            out_file.write(content)
+
+        cloned_voice_id = engine.minimax_clone_voice(tmp_path, voice_id, model)
+    except Exception as e:
+        logger.error(f"MiniMax voice clone failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+    logger.info(f"MiniMax voice cloned as '{cloned_voice_id}'")
+    return {"status": "cloned", "voice_id": cloned_voice_id}
+
+@app.post("/api/minimax/voice_design")
+async def minimax_voice_design(request: MiniMaxVoiceDesignRequest):
+    """Design a voice on MiniMax from a text description.
+
+    Calls POST /v1/voice_design with prompt and a self-defined voice_id.
+    Returns the resulting MiniMax voice_id.
+    """
+    engine = project_manager.get_engine()
+    if not engine:
+        raise HTTPException(status_code=500, detail="Failed to initialize TTS engine")
+
+    try:
+        designed_voice_id = engine.minimax_voice_design(request.prompt, request.voice_id)
+    except Exception as e:
+        logger.error(f"MiniMax voice design failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+    logger.info(f"MiniMax voice designed as '{designed_voice_id}'")
+    return {"status": "designed", "voice_id": designed_voice_id}
 
 ## ── LoRA Training ──────────────────────────────────────────────
 

--- a/app/test_tts.py
+++ b/app/test_tts.py
@@ -1,0 +1,257 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from tts import (
+    MINIMAX_DEFAULT_VOICE_CLONE_MODEL,
+    MINIMAX_FILE_UPLOAD_ENDPOINTS,
+    MINIMAX_VOICE_CLONE_ENDPOINTS,
+    MINIMAX_VOICE_DESIGN_ENDPOINTS,
+    TTSEngine,
+)
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class MiniMaxVoiceCloneTests(unittest.TestCase):
+    def make_engine(self, **overrides):
+        config = {
+            "mode": "external",
+            "provider": "minimax",
+            "api_key": "test",
+            "region": "global_en",
+            "voice_clone_model": MINIMAX_DEFAULT_VOICE_CLONE_MODEL,
+        }
+        config.update(overrides)
+        return TTSEngine({"tts": config})
+
+    def write_audio(self, tmpdir, name="ref.wav"):
+        path = os.path.join(tmpdir, name)
+        with open(path, "wb") as f:
+            f.write(b"RIFF-test-audio")
+        return path
+
+    def test_regional_endpoint_selection(self):
+        engine = self.make_engine(region="cn_zh")
+        self.assertEqual(
+            engine._minimax_endpoint_for(MINIMAX_FILE_UPLOAD_ENDPOINTS),
+            "https://api.minimaxi.com/v1/files/upload",
+        )
+        self.assertEqual(
+            engine._minimax_endpoint_for(MINIMAX_VOICE_CLONE_ENDPOINTS),
+            "https://api.minimaxi.com/v1/voice_clone",
+        )
+        self.assertEqual(
+            engine._minimax_endpoint_for(MINIMAX_VOICE_DESIGN_ENDPOINTS),
+            "https://api.minimaxi.com/v1/voice_design",
+        )
+
+    def test_upload_audio_returns_file_id(self):
+        response = FakeResponse({
+            "file": {"file_id": "file-123"},
+            "base_resp": {"status_code": 0},
+        })
+        engine = self.make_engine()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audio_path = self.write_audio(tmpdir)
+            with patch("tts.requests.post", return_value=response) as post_request:
+                file_id = engine.minimax_upload_audio(audio_path, "voice_clone")
+
+        self.assertEqual(file_id, "file-123")
+        request_args, request_kwargs = post_request.call_args
+        self.assertEqual(request_args[0], MINIMAX_FILE_UPLOAD_ENDPOINTS["global_en"])
+        self.assertEqual(request_kwargs["headers"]["Authorization"], "Bearer test")
+        self.assertEqual(request_kwargs["data"]["purpose"], "voice_clone")
+        self.assertIn("file", request_kwargs["files"])
+
+    def test_upload_audio_supports_prompt_purpose(self):
+        response = FakeResponse({
+            "file": {"file_id": "file-456"},
+            "base_resp": {"status_code": 0},
+        })
+        engine = self.make_engine()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audio_path = self.write_audio(tmpdir)
+            with patch("tts.requests.post", return_value=response) as post_request:
+                file_id = engine.minimax_upload_audio(audio_path, "prompt_audio")
+
+        self.assertEqual(file_id, "file-456")
+        self.assertEqual(
+            post_request.call_args.kwargs["data"]["purpose"], "prompt_audio"
+        )
+
+    def test_upload_audio_rejects_unsupported_purpose(self):
+        engine = self.make_engine()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audio_path = self.write_audio(tmpdir)
+            with self.assertRaises(ValueError):
+                engine.minimax_upload_audio(audio_path, "transcribe")
+
+    def test_upload_audio_rejects_unsupported_extension(self):
+        engine = self.make_engine()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audio_path = self.write_audio(tmpdir, name="ref.flac")
+            with self.assertRaises(ValueError):
+                engine.minimax_upload_audio(audio_path, "voice_clone")
+
+    def test_upload_audio_requires_api_key(self):
+        engine = self.make_engine(api_key="")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audio_path = self.write_audio(tmpdir)
+            with self.assertRaises(ValueError):
+                engine.minimax_upload_audio(audio_path, "voice_clone")
+
+    def test_upload_audio_raises_when_file_missing(self):
+        engine = self.make_engine()
+        with self.assertRaises(ValueError):
+            engine.minimax_upload_audio("/nonexistent/ref.wav", "voice_clone")
+
+    def test_clone_voice_uploads_then_clones(self):
+        upload_response = FakeResponse({
+            "file": {"file_id": "file-123"},
+            "base_resp": {"status_code": 0},
+        })
+        clone_response = FakeResponse({
+            "voice_id": "voice-cloned-1",
+            "base_resp": {"status_code": 0},
+        })
+        engine = self.make_engine()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audio_path = self.write_audio(tmpdir)
+            with patch(
+                "tts.requests.post", side_effect=[upload_response, clone_response]
+            ) as post_request:
+                voice_id = engine.minimax_clone_voice(
+                    audio_path, "my-voice", "speech-2.6-hd"
+                )
+
+        self.assertEqual(voice_id, "voice-cloned-1")
+        self.assertEqual(post_request.call_count, 2)
+        upload_kwargs = post_request.call_args_list[0].kwargs
+        self.assertEqual(upload_kwargs["data"]["purpose"], "voice_clone")
+        clone_args, clone_kwargs = post_request.call_args_list[1]
+        self.assertEqual(clone_args[0], MINIMAX_VOICE_CLONE_ENDPOINTS["global_en"])
+        self.assertEqual(clone_kwargs["json"], {
+            "file_id": "file-123",
+            "voice_id": "my-voice",
+            "model": "speech-2.6-hd",
+        })
+
+    def test_clone_voice_uses_configured_default_model(self):
+        upload_response = FakeResponse({
+            "file": {"file_id": "file-123"},
+            "base_resp": {"status_code": 0},
+        })
+        clone_response = FakeResponse({
+            "voice_id": "voice-cloned-1",
+            "base_resp": {"status_code": 0},
+        })
+        engine = self.make_engine(voice_clone_model="speech-01-hd")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audio_path = self.write_audio(tmpdir)
+            with patch(
+                "tts.requests.post", side_effect=[upload_response, clone_response]
+            ) as post_request:
+                engine.minimax_clone_voice(audio_path, "my-voice")
+
+        clone_kwargs = post_request.call_args_list[1].kwargs
+        self.assertEqual(clone_kwargs["json"]["model"], "speech-01-hd")
+
+    def test_clone_voice_rejects_unsupported_model(self):
+        engine = self.make_engine()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audio_path = self.write_audio(tmpdir)
+            with patch("tts.requests.post") as post_request:
+                with self.assertRaises(ValueError):
+                    engine.minimax_clone_voice(audio_path, "my-voice", "speech-99")
+            post_request.assert_not_called()
+
+    def test_voice_design_returns_voice_id(self):
+        response = FakeResponse({
+            "voice_id": "voice-designed-1",
+            "base_resp": {"status_code": 0},
+        })
+        engine = self.make_engine()
+
+        with patch("tts.requests.post", return_value=response) as post_request:
+            voice_id = engine.minimax_voice_design(
+                "Warm grandmotherly tone", "design-1"
+            )
+
+        self.assertEqual(voice_id, "voice-designed-1")
+        request_args, request_kwargs = post_request.call_args
+        self.assertEqual(request_args[0], MINIMAX_VOICE_DESIGN_ENDPOINTS["global_en"])
+        self.assertEqual(request_kwargs["json"], {
+            "prompt": "Warm grandmotherly tone",
+            "voice_id": "design-1",
+        })
+
+    def test_voice_design_rejects_empty_prompt(self):
+        engine = self.make_engine()
+        with patch("tts.requests.post") as post_request:
+            with self.assertRaises(ValueError):
+                engine.minimax_voice_design("   ", "design-1")
+            post_request.assert_not_called()
+
+    def test_voice_clone_raises_on_api_error(self):
+        upload_response = FakeResponse({
+            "file": {"file_id": "file-123"},
+            "base_resp": {"status_code": 0},
+        })
+        clone_response = FakeResponse({
+            "base_resp": {"status_code": 1004, "status_msg": "invalid model"},
+        })
+        engine = self.make_engine()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audio_path = self.write_audio(tmpdir)
+            with patch(
+                "tts.requests.post", side_effect=[upload_response, clone_response]
+            ):
+                with self.assertRaises(RuntimeError):
+                    engine.minimax_clone_voice(audio_path, "my-voice")
+
+    def test_voice_design_raises_on_api_error(self):
+        response = FakeResponse({
+            "base_resp": {"status_code": 1001, "status_msg": "bad prompt"},
+        })
+        engine = self.make_engine()
+        with patch("tts.requests.post", return_value=response):
+            with self.assertRaises(RuntimeError):
+                engine.minimax_voice_design("some prompt", "design-1")
+
+    def test_voice_clone_raises_when_voice_id_missing(self):
+        upload_response = FakeResponse({
+            "file": {"file_id": "file-123"},
+            "base_resp": {"status_code": 0},
+        })
+        clone_response = FakeResponse({
+            "base_resp": {"status_code": 0},
+        })
+        engine = self.make_engine()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            audio_path = self.write_audio(tmpdir)
+            with patch(
+                "tts.requests.post", side_effect=[upload_response, clone_response]
+            ):
+                with self.assertRaises(RuntimeError):
+                    engine.minimax_clone_voice(audio_path, "my-voice")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/app/tts.py
+++ b/app/tts.py
@@ -3,12 +3,36 @@ import re
 import json
 import threading
 import shutil
+import requests
 import numpy as np
 import soundfile as sf
 from pydub import AudioSegment
 
 DEFAULT_PAUSE_MS = 500  # Pause between different speakers
 SAME_SPEAKER_PAUSE_MS = 250  # Shorter pause for same speaker continuing
+
+# MiniMax voice-clone / voice-design API configuration.
+MINIMAX_VOICE_CLONE_ENDPOINTS = {
+    "global_en": "https://api.minimax.io/v1/voice_clone",
+    "cn_zh": "https://api.minimaxi.com/v1/voice_clone",
+}
+MINIMAX_VOICE_DESIGN_ENDPOINTS = {
+    "global_en": "https://api.minimax.io/v1/voice_design",
+    "cn_zh": "https://api.minimaxi.com/v1/voice_design",
+}
+MINIMAX_FILE_UPLOAD_ENDPOINTS = {
+    "global_en": "https://api.minimax.io/v1/files/upload",
+    "cn_zh": "https://api.minimaxi.com/v1/files/upload",
+}
+MINIMAX_VOICE_CLONE_MODELS = (
+    "speech-2.8-hd",
+    "speech-2.6-hd",
+    "speech-02-hd",
+    "speech-01-hd",
+)
+MINIMAX_VOICE_CLONE_PURPOSES = ("voice_clone", "prompt_audio")
+MINIMAX_VOICE_AUDIO_EXTS = (".mp3", ".m4a", ".wav")
+MINIMAX_DEFAULT_VOICE_CLONE_MODEL = MINIMAX_VOICE_CLONE_MODELS[0]
 
 
 def sanitize_filename(name):
@@ -101,6 +125,14 @@ class TTSEngine:
         self._url = tts_config.get("url", "http://127.0.0.1:7860")
         self._device = tts_config.get("device", "auto")
         self._compile_codec_enabled = tts_config.get("compile_codec", False)
+
+        # MiniMax provider configuration (used by the voice-clone flow)
+        self._provider = str(tts_config.get("provider", "server")).strip().lower()
+        self._api_key = str(tts_config.get("api_key", "")).strip()
+        self._speech_region = str(tts_config.get("region", "global_en")).strip()
+        self._voice_clone_model = str(
+            tts_config.get("voice_clone_model", MINIMAX_DEFAULT_VOICE_CLONE_MODEL)
+        ).strip()
 
         # Language setting (passed to Qwen3-TTS)
         self._language = tts_config.get("language", "English")
@@ -660,6 +692,129 @@ class TTSEngine:
         self._gradio_client = Client(self._url)
         print("Connected to external TTS server.")
         return self._gradio_client
+
+    # ── MiniMax voice-clone / voice-design flow ──────────────────
+
+    def _minimax_endpoint_for(self, endpoints):
+        """Resolve the configured regional MiniMax endpoint."""
+        endpoint = endpoints.get(self._speech_region)
+        if not endpoint:
+            raise ValueError(f"Unsupported MiniMax region: {self._speech_region}")
+        return endpoint
+
+    def _minimax_headers(self):
+        """Build authenticated MiniMax request headers."""
+        if not self._api_key:
+            raise ValueError("MiniMax API key is missing")
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _minimax_raise_for_base_resp(self, result, message):
+        """Raise if the MiniMax response reports a non-zero status code."""
+        base_response = result.get("base_resp") or {}
+        status_code = base_response.get("status_code")
+        if status_code not in (None, 0):
+            detail = base_response.get("status_msg") or message
+            raise RuntimeError(f"{message}: {detail}")
+
+    def minimax_upload_audio(self, file_path, purpose):
+        """Upload a reference audio file to MiniMax.
+
+        POST /v1/files/upload with purpose "voice_clone" or "prompt_audio".
+        Returns the uploaded file_id.
+        """
+        if purpose not in MINIMAX_VOICE_CLONE_PURPOSES:
+            raise ValueError(f"Unsupported MiniMax upload purpose: {purpose}")
+        if not os.path.exists(file_path):
+            raise ValueError(f"Reference audio not found: {file_path}")
+        ext = os.path.splitext(file_path)[1].lower()
+        if ext not in MINIMAX_VOICE_AUDIO_EXTS:
+            raise ValueError(
+                f"Unsupported audio format: {ext}. "
+                f"Use {', '.join(MINIMAX_VOICE_AUDIO_EXTS)}"
+            )
+        if not self._api_key:
+            raise ValueError("MiniMax API key is missing")
+
+        url = self._minimax_endpoint_for(MINIMAX_FILE_UPLOAD_ENDPOINTS)
+        with open(file_path, "rb") as audio_file:
+            response = requests.post(
+                url,
+                headers={"Authorization": f"Bearer {self._api_key}"},
+                data={"purpose": purpose},
+                files={"file": (os.path.basename(file_path), audio_file)},
+                timeout=120,
+            )
+        response.raise_for_status()
+        result = response.json()
+        self._minimax_raise_for_base_resp(result, "MiniMax audio upload failed")
+
+        file_id = ((result.get("file") or {}).get("file_id") or "").strip()
+        if not file_id:
+            raise RuntimeError("MiniMax audio upload response did not contain file_id")
+        return file_id
+
+    def minimax_clone_voice(self, file_path, voice_id, model=None):
+        """Clone a voice on MiniMax from a reference audio file.
+
+        Uploads the audio (purpose "voice_clone") then calls POST
+        /v1/voice_clone with file_id, voice_id and model. Returns the
+        cloned voice_id.
+        """
+        clone_model = model or self._voice_clone_model
+        if clone_model not in MINIMAX_VOICE_CLONE_MODELS:
+            raise ValueError(f"Unsupported MiniMax voice clone model: {clone_model}")
+
+        file_id = self.minimax_upload_audio(file_path, "voice_clone")
+        url = self._minimax_endpoint_for(MINIMAX_VOICE_CLONE_ENDPOINTS)
+        response = requests.post(
+            url,
+            headers=self._minimax_headers(),
+            json={
+                "file_id": file_id,
+                "voice_id": voice_id,
+                "model": clone_model,
+            },
+            timeout=120,
+        )
+        response.raise_for_status()
+        result = response.json()
+        self._minimax_raise_for_base_resp(result, "MiniMax voice clone failed")
+
+        cloned_voice_id = (result.get("voice_id") or "").strip()
+        if not cloned_voice_id:
+            raise RuntimeError("MiniMax voice clone response did not contain voice_id")
+        return cloned_voice_id
+
+    def minimax_voice_design(self, prompt, voice_id):
+        """Design a voice on MiniMax from a text description.
+
+        Calls POST /v1/voice_design with prompt and voice_id. Returns the
+        designed voice_id.
+        """
+        if not prompt or not str(prompt).strip():
+            raise ValueError("MiniMax voice design prompt is required")
+
+        url = self._minimax_endpoint_for(MINIMAX_VOICE_DESIGN_ENDPOINTS)
+        response = requests.post(
+            url,
+            headers=self._minimax_headers(),
+            json={
+                "prompt": str(prompt).strip(),
+                "voice_id": voice_id,
+            },
+            timeout=120,
+        )
+        response.raise_for_status()
+        result = response.json()
+        self._minimax_raise_for_base_resp(result, "MiniMax voice design failed")
+
+        designed_voice_id = (result.get("voice_id") or "").strip()
+        if not designed_voice_id:
+            raise RuntimeError("MiniMax voice design response did not contain voice_id")
+        return designed_voice_id
 
     # ── Clone prompt cache (local mode) ──────────────────────────
 


### PR DESCRIPTION
Reason: Add a MiniMax voice-clone and voice-design flow to the TTS engine.

## Changes

- Add MiniMax voice-clone and voice-design API configuration with regional endpoints for the global and China hosts, the supported clone models (speech-2.8-hd, speech-2.6-hd, speech-02-hd, speech-01-hd), upload purposes (voice_clone, prompt_audio) and accepted audio formats (mp3, m4a, wav).
- Add `minimax_upload_audio`, `minimax_clone_voice` and `minimax_voice_design` methods to the TTS engine covering POST /v1/files/upload, POST /v1/voice_clone and POST /v1/voice_design.
- Add persisted setup fields (provider, api_key, region, voice_clone_model) and an optional `voice_id` field on voice config items.
- Expose `/api/minimax/voice_clone` (multipart upload then clone) and `/api/minimax/voice_design` HTTP endpoints.

## Checks

- `cd app && python3 -m unittest test_tts` (15 tests pass)
- `python3 -m py_compile app/tts.py app/app.py app/project.py app/test_api.py app/test_tts.py`
- `git diff --check`
