### PR TITLE
Verbatim audiobook pipeline: span classification, canonical speakers, safe review

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,22 @@ Transform any book or novel into a fully-voiced audiobook using AI-powered scrip
 
 ### AI-Powered Pipeline
 - **Local & Cloud LLM Support** - Use any OpenAI-compatible API (LM Studio, Ollama, OpenAI, etc.)
-- **Automatic Script Annotation** - LLM parses text into JSON with speakers, dialogue, and TTS instruct directions
-- **LLM Script Review** - Optional second LLM pass that fixes common annotation errors: strips attribution tags from dialogue, splits misattributed narration/dialogue, merges over-split narrator entries, and validates instruct fields
+- **Verbatim Script Annotation** - Code splits each chunk into quoted/unquoted spans and the LLM returns only labels (`id`, `speaker`, `role`, `instruct`). The script text is reassembled from the source by offset, so the author's words are never rewritten
+- **LLM Script Review** - Optional second LLM pass that checks only two things per entry: whether `speaker` is the correct attribution and whether `instruct` is a usable voice direction. Entry text is always re-imposed from the original, so review cannot alter a single character of the book
 - **Persona Generation** - LLM analyzes the script to create voice descriptions for each character, then generates reference audio via VoiceDesign and assigns clone voices automatically — one click to go from script to fully-voiced cast
+- **Speaker Canonicalization** - Speaker labels are normalized to a canonical UPPERCASE form (accents folded, parentheticals and wrapping quotes removed, honorifics dropped). Spellings that differ only in spaces, hyphens or apostrophes ("ABBEMARIGNAN" / "ABBE MARIGNAN") are unified; similar-but-distinct names (JON/JOHN) never are
 - **Speaker Aliases** - Map multiple speaker names to the same voice (e.g. "YOUNG ELENA" → "ELENA") so variants share a single voice configuration
 - **Smart Chunking** - Groups consecutive lines by speaker (up to 500 chars) for natural flow
-- **Context Preservation** - Passes character roster and last 3 script entries between chunks for name and style continuity
+- **Context Preservation** - Passes a capped character roster (50 most recently spoken names by default) and short snippets of the last 3 script entries between chunks for name and style continuity
+
+#### Verbatim Fidelity
+
+The goal is an industry-standard audiobook, not an audio drama: the author's text is read word-for-word. Quoted dialogue gets character voices; everything else — including attribution tags like "said Marcus" — is read by the narrator. The LLM is an analytical classifier, never a generator of book text.
+
+- **Verbatim reassembly** - Each chunk is tokenized into contiguous quoted/unquoted spans that tile the source exactly. The LLM sees numbered spans and returns only labels; code rebuilds the entries from the source string by `(start, end)` offset. A truncated or malformed response costs labels, never prose
+- **Byte-identity is asserted, not hoped for** - Every chunk's entries must concatenate back to the chunk byte-for-byte; a mismatch raises rather than warns. Source → `annotated_script.json` word coverage is exactly 1.0
+- **NARRATOR fallback** - Any span the LLM failed to label keeps its text and is attributed to NARRATOR. Enumerated placeholder labels ("SPEAKER 1", "VOICE 3") are rejected the same way
+- **Loud degradation** - Script generation exits with code **3** when the script was written but some spans fell back to NARRATOR — distinct from 0 (clean) and 1 (nothing produced). The task log reports it as "completed with degradations" and the run summary names every degraded chunk
 
 ### Voice Generation
 - **Built-in TTS Engine** - Qwen3-TTS runs locally with no external server required
@@ -38,7 +48,7 @@ Transform any book or novel into a fully-voiced audiobook using AI-powered scrip
 - **Dataset Builder** - Interactive tool for creating LoRA training datasets with per-sample text, emotion, and audio preview
 - **Batch Processing** - Generate dozens of chunks simultaneously with 3-6x real-time throughput
 - **Codec Compilation** - Optional `torch.compile` optimization for 3-4x faster batch decoding
-- **Non-verbal Sounds** - LLM writes natural vocalizations ("Ahh!", "Mmm...", "Haha!") with context-aware instruct directions
+- **Non-verbal Sounds** - Vocalizations the author wrote ("Ahh!", "Mmm...", "Haha!") are spoken as-is with context-aware instruct directions — no bracket tags or special tokens. The LLM never adds sounds that aren't in the book; add your own in the Editor if you want them
 - **Natural Pauses** - Configurable silence between speakers (default 500ms) and same-speaker segments (default 250ms)
 
 ### Web UI Editor
@@ -192,7 +202,7 @@ Configure your LLM connection and TTS engine. At minimum you need:
 **Step 2 — Script**
 - Select your book file (.txt, .md, or .epub) using the file picker — it uploads automatically
 - Click **Generate Annotated Script** — this sends the book to your LLM to split it into annotated chunks with speaker labels and voice directions
-- *(Optional)* Click **Review Script** if the generated script has issues — this runs a second LLM pass to fix speaker misattributions or formatting problems
+- *(Optional)* Click **Review Script** if the generated script has issues — this runs a second LLM pass to fix speaker misattributions and weak instruct directions. It cannot change the text
 - You can save the script for later use with the Save feature below
 
 **Step 3 — Voices**
@@ -245,20 +255,37 @@ Configure connections to your LLM and TTS engine.
 - **Banned Tokens** - Comma-separated list of tokens to ban from LLM output (useful for disabling thinking mode on models like GLM4, DeepSeek-R1, etc.)
 - **Prompt Customization** - System and user prompts used for script generation. Defaults are loaded from `default_prompts.txt` and can be customized per-session in the UI. Click "Reset to Defaults" to reload the file-based defaults (picks up edits without restarting the app)
 
+**Advanced Keys (edit `app/config.json` directly):**
+
+These have no UI control and are read straight from `app/config.json` by the generation/review/TTS code. Note that clicking **Save Configuration** rewrites `config.json` from the UI's form fields and will drop them, so set them after your last save (or re-add them afterwards).
+
+| Key | Default | What it does |
+|-----|---------|--------------|
+| `generation.num_ctx` | unset | Serving context window requested from the LLM server per call, for servers that honor it (Ollama). Set this when you see the prompt-truncation warning |
+| `generation.max_context_roster_names` | 50 | Cap on how many character names the per-chunk roster block may list. Kept names are the most recently spoken; the prompt says so when the list is partial |
+| `generation.review_batch_char_budget` | 12000 | Rendered-JSON character budget per review batch, applied alongside `review_batch_size`. Keeps a few very long entries from producing a prompt that overflows a modest serving window |
+| `tts.enable_nemo_normalization` | `false` | Optional text normalization ("Dr." → "doctor") applied **only** at the TTS call boundary — never to `instruct`, never to the script file. Uses `nemo_text_processing` where installable, else `wetext` (which has prebuilt Windows wheels). Off by default because whether it helps is book- and voice-specific |
+| `pronunciation_dict.json` (repo root) | absent | Optional per-book file of flat `{"from": "to"}` literal replacements, applied after the normalizer to correct its mistakes (e.g. `{"Marlborough Dr.": "Marlborough Drive"}`). Only applied when normalization is enabled |
+
+Run `python tools/verify_tts_normalization.py` to see raw vs. normalized vs. dictionary-applied text for a test sentence before deciding, or `--synthesize` to render the sentence both ways and listen.
+
 ### Script Tab
-Upload a text file (.txt, .md, or .epub) and generate the annotated script. EPUB files are automatically converted to plain text on upload. The LLM converts your book into a structured JSON format with:
+Upload a text file (.txt, .md, or .epub) and generate the annotated script. EPUB files are automatically converted to plain text on upload, in spine (reading) order; a per-chapter character count is printed to the terminal so you can confirm nothing was lost. A spine item whose file cannot be resolved, or an `idref` with no manifest entry, aborts the extraction rather than silently dropping a chapter. Non-text spine items (e.g. an SVG cover page) and the EPUB3 navigation document are skipped with a notice.
+
+The LLM annotates your book into a structured JSON format with:
 - Speaker identification (NARRATOR vs character names)
-- Dialogue text with natural vocalizations (written as pronounceable text, not tags)
+- The author's text, reassembled verbatim from the source — the LLM only labels spans, it never emits book text
 - Style directions for TTS delivery
 
-**Review Script** - After generation, click "Review Script" to run a second LLM pass that detects and fixes common annotation errors:
-1. Attribution tags left in dialogue ("said he", "she replied") are stripped
-2. Narration mixed into character entries is split out as NARRATOR
-3. Dialogue embedded in narrator entries is extracted as the correct speaker
-4. Short consecutive narrator entries covering the same scene are merged
-5. Invalid instruct fields (physical actions instead of voice directions) are corrected
+**Review Script** - After generation, click "Review Script" to run a second LLM pass. It checks exactly two fields per entry:
+1. `speaker` — is the entry attributed to the right character?
+2. `instruct` — is it a usable voice direction (not a physical action, not empty)?
+
+Entry `text` is always re-imposed from the original entry, so a review pass cannot reword, split, merge or strip anything. A batch whose response has a different entry count than it was sent is rejected wholesale and the originals are kept. Speaker corrections are canonicalized and snapped back onto the spelling already established in the script.
 
 Review prompts are customizable in `review_prompts.txt` (same format as `default_prompts.txt`).
+
+> **Note:** `default_prompts.txt` carries a `span-labels-v1` marker and `review_prompts.txt` a `verbatim-review-v1` marker. A custom prompt saved in `config.json` before this pipeline existed asks the LLM for something it can no longer use, so a saved prompt missing its marker is rejected with a loud warning and the built-in default is used instead. If you customize a prompt, keep the marker line.
 
 ### Voices Tab
 After script generation, voices are automatically loaded from the annotated script. For each speaker:
@@ -271,11 +298,17 @@ Click **Generate Personas** to automatically assign voices to all characters. Th
 
 **Speaker Aliases:**
 Each voice card has an "Alias of" dropdown. Setting a speaker as an alias of another speaker means it will use the target's voice configuration during audio generation. Useful for:
-- Character name variants (e.g., "DR. SMITH" → "SMITH")
 - Age variants (e.g., "YOUNG ELENA" → "ELENA")
+- Nickname or spelling variants the automatic rules deliberately don't merge (e.g. "JON" / "JOHN" — the pipeline never auto-merges similar names, because they are often two different people)
 - Reducing the number of voices to configure
 
 Aliases resolve transitively (A → B → C uses C's config) with cycle detection.
+
+Honorific variants ("DR. SMITH" → "SMITH") no longer need an alias — canonicalization strips a leading honorific automatically.
+
+> **Known limitation:** because honorifics are stripped, `MR SMITH` and `MRS SMITH` both canonicalize to `SMITH`, so a husband and wife share one voice card and one voice. There is currently no way to split them back apart. If a book distinguishes two characters only by title, edit their `speaker` values in the Editor to something unambiguous before configuring voices.
+
+`GET /api/voices/alias_suggestions` returns advisory fuzzy-similarity suggestions (JON/JOHN, ELLA/BELLA) for the current roster. It is purely advisory — nothing is merged — and is not yet surfaced in the UI.
 
 **Custom Voice Mode:**
 - Select from 9 pre-trained voices: Aiden, Dylan, Eric, Ono_anna, Ryan, Serena, Sohee, Uncle_fu, Vivian
@@ -428,16 +461,19 @@ The generated script is a JSON array with `speaker`, `text`, and `instruct` fiel
 
 ```json
 [
-  {"speaker": "NARRATOR", "text": "The door creaked open slowly.", "instruct": "Calm, even narration."},
-  {"speaker": "ELENA", "text": "Ah! Who's there?", "instruct": "Startled and fearful, sharp whispered question, voice cracking with panic."},
-  {"speaker": "MARCUS", "text": "Haha... did you miss me?", "instruct": "Menacing confidence, low smug drawl with a dark chuckle, savoring the moment."}
+  {"speaker": "NARRATOR", "text": "The door creaked open slowly. ", "instruct": "Calm, even narration."},
+  {"speaker": "ELENA", "text": "\"Ah! Who's there?\"", "instruct": "Startled and fearful, sharp whispered question, voice cracking with panic."},
+  {"speaker": "NARRATOR", "text": " she whispered.\n\n", "instruct": "Neutral, even narration."},
+  {"speaker": "MARCUS", "text": "\"Haha... did you miss me?\"", "instruct": "Menacing confidence, low smug drawl with a dark chuckle, savoring the moment."}
 ]
 ```
 
+- **`speaker`** — canonical UPPERCASE character name, or `NARRATOR`. The casing is load-bearing: the pipeline compares against the literal `"NARRATOR"`
+- **`text`** — verbatim from the source book, including quotation marks and the whitespace between entries. Concatenating every entry's `text` in order reproduces the book exactly, which is why attribution tags ("she whispered") are their own NARRATOR entries rather than being dropped
 - **`instruct`** — 2-3 sentence TTS voice direction sent directly to the engine. Set tone, describe delivery, then give specific references. Example: "Devastated by grief, Sniffing between words and pausing to collect herself, end with a wracking sob."
 
 ### Non-verbal Sounds
-Vocalizations are written as real pronounceable text that the TTS speaks directly — no bracket tags or special tokens. The LLM generates natural onomatopoeia with short instruct directions:
+Vocalizations are real pronounceable text that the TTS speaks directly — no bracket tags or special tokens. Because the script is verbatim, these come from the book itself (or from your own edits in the Editor), and the LLM gives them a short instruct direction:
 - Gasps: "Ah!", "Oh!" with instruct like "Fearful, sharp gasp."
 - Sighs: "Haah...", "Hff..."
 - Laughter: "Haha!", "Ahaha..."
@@ -526,7 +562,7 @@ curl -X POST http://127.0.0.1:4200/api/generate_script
 # Check status
 curl http://127.0.0.1:4200/api/status/script_generation
 
-# Review script (fix attribution tags, misattributed lines, etc.)
+# Review script (fix speaker attribution and instruct fields; text is never altered)
 curl -X POST http://127.0.0.1:4200/api/review_script
 
 # Check review status
@@ -540,6 +576,10 @@ curl http://127.0.0.1:4200/api/voices
 
 # Parse voices from script
 curl -X POST http://127.0.0.1:4200/api/parse_voices
+
+# Advisory alias suggestions for similar roster names (never merges anything)
+# Kept off the /api/voices hot path — it is O(n^2) in roster size
+curl http://127.0.0.1:4200/api/voices/alias_suggestions
 
 # Save voice config
 curl -X POST http://127.0.0.1:4200/api/save_voice_config \
@@ -842,6 +882,20 @@ For script generation, non-thinking models work best:
 - Verify model name matches what's loaded
 - Try a different model - some struggle with JSON output
 
+### Script generation "completed with degradations" (return code 3)
+This is not a failure: the script was written and no text was lost, but some spans could not be classified and are attributed to NARRATOR. The run summary lists every degraded chunk. Review those entries in the Editor, or re-run after fixing the cause below.
+
+### Speakers are mostly NARRATOR, or `prompt_tokens` never changes
+Your LLM server is silently truncating the prompt. A server whose context window is smaller than the prompt does not error — it drops the overflow and answers from what's left, so the model is asked to classify spans it was never shown. Symptoms in the terminal:
+- A `PROMPT LIKELY TRUNCATED BY THE SERVER` warning on individual chunks
+- A `SERVER CONTEXT WINDOW SUSPECT` line in the run summary, reporting that `prompt_tokens` was pinned to one exact value across prompts of wildly different sizes (Ollama's default `num_ctx=2048` produces exactly this)
+- Lots of retries and degraded chunks with an otherwise green run
+
+Fix it by raising the **server's** context window:
+- **Ollama:** set `OLLAMA_CONTEXT_LENGTH=8192` in the environment, bake `num_ctx` into the model's Modelfile, or set `generation.num_ctx` in `app/config.json` (forwarded per request to servers that honor it)
+- **llama.cpp / vLLM:** raise `-c` / `--max-model-len`
+- Or reduce the prompt: lower `generation.chunk_size` or `generation.max_context_roster_names`
+
 ### Model download fails or is very slow
 - TTS models (~3.5 GB each) are downloaded from Hugging Face on first use
 - If downloads are slow or fail due to network restrictions (common in mainland China), set a Hugging Face mirror before launching:
@@ -902,6 +956,27 @@ LLM prompts are stored in plain-text files at the project root, split into syste
 
 **Non-English books:** The default LLM prompts are written for English text and reference English-specific conventions (attribution tags like "said he", quotation marks, etc.). When processing books in other languages, you'll get better results by editing the prompts to match that language's dialogue conventions — for example, French guillemets (« »), Japanese brackets (「」), or language-appropriate attribution patterns. Set the TTS **Language** dropdown to match as well.
 
+> **Limitation:** the span tokenizer recognizes straight and curly double quotes (`"` `“` `”`) and single quotes (`'` `‘` `’`) as dialogue delimiters. Guillemets (« ») and CJK brackets (「」) are **not** recognized, so dialogue marked that way is currently classified as narration and read by the narrator. No text is lost — it is the safe failure direction — but such a book will not get character voices until the tokenizer learns those marks. Prompt customization cannot work around this, since the LLM only labels the spans code gives it.
+
+## Testing
+
+The test suites are standalone scripts (not pytest) and run fully offline — they use fake LLM clients and programmatically built EPUB fixtures, so no LLM server, no TTS model and no network are required. Run them from the `app/` directory:
+
+```bash
+cd app
+python test_api.py --offline        # pipeline invariants (verbatim, coverage == 1.0) — ~1 second
+python test_span_tokenizer.py       # span FSM: tiling, quote disambiguation
+python test_span_integration.py     # span classification -> verbatim entries end to end
+python test_speaker_canon.py        # canonicalization, roster keys, alias suggestions
+python test_canon_wiring.py         # canonicalization wired through generation/review/API
+python test_review_verbatim.py      # positional overlay, batch sizing, text-loss guards
+python test_epub_extract.py         # EPUB href resolution and loud-failure behavior
+python test_integration_fixes.py    # regression checks for previously shipped fixes
+python test_tts_normalization.py    # normalizer no-op-when-off and backend chain
+```
+
+`python test_api.py` without `--offline` additionally exercises the HTTP API and needs the server running.
+
 ## Project Structure
 
 ```
@@ -909,15 +984,18 @@ Alexandria/
 ├── app/
 │   ├── app.py                 # FastAPI server
 │   ├── tts.py                 # TTS engine (local + external backends)
+│   ├── tts_normalizer.py      # Optional TTS-boundary text normalization (off by default)
 │   ├── train_lora.py          # LoRA training subprocess script
-│   ├── generate_script.py     # LLM script annotation
+│   ├── generate_script.py     # LLM span classification -> verbatim script
+│   ├── span_tokenizer.py      # FSM splitting text into quoted/unquoted spans
+│   ├── speaker_canon.py       # Speaker-label canonicalization and alias suggestions
 │   ├── generate_personas.py   # LLM persona generation + VoiceDesign voice assignment
-│   ├── review_script.py       # LLM script review (second pass)
+│   ├── review_script.py       # LLM script review (second pass, speaker/instruct only)
 │   ├── utils.py               # Shared utilities (atomic JSON writes)
+│   ├── test_*.py              # Standalone offline test suites (see Testing above)
 │   ├── default_prompts.py     # Generation prompt loader (reads default_prompts.txt)
 │   ├── review_prompts.py      # Review prompt loader (reads review_prompts.txt)
 │   ├── project.py             # Chunk management & batch generation
-│   ├── parse_voices.py        # Voice extraction
 │   ├── config.json            # Runtime configuration (gitignored)
 │   ├── static/index.html      # Web UI
 │   └── requirements.txt       # Python dependencies
@@ -926,6 +1004,7 @@ Alexandria/
 ├── designed_voices/           # Saved Voice Designer outputs (gitignored)
 ├── lora_datasets/             # Uploaded/generated training datasets (gitignored)
 ├── lora_models/               # Trained LoRA adapters (gitignored)
+├── tools/                     # Standalone diagnostic tools (TTS normalization check)
 ├── default_prompts.txt        # LLM prompts for script generation
 ├── review_prompts.txt         # LLM prompts for script review
 ├── install.js                 # Pinokio installer

--- a/app/app.py
+++ b/app/app.py
@@ -8,7 +8,7 @@ from fastapi import FastAPI, UploadFile, File, Form, HTTPException, BackgroundTa
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import List, Optional, Dict
 import re
 import time
@@ -201,6 +201,8 @@ class LLMConfig(BaseModel):
     model_name: str
 
 class TTSConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     mode: str = "local"  # "local" or "external"
     url: str = "http://127.0.0.1:7860"  # external mode only
     device: str = "auto"  # local mode: "auto", "cuda:0", "cpu", etc.
@@ -215,8 +217,11 @@ class TTSConfig(BaseModel):
     batch_group_by_type: bool = False  # group chunks by voice type for efficient batching
     pause_between_speakers_ms: int = 500  # silence (ms) between different speakers during merge
     pause_same_speaker_ms: int = 250  # silence (ms) when same speaker continues during merge
+    enable_nemo_normalization: bool = False  # run NeMo text normalization before TTS
 
 class GenerationConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     chunk_size: int = 3000
     max_tokens: int = 4096
     temperature: float = 0.6
@@ -226,6 +231,15 @@ class GenerationConfig(BaseModel):
     presence_penalty: float = 0.0
     banned_tokens: List[str] = []
     merge_narrators: bool = False
+    max_context_roster_names: int = 50  # cap on named characters included in LLM context
+    review_batch_size: int = 25  # entries per review batch
+    review_batch_char_budget: int = 12000  # char budget per review batch
+    # Server context window (Ollama num_ctx) to request. None/unset = do not
+    # send an options.num_ctx override; the server's own default is used.
+    # Declaring a concrete default here would start forcing a context window
+    # on every user the moment they save the config, so keep it Optional and
+    # excluded from output when None (see save_config).
+    num_ctx: Optional[int] = None
 
 class PromptConfig(BaseModel):
     system_prompt: Optional[str] = None
@@ -237,6 +251,8 @@ class PromptConfig(BaseModel):
     persona_advanced_prompt: Optional[str] = None
 
 class AppConfig(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
     llm: LLMConfig
     tts: TTSConfig
     prompts: Optional[PromptConfig] = None
@@ -619,7 +635,7 @@ async def get_default_prompts():
 async def save_config(config: AppConfig):
     os.makedirs(os.path.dirname(CONFIG_PATH) or ".", exist_ok=True)
     with open(CONFIG_PATH, "w", encoding="utf-8") as f:
-        json.dump(config.model_dump(), f, indent=2, ensure_ascii=False)
+        json.dump(config.model_dump(exclude_none=True), f, indent=2, ensure_ascii=False)
     # Reset engine so it picks up new TTS settings on next use
     project_manager.engine = None
     return {"status": "saved"}

--- a/app/app.py
+++ b/app/app.py
@@ -28,6 +28,7 @@ from default_prompts import load_default_prompts
 from review_prompts import load_review_prompts
 from persona_prompts import load_persona_prompts
 from hf_utils import fetch_builtin_manifest, download_builtin_adapter, is_adapter_downloaded
+from speaker_canon import canonicalize, suggest_aliases
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
@@ -368,6 +369,32 @@ process_state = {
     "batch_preparer": {"running": False, "logs": [], "cancel": False, "tasks": [], "current_task_idx": -1},
 }
 
+
+# Task families where generate_script.py's exit code 3 ("output written,
+# but one or more spans fell back to NARRATOR -- review recommended") can
+# be reached. Distinct from a genuine failure: the script file was written
+# successfully and is usable, just degraded. See generate_script.py's
+# EXIT_DEGRADED constant / module docstring for the exit-code contract.
+_DEGRADED_EXIT_CODE = 3
+_SCRIPT_TASK_NAMES = {"script"}
+
+
+def _process_completion_message(task_name: str, return_code: int) -> str:
+    """Choose the log line for a finished (non-cancelled) task.
+
+    Factored out from run_process so the exit-code-3 special case is
+    independently testable without spinning up a real subprocess.
+    """
+    if return_code == 0:
+        return f"Task {task_name} completed successfully."
+    if return_code == _DEGRADED_EXIT_CODE and task_name in _SCRIPT_TASK_NAMES:
+        return (
+            f"Task {task_name} completed with degradations (return code 3): "
+            f"output was written; some spans fell back to NARRATOR — check the log above."
+        )
+    return f"Task {task_name} failed with return code {return_code}."
+
+
 def run_process(command: List[str], task_name: str):
     """Run a subprocess and stream its output into process_state logs."""
     state = process_state[task_name]
@@ -381,10 +408,8 @@ def run_process(command: List[str], task_name: str):
 
         if state.get("cancel"):
             state["logs"].append(f"Task {task_name} cancelled.")
-        elif return_code == 0:
-            state["logs"].append(f"Task {task_name} completed successfully.")
         else:
-            state["logs"].append(f"Task {task_name} failed with return code {return_code}.")
+            state["logs"].append(_process_completion_message(task_name, return_code))
 
     except Exception as e:
         logger.error(f"Error running {task_name}: {e}")
@@ -626,12 +651,20 @@ class _HTMLTextExtractor(HTMLParser):
         if self._skip_depth > 0:
             return
         if self._pending_newline and self.parts:
-            self.parts.append('\n')
+            self.parts.append('\n\n')
             self._pending_newline = False
         self.parts.append(data)
 
     def get_text(self):
-        return ''.join(self.parts)
+        text = ''.join(self.parts)
+        # Normalize intra-line whitespace noise from source indentation
+        # (e.g. pretty-printed XHTML) without disturbing paragraph breaks.
+        text = re.sub(r'[ \t]+', ' ', text)
+        text = re.sub(r' *\n *', '\n', text)
+        # Collapse any run of 3+ newlines (from adjacent/nested block tags)
+        # down to a single blank line so paragraph structure stays uniform.
+        text = re.sub(r'\n{3,}', '\n\n', text)
+        return text.strip()
 
 
 def extract_epub_text(epub_path: str) -> str:
@@ -639,7 +672,20 @@ def extract_epub_text(epub_path: str) -> str:
 
     Parses the EPUB ZIP structure directly using stdlib only:
     META-INF/container.xml -> .opf manifest+spine -> XHTML content files.
+
+    Hrefs are resolved robustly against the OPF directory: percent-encoding
+    is decoded and '../'-style traversal is normalized before matching
+    against the archive's actual member names. If normalization doesn't
+    find a match, a case-insensitive lookup is tried, followed by an
+    unambiguous basename match. Any spine item that still can't be
+    resolved raises ValueError instead of being silently skipped. The
+    EPUB3 navigation document (manifest item with properties="nav") is
+    excluded from the extracted text. A per-chapter char-count report is
+    printed to stdout.
     """
+    import posixpath
+    from urllib.parse import unquote
+
     with zipfile.ZipFile(epub_path, 'r') as zf:
         # 1. Find the OPF file path from container.xml
         container_xml = zf.read('META-INF/container.xml')
@@ -656,15 +702,51 @@ def extract_epub_text(epub_path: str) -> str:
         # Detect OPF namespace (varies between EPUB 2 and 3)
         opf_ns = opf.tag.split('}')[0] + '}' if '}' in opf.tag else ''
 
-        # Build manifest: id -> href (resolve relative to OPF directory)
         opf_dir = opf_path.rsplit('/', 1)[0] + '/' if '/' in opf_path else ''
+
+        # Build a normalized index of every member in the archive so hrefs
+        # can be matched regardless of percent-encoding, '../' segments,
+        # or case differences.
+        normalized_index = {}   # normalized path -> actual member name
+        ci_index = {}            # lowercased normalized path -> actual member name
+        basename_index = {}      # lowercased basename -> [actual member names]
+        for name in zf.namelist():
+            norm = posixpath.normpath(name)
+            normalized_index.setdefault(norm, name)
+            ci_index.setdefault(norm.lower(), name)
+            basename_index.setdefault(posixpath.basename(norm).lower(), []).append(name)
+
+        def resolve_href(href, item_id):
+            joined = posixpath.normpath(unquote(opf_dir + href))
+            candidate = normalized_index.get(joined)
+            if candidate is None:
+                candidate = ci_index.get(joined.lower())
+            if candidate is None:
+                base = posixpath.basename(joined).lower()
+                matches = basename_index.get(base, [])
+                if len(matches) == 1:
+                    candidate = matches[0]
+            if candidate is None:
+                raise ValueError(
+                    f"EPUB spine item '{item_id}' references href '{href}' "
+                    f"(resolved to '{joined}') which does not match any file "
+                    f"in the archive."
+                )
+            return candidate
+
+        # Build manifest: id -> (href, media_type, is_nav_doc).
+        # Include ALL manifest items regardless of media type -- the spine
+        # may legally reference non-HTML content (e.g. an SVG cover page),
+        # and that's not the silent-skip bug class this fix targets. Only a
+        # genuinely absent manifest item should raise.
         manifest = {}
         for item in opf.findall(f'.//{opf_ns}item'):
             item_id = item.get('id')
             href = item.get('href')
             media_type = item.get('media-type', '')
-            if item_id and href and 'html' in media_type:
-                manifest[item_id] = opf_dir + href
+            properties = (item.get('properties') or '').split()
+            if item_id and href:
+                manifest[item_id] = (href, media_type, 'nav' in properties)
 
         # Get spine order
         spine_ids = []
@@ -675,20 +757,35 @@ def extract_epub_text(epub_path: str) -> str:
 
         # 3. Extract text from each spine item in order
         chapters = []
+        report = []
         for item_id in spine_ids:
-            href = manifest.get(item_id)
-            if href is None:
+            entry = manifest.get(item_id)
+            if entry is None:
+                raise ValueError(
+                    f"EPUB spine references idref '{item_id}' which has no "
+                    f"corresponding manifest item."
+                )
+            href, media_type, is_nav = entry
+            if is_nav:
+                continue  # EPUB3 navigation document isn't chapter content
+            if 'html' not in media_type:
+                # Legally spineable non-text content (e.g. an SVG cover
+                # page). Not a silent-skip bug -- intentionally excluded.
+                print(f"[extract_epub_text] skipping non-text spine item '{item_id}' ({media_type})")
                 continue
-            try:
-                html_bytes = zf.read(href)
-            except KeyError:
-                continue
+            member_name = resolve_href(href, item_id)
+            html_bytes = zf.read(member_name)
             html_content = html_bytes.decode('utf-8', errors='replace')
             extractor = _HTMLTextExtractor()
             extractor.feed(html_content)
             text = extractor.get_text().strip()
             if text:
                 chapters.append(text)
+                report.append((len(chapters), href, len(text)))
+
+    print(f"[extract_epub_text] {epub_path}: extracted {len(chapters)} chapter(s)")
+    for idx, href, char_count in report:
+        print(f"  chapter {idx}: {href} -> {char_count} chars")
 
     return '\n\n'.join(chapters)
 
@@ -830,24 +927,62 @@ async def get_status(task_name: str):
     state.pop("process", None)
     return state
 
+def build_voice_roster(script_data, voice_config):
+    """Build a canonical, fragment-free voice roster from script entries.
+
+    Args:
+        script_data: list of annotated_script.json entries (each with a
+            "speaker" and/or legacy "type" field). Speaker labels are only
+            ever read here -- never mutated, and entry "text" is untouched.
+        voice_config: dict loaded from voice_config.json, possibly keyed by
+            older non-canonical speaker names (e.g. "Mr. Mark").
+
+    Returns:
+        (roster_names, alias_suggestions, config_lookup):
+          - roster_names: sorted list of deduped canonical speaker names.
+          - alias_suggestions: suggest_aliases(roster_names) -- advisory
+            records only, never used to merge anything here.
+          - config_lookup: dict mapping each canonical roster name to the
+            voice_config entry that resolves for it (exact key match first,
+            falling back to scanning voice_config keys for one whose
+            canonicalize() equals the roster name; first match wins). Names
+            with no resolvable config are simply absent from this dict.
+    """
+    roster_set = set()
+    for entry in script_data:
+        raw_speaker = entry.get("speaker") or entry.get("type") or ""
+        canonical = canonicalize(raw_speaker)
+        if canonical:
+            roster_set.add(canonical)
+    roster_names = sorted(roster_set)
+
+    alias_suggestions = suggest_aliases(roster_names)
+
+    config_lookup = {}
+    for roster_name in roster_names:
+        if roster_name in voice_config:
+            config_lookup[roster_name] = voice_config[roster_name]
+            continue
+        for key, value in voice_config.items():
+            if canonicalize(key) == roster_name:
+                config_lookup[roster_name] = value
+                break
+
+    return roster_names, alias_suggestions, config_lookup
+
+
 @app.get("/api/voices")
 async def get_voices():
     # Parse voices directly from the current script (no stale cache)
-    voices_list = []
+    script_data = []
     if os.path.exists(SCRIPT_PATH):
         try:
             with open(SCRIPT_PATH, "r", encoding="utf-8") as f:
                 script_data = json.load(f)
-            voices_set = set()
-            for entry in script_data:
-                speaker = (entry.get("speaker") or entry.get("type") or "").strip()
-                if speaker:
-                    voices_set.add(speaker)
-            voices_list = sorted(voices_set)
         except (json.JSONDecodeError, ValueError):
-            pass
+            script_data = []
 
-    if not voices_list:
+    if not script_data:
         return []
 
     # Combine with config
@@ -859,15 +994,20 @@ async def get_voices():
         except (json.JSONDecodeError, ValueError):
             voice_config = {}
 
-    missing_speakers = {voice_name for voice_name in voices_list if voice_name not in voice_config}
+    roster_names, alias_suggestions, config_lookup = build_voice_roster(script_data, voice_config)
+
+    if not roster_names:
+        return []
 
     result = []
-    for voice_name in voices_list:
-        config = voice_config.get(voice_name, {})
+    for voice_name in roster_names:
+        config = config_lookup.get(voice_name, {})
+        voice_aliases = [s for s in alias_suggestions if s["name"] == voice_name]
         result.append({
             "name": voice_name,
             "config": config,
-            "persona_pending": voice_name in missing_speakers
+            "persona_pending": voice_name not in config_lookup,
+            "alias_suggestions": voice_aliases
         })
     return result
 

--- a/app/app.py
+++ b/app/app.py
@@ -303,6 +303,15 @@ class AppConfig(BaseModel):
     generation: Optional[GenerationConfig] = None
 
 class VoiceConfigItem(BaseModel):
+    # Same reason as the other config models in this file: without
+    # extra="allow", save_voice_config's model_dump() silently DROPS any key
+    # this model does not declare. That is not hypothetical -- "alias_of" was
+    # dropped on every save, so the Voices UI's alias dropdown appeared to do
+    # nothing and an alias set outside the UI was erased the next time the page
+    # autosaved. Declare new keys explicitly anyway, so they get a documented
+    # default.
+    model_config = ConfigDict(extra="allow")
+
     type: str = "custom"
     voice: Optional[str] = "Ryan"
     character_style: Optional[str] = ""
@@ -313,6 +322,13 @@ class VoiceConfigItem(BaseModel):
     adapter_id: Optional[str] = None
     adapter_path: Optional[str] = None
     description: Optional[str] = ""  # voice description (for design type)
+    # Point this speaker at another speaker's voice. tts.resolve_voice follows
+    # the chain (cycle-safe). None/unset means the speaker has its own voice;
+    # excluded from output when None so an unaliased entry stays clean.
+    alias_of: Optional[str] = None
+    # Set by generate_personas when a speaker got no persona and fell back to
+    # the narrator's voice, so the operator can find them in the Voices UI.
+    defaulted_from_narrator: Optional[bool] = None
 
 class ChunkUpdate(BaseModel):
     text: Optional[str] = None
@@ -1344,8 +1360,14 @@ async def save_voice_config(config_data: Dict[str, VoiceConfigItem]):
 
     # Update current config with new data
     for voice_name, config in config_data.items():
-        # Convert Pydantic model to dict
-        current_config[voice_name] = config.model_dump()
+        # Convert Pydantic model to dict. Optional-by-absence keys (alias_of,
+        # defaulted_from_narrator) are excluded when None so clearing an alias
+        # in the UI removes the key rather than writing a null one.
+        entry = config.model_dump()
+        for optional_key in ("alias_of", "defaulted_from_narrator"):
+            if entry.get(optional_key) is None:
+                entry.pop(optional_key, None)
+        current_config[voice_name] = entry
 
     # Stamp the canonicalization generation this file's keys were written
     # under. Generation 2 is "canonicalize() preserves gender-marking titles",

--- a/app/app.py
+++ b/app/app.py
@@ -678,12 +678,23 @@ async def save_config(config: AppConfig):
     return {"status": "saved"}
 
 class _HTMLTextExtractor(HTMLParser):
-    """Strip HTML tags from EPUB content, preserving block-level structure."""
+    """Strip HTML tags from EPUB content, preserving block-level structure.
+
+    `title` is skipped because HTMLParser reports <head><title> text through
+    handle_data like any other text, so the per-chapter document title (often
+    a generic converter artifact such as "Unknown") was being spliced into the
+    book body and read aloud by the narrator. Only `title` is skipped, not
+    `head` wholesale: this parser closes a skip region on the explicit end tag
+    and never implicitly closes <head> at <body>, so a document with an
+    unclosed <head> would silently lose its entire chapter. Measured on a real
+    23-chapter EPUB, skipping `head` and skipping `title` produce byte-identical
+    text, so `title` buys the same fix with a far smaller blast radius.
+    """
     BLOCK_TAGS = frozenset({
         'p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
         'li', 'blockquote', 'br', 'hr', 'tr', 'section', 'article',
     })
-    SKIP_TAGS = frozenset({'style', 'script'})
+    SKIP_TAGS = frozenset({'style', 'script', 'title'})
 
     def __init__(self):
         super().__init__()

--- a/app/app.py
+++ b/app/app.py
@@ -272,6 +272,13 @@ class GenerationConfig(BaseModel):
     # clean run into an exit-3 degraded run, so it must be an explicit opt-in.
     # Measure a book first with tools/verify_attestation.py.
     require_attested_speakers: bool = False
+    # Adjacent-attribution-tag check (generate_script._tag_contradictions).
+    # DEFAULT FALSE for the same reason as require_attested_speakers: it spends
+    # retries and can turn a clean run into an exit-3 degraded run, so it is an
+    # explicit opt-in. It only ever flags and retries -- it never rewrites a
+    # label -- and it degrades to doing nothing on a non-English book, whose
+    # attribution tags carry none of the English speech verbs it recognizes.
+    check_attribution_tags: bool = False
     # Preceding source characters joined to the current chunk when attesting a
     # speaker name. None/unset = fall back to chunk_size, so the default tracks
     # the chunk size rather than pinning a second number that can disagree

--- a/app/app.py
+++ b/app/app.py
@@ -196,9 +196,25 @@ async def get_system_stats():
 
 # Data Models
 class LLMConfig(BaseModel):
+    # extra="allow" to match GenerationConfig/TTSConfig/AppConfig. Without it
+    # this section silently DROPPED any key it did not declare on save, which
+    # is the bug class already fixed for the other sections.
+    model_config = ConfigDict(extra="allow")
+
     base_url: str
     api_key: str
     model_name: str
+    # Per-request timeout, in seconds, for LLM calls. None/unset = use the
+    # OpenAI SDK default (600s), so existing installs are unchanged.
+    #
+    # Why this is configurable: local inference speed varies by orders of
+    # magnitude, and the SDK default is a hard ceiling with no override. On a
+    # measured local setup (27.9B Q4 model, 8GB card, so most weights in system
+    # RAM) generation ran at 9.5 tok/s, which means a 8192-token completion
+    # needs ~861s and dies at 600s having produced nothing usable. Capping
+    # generation.max_tokens is the better primary fix, but a machine slow
+    # enough still needs the ceiling raised.
+    timeout: Optional[float] = None
 
 class TTSConfig(BaseModel):
     model_config = ConfigDict(extra="allow")

--- a/app/app.py
+++ b/app/app.py
@@ -215,6 +215,17 @@ class LLMConfig(BaseModel):
     # generation.max_tokens is the better primary fix, but a machine slow
     # enough still needs the ceiling raised.
     timeout: Optional[float] = None
+    # Reasoning suppression for "thinking" models, passed through to the API as
+    # the standard OpenAI `reasoning_effort` field. None/unset = send nothing.
+    #
+    # Why this exists: a reasoning model can spend its ENTIRE completion budget
+    # thinking and return an empty message body, which yields zero labels and
+    # narrates every span in the chunk. Measured on Ollama /v1 with a 27.9B
+    # thinking model: 4096 completion tokens, empty content, three attempts in a
+    # row. reasoning_effort="none" removed reasoning entirely (498 chars -> 0,
+    # 118 completion tokens -> 63 on the same probe); Ollama's native
+    # `"think": false` was silently IGNORED on the /v1 path.
+    reasoning_effort: Optional[str] = None
 
 class TTSConfig(BaseModel):
     model_config = ConfigDict(extra="allow")

--- a/app/app.py
+++ b/app/app.py
@@ -29,7 +29,7 @@ from review_prompts import load_review_prompts
 from persona_prompts import load_persona_prompts
 from hf_utils import fetch_builtin_manifest, download_builtin_adapter, is_adapter_downloaded
 from speaker_canon import (
-    remember_in_roster, roster_key, suggest_aliases,
+    remember_in_roster, roster_key, suggest_aliases, attest_label,
 )
 
 # Setup logging
@@ -240,6 +240,16 @@ class GenerationConfig(BaseModel):
     # on every user the moment they save the config, so keep it Optional and
     # excluded from output when None (see save_config).
     num_ctx: Optional[int] = None
+    # Attestation gate for speaker labels (generate_script.resolve_span_labels).
+    # DEFAULT FALSE: enabling it changes which labels survive and can turn a
+    # clean run into an exit-3 degraded run, so it must be an explicit opt-in.
+    # Measure a book first with tools/verify_attestation.py.
+    require_attested_speakers: bool = False
+    # Preceding source characters joined to the current chunk when attesting a
+    # speaker name. None/unset = fall back to chunk_size, so the default tracks
+    # the chunk size rather than pinning a second number that can disagree
+    # with it.
+    attestation_lookback_chars: Optional[int] = None
 
 class PromptConfig(BaseModel):
     system_prompt: Optional[str] = None
@@ -1019,6 +1029,10 @@ def build_voice_roster(script_data, voice_config):
             config_lookup[roster_name] = voice_config[roster_name]
             continue
         for key, value in voice_config.items():
+            # Keys beginning with "_" are file metadata (e.g. the
+            # "_canon_version" stamp), never speakers.
+            if key.startswith("_"):
+                continue
             # roster_key(): canonical form with boundary marks removed, so a
             # config entry saved under a drifted spelling of the same name
             # still resolves. Exact key equality, never fuzzy similarity.
@@ -1060,6 +1074,151 @@ async def get_voices():
             "persona_pending": voice_name not in config_lookup,
         })
     return result
+
+
+def _load_source_text():
+    """Best-effort load of the source text currently backing
+    annotated_script.json, using the same "current project" pointer
+    (state.json's input_file_path) that /api/generate_script reads.
+
+    Read-only, and deliberately forgiving: any failure (no state.json, no
+    input_file_path, missing file, unreadable epub) returns None rather than
+    raising, since this backs an advisory-only endpoint that must degrade to
+    "nothing to show" instead of an error.
+    """
+    state_path = os.path.join(ROOT_DIR, "state.json")
+    if not os.path.exists(state_path):
+        return None
+    try:
+        with open(state_path, "r", encoding="utf-8") as f:
+            state = json.load(f)
+    except (json.JSONDecodeError, ValueError, OSError):
+        return None
+
+    input_file = state.get("input_file_path")
+    if not input_file or not os.path.exists(input_file):
+        return None
+
+    try:
+        if input_file.lower().endswith(".epub"):
+            raw = extract_epub_text(input_file)
+        else:
+            with open(input_file, "r", encoding="utf-8") as f:
+                raw = f.read()
+    except Exception:
+        return None
+
+    # Apply the SAME mojibake fix generation applied (generate_script.main
+    # calls fix_mojibake before chunking). The entry texts in
+    # annotated_script.json were produced from the FIXED text, so
+    # _compute_label_flags' `source_text.find(entry_text)` misses on every
+    # entry of an affected book when this returns the raw bytes -- and a miss
+    # yields no attestation window, which attest_label reports as "not
+    # attested". The badge then flags every speaker in the book, which reads
+    # as total corruption rather than as a lookup failure.
+    #
+    # Imported lazily: this is the only place app.py needs it, and keeping the
+    # import inside the call leaves server startup untouched. A failure to
+    # import degrades to the raw text (today's behaviour) rather than losing
+    # the endpoint.
+    try:
+        from generate_script import fix_mojibake
+    except Exception:
+        return raw
+    return fix_mojibake(raw)
+
+
+# Bound search cost for speakers with very large entry counts: only the
+# first N entries per speaker are sampled for attestation windows. This is
+# advisory tooling, not a completeness guarantee -- a speaker attested as
+# missing here may simply not have been sampled, which is why the endpoint
+# reports counts alongside the flag rather than claiming exhaustiveness.
+_MAX_SAMPLED_ENTRIES_PER_SPEAKER = 20
+
+# Characters of source text included on each side of a sampled entry when
+# building its attestation window.
+_ATTESTATION_WINDOW_RADIUS = 400
+
+
+def _compute_label_flags(script_data, source_text):
+    """Pure(ish) computation backing GET /api/voices/label_flags.
+
+    Args:
+        script_data: list of annotated_script.json entries.
+        source_text: the full source text string, or None/"" if unavailable.
+
+    Returns:
+        A list of {"name", "entry_count", "attested", "missing_tokens"}
+        dicts, one per non-NARRATOR canonical speaker label present in
+        script_data, sorted by descending entry_count. Read-only: does not
+        write any file and does not mutate script_data or source_text.
+    """
+    if not script_data or not source_text:
+        return []
+
+    # Group verbatim entry texts by canonical speaker label. A single
+    # roster_index is shared across the loop (not a throwaway per entry) so
+    # boundary-mark consolidation matches _canonical_roster_names exactly.
+    roster_index = {}
+    by_speaker = {}
+    for entry in script_data:
+        raw_speaker = entry.get("speaker") or entry.get("type") or ""
+        canonical = remember_in_roster(roster_index, raw_speaker)
+        if not canonical or canonical == "NARRATOR":
+            continue
+        text = entry.get("text") or ""
+        by_speaker.setdefault(canonical, []).append(text)
+
+    flags = []
+    for name, texts in by_speaker.items():
+        entry_count = len(texts)
+        windows = []
+        for text in texts[:_MAX_SAMPLED_ENTRIES_PER_SPEAKER]:
+            if not text:
+                continue
+            occurrence = source_text.find(text)
+            if occurrence == -1:
+                continue
+            start = max(0, occurrence - _ATTESTATION_WINDOW_RADIUS)
+            end = min(len(source_text), occurrence + len(text) + _ATTESTATION_WINDOW_RADIUS)
+            windows.append(source_text[start:end])
+
+        result = attest_label(name, windows)
+        flags.append({
+            "name": name,
+            "entry_count": entry_count,
+            "attested": result["attested"],
+            "missing_tokens": result["missing_tokens"],
+        })
+
+    flags.sort(key=lambda f: f["entry_count"], reverse=True)
+    return flags
+
+
+@app.get("/api/voices/label_flags")
+async def get_voice_label_flags():
+    """Advisory, read-only attestation flags for the current voice roster.
+
+    For each non-NARRATOR canonical speaker label, samples up to
+    _MAX_SAMPLED_ENTRIES_PER_SPEAKER of its entries, builds a local source
+    window around each occurrence, and calls speaker_canon.attest_label to
+    check whether the label's own core name tokens appear near its lines.
+    Never merges, mutates, or writes anything -- purely advisory, for a
+    human reviewer via the Voices UI.
+
+    Degrades to an empty list with an explanatory `note` (not an HTTP
+    error) when there is no script or no source text available, since both
+    are normal, expected states (e.g. before a script has been generated).
+    """
+    script_data = _load_script_entries()
+    if not script_data:
+        return {"flags": [], "note": "no script/source available"}
+
+    source_text = _load_source_text()
+    if not source_text:
+        return {"flags": [], "note": "no script/source available"}
+
+    return {"flags": _compute_label_flags(script_data, source_text)}
 
 
 @app.get("/api/voices/alias_suggestions")
@@ -1142,6 +1301,14 @@ async def save_voice_config(config_data: Dict[str, VoiceConfigItem]):
     for voice_name, config in config_data.items():
         # Convert Pydantic model to dict
         current_config[voice_name] = config.model_dump()
+
+    # Stamp the canonicalization generation this file's keys were written
+    # under. Generation 2 is "canonicalize() preserves gender-marking titles",
+    # so "MISTER SMITH" and "MISSUS SMITH" are distinct keys; generation 1
+    # (unstamped) files key both of them as "SMITH". tts.resolve_voice's
+    # migration shim bridges the two. Underscore-prefixed keys are metadata and
+    # are skipped everywhere voice_config is scanned for speakers.
+    current_config["_canon_version"] = 2
 
     atomic_json_write(current_config, VOICE_CONFIG_PATH)
 

--- a/app/app.py
+++ b/app/app.py
@@ -268,17 +268,35 @@ class GenerationConfig(BaseModel):
     # excluded from output when None (see save_config).
     num_ctx: Optional[int] = None
     # Attestation gate for speaker labels (generate_script.resolve_span_labels).
-    # DEFAULT FALSE: enabling it changes which labels survive and can turn a
-    # clean run into an exit-3 degraded run, so it must be an explicit opt-in.
-    # Measure a book first with tools/verify_attestation.py.
-    require_attested_speakers: bool = False
+    # DEFAULT TRUE. It refuses a label the book does not support near its own
+    # lines, which is what stops the classifier inventing a character by
+    # recombining words the prose supplies -- measured on one novel: 5
+    # fabricated labels refused, including a plausible full personal name
+    # assembled from two different characters' name parts, while all 16
+    # legitimate multi-token labels passed.
+    #
+    # THE COST, STATED PLAINLY: when the model names a real speaker with a
+    # descriptor the book does not use near that line ("FATHER" beside prose
+    # that only ever says "her dad"), the label is refused and those lines are
+    # NARRATED. Measured across two runs of the same book that cost 1 span in
+    # one run and 21 in the other -- the variance is the model's, not the
+    # gate's. Rejections are named by chunk and span, so they are auditable.
+    # Set false to accept every label the model offers, fabricated ones
+    # included. Measure a book first with tools/verify_attestation.py.
+    require_attested_speakers: bool = True
     # Adjacent-attribution-tag check (generate_script._tag_contradictions).
-    # DEFAULT FALSE for the same reason as require_attested_speakers: it spends
-    # retries and can turn a clean run into an exit-3 degraded run, so it is an
-    # explicit opt-in. It only ever flags and retries -- it never rewrites a
-    # label -- and it degrades to doing nothing on a non-English book, whose
-    # attribution tags carry none of the English speech verbs it recognizes.
-    check_attribution_tags: bool = False
+    # DEFAULT TRUE. The book names the speaker in the narration beside the
+    # line, and nothing used to read it: measured 60 of 1,117 checkable pairs
+    # (5.4%) carried a label their own attribution tag contradicted, on a run
+    # that reported success. With the check on, that fell to 0.90%.
+    #
+    # It only ever flags and retries -- it never rewrites a label. Cost is
+    # retries: 84 -> 143 on one book, so generation is slower, and surviving
+    # contradictions are reported by chunk and span (exit 3) rather than
+    # passing silently. On a non-English book it degrades to doing nothing
+    # rather than misfiring, since the tags carry none of the English speech
+    # verbs it recognizes.
+    check_attribution_tags: bool = True
     # Preceding source characters joined to the current chunk when attesting a
     # speaker name. None/unset = fall back to chunk_size, so the default tracks
     # the chunk size rather than pinning a second number that can disagree

--- a/app/app.py
+++ b/app/app.py
@@ -927,6 +927,40 @@ async def get_status(task_name: str):
     state.pop("process", None)
     return state
 
+def _load_script_entries():
+    """Read annotated_script.json the same way the voices endpoints do:
+    a missing file or malformed JSON both silently resolve to an empty
+    list rather than raising, since "no script yet" is a normal, expected
+    state for these read-only roster views -- not an error.
+    """
+    if not os.path.exists(SCRIPT_PATH):
+        return []
+    try:
+        with open(SCRIPT_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, ValueError):
+        return []
+
+
+def _canonical_roster_names(script_data):
+    """Dedupe + canonicalize + sort every speaker/type label in
+    `script_data` into the fragment-free voice roster.
+
+    Pure, and deliberately does NOT touch voice_config or alias
+    suggestions -- shared by build_voice_roster() (which adds config
+    resolution) and the on-demand alias-suggestions endpoint (which adds
+    fuzzy-similarity suggestions), so each caller only pays for the work
+    it actually needs.
+    """
+    roster_set = set()
+    for entry in script_data:
+        raw_speaker = entry.get("speaker") or entry.get("type") or ""
+        canonical = canonicalize(raw_speaker)
+        if canonical:
+            roster_set.add(canonical)
+    return sorted(roster_set)
+
+
 def build_voice_roster(script_data, voice_config):
     """Build a canonical, fragment-free voice roster from script entries.
 
@@ -938,25 +972,22 @@ def build_voice_roster(script_data, voice_config):
             older non-canonical speaker names (e.g. "Mr. Mark").
 
     Returns:
-        (roster_names, alias_suggestions, config_lookup):
+        (roster_names, config_lookup):
           - roster_names: sorted list of deduped canonical speaker names.
-          - alias_suggestions: suggest_aliases(roster_names) -- advisory
-            records only, never used to merge anything here.
           - config_lookup: dict mapping each canonical roster name to the
             voice_config entry that resolves for it (exact key match first,
             falling back to scanning voice_config keys for one whose
             canonicalize() equals the roster name; first match wins). Names
             with no resolvable config are simply absent from this dict.
-    """
-    roster_set = set()
-    for entry in script_data:
-        raw_speaker = entry.get("speaker") or entry.get("type") or ""
-        canonical = canonicalize(raw_speaker)
-        if canonical:
-            roster_set.add(canonical)
-    roster_names = sorted(roster_set)
 
-    alias_suggestions = suggest_aliases(roster_names)
+    Deliberately does NOT compute alias suggestions. suggest_aliases() is
+    O(n^2) in roster size and was previously run unconditionally on every
+    GET /api/voices call even though the frontend never read its output
+    (measured on a real 589-speaker roster: ~52ms of an ~80ms request,
+    plus ~160KB of unused response payload). Alias suggestions are now
+    computed on demand only, via GET /api/voices/alias_suggestions.
+    """
+    roster_names = _canonical_roster_names(script_data)
 
     config_lookup = {}
     for roster_name in roster_names:
@@ -968,19 +999,13 @@ def build_voice_roster(script_data, voice_config):
                 config_lookup[roster_name] = value
                 break
 
-    return roster_names, alias_suggestions, config_lookup
+    return roster_names, config_lookup
 
 
 @app.get("/api/voices")
 async def get_voices():
     # Parse voices directly from the current script (no stale cache)
-    script_data = []
-    if os.path.exists(SCRIPT_PATH):
-        try:
-            with open(SCRIPT_PATH, "r", encoding="utf-8") as f:
-                script_data = json.load(f)
-        except (json.JSONDecodeError, ValueError):
-            script_data = []
+    script_data = _load_script_entries()
 
     if not script_data:
         return []
@@ -994,7 +1019,7 @@ async def get_voices():
         except (json.JSONDecodeError, ValueError):
             voice_config = {}
 
-    roster_names, alias_suggestions, config_lookup = build_voice_roster(script_data, voice_config)
+    roster_names, config_lookup = build_voice_roster(script_data, voice_config)
 
     if not roster_names:
         return []
@@ -1002,14 +1027,29 @@ async def get_voices():
     result = []
     for voice_name in roster_names:
         config = config_lookup.get(voice_name, {})
-        voice_aliases = [s for s in alias_suggestions if s["name"] == voice_name]
         result.append({
             "name": voice_name,
             "config": config,
             "persona_pending": voice_name not in config_lookup,
-            "alias_suggestions": voice_aliases
         })
     return result
+
+
+@app.get("/api/voices/alias_suggestions")
+async def get_voice_alias_suggestions():
+    """On-demand fuzzy-similarity alias suggestions for the current voice
+    roster (e.g. JON/JOHN), advisory-only -- never merges anything.
+
+    Split out from GET /api/voices because suggest_aliases() is O(n^2) in
+    roster size and the frontend never read this field when it was inlined
+    there (see build_voice_roster's docstring). Computed fresh on every
+    call by design, same as GET /api/voices -- no cache, since both
+    endpoints deliberately re-read the current script rather than serving
+    a possibly-stale cached roster.
+    """
+    script_data = _load_script_entries()
+    roster_names = _canonical_roster_names(script_data)
+    return {"suggestions": suggest_aliases(roster_names)}
 
 
 @app.post("/api/generate_personas")

--- a/app/app.py
+++ b/app/app.py
@@ -28,7 +28,9 @@ from default_prompts import load_default_prompts
 from review_prompts import load_review_prompts
 from persona_prompts import load_persona_prompts
 from hf_utils import fetch_builtin_manifest, download_builtin_adapter, is_adapter_downloaded
-from speaker_canon import canonicalize, suggest_aliases
+from speaker_canon import (
+    remember_in_roster, roster_key, suggest_aliases,
+)
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
@@ -951,14 +953,20 @@ def _canonical_roster_names(script_data):
     resolution) and the on-demand alias-suggestions endpoint (which adds
     fuzzy-similarity suggestions), so each caller only pays for the work
     it actually needs.
+
+    Spellings that drifted only in their boundary marks are consolidated: a
+    legacy script containing both "ABBE MARIGNAN" and the drifted
+    "ABBEMARIGNAN" (or "O'BRIEN" and "OBRIEN") displays, and assigns a voice
+    to, one name -- the more-punctuated one, regardless of which appears
+    first. Exact roster-key equality only -- names that are merely similar
+    (JON/JOHN, ELLA/BELLA) stay distinct entries and are surfaced, if at all,
+    as advisory alias suggestions.
     """
-    roster_set = set()
+    roster_index = {}
     for entry in script_data:
         raw_speaker = entry.get("speaker") or entry.get("type") or ""
-        canonical = canonicalize(raw_speaker)
-        if canonical:
-            roster_set.add(canonical)
-    return sorted(roster_set)
+        remember_in_roster(roster_index, raw_speaker)
+    return sorted(roster_index.values())
 
 
 def build_voice_roster(script_data, voice_config):
@@ -977,7 +985,7 @@ def build_voice_roster(script_data, voice_config):
           - config_lookup: dict mapping each canonical roster name to the
             voice_config entry that resolves for it (exact key match first,
             falling back to scanning voice_config keys for one whose
-            canonicalize() equals the roster name; first match wins). Names
+            roster_key() equals the roster name's; first match wins). Names
             with no resolvable config are simply absent from this dict.
 
     Deliberately does NOT compute alias suggestions. suggest_aliases() is
@@ -995,7 +1003,10 @@ def build_voice_roster(script_data, voice_config):
             config_lookup[roster_name] = voice_config[roster_name]
             continue
         for key, value in voice_config.items():
-            if canonicalize(key) == roster_name:
+            # roster_key(): canonical form with boundary marks removed, so a
+            # config entry saved under a drifted spelling of the same name
+            # still resolves. Exact key equality, never fuzzy similarity.
+            if roster_key(key) == roster_key(roster_name):
                 config_lookup[roster_name] = value
                 break
 

--- a/app/generate_personas.py
+++ b/app/generate_personas.py
@@ -787,6 +787,16 @@ def main():
     remaining_speakers = []
 
     for speaker in selected_speakers:
+        # An alias the operator already set is a decision, not a candidate.
+        # Honour it and skip: generating a persona would overwrite the entry
+        # and give this speaker its own voice again.
+        preset = (voice_config.get(speaker) or {}).get("alias_of") \
+            or (voice_config.get(speaker) or {}).get("alias")
+        if preset:
+            print(f"Existing alias kept: {speaker} -> {preset}")
+            resolved_aliases[speaker] = preset
+            continue
+
         existing_names = [n for n in _configured_speaker_names(voice_config) if n != speaker]
         norm_self = normalize_speaker_name(speaker)
         heuristic_alias = ""
@@ -925,7 +935,13 @@ def main():
         for speaker in selected_speakers:
             if speaker == NARRATOR_KEY or speaker in resolved_aliases:
                 continue
-            if _entry_has_voice(voice_config.get(speaker)):
+            existing = voice_config.get(speaker) or {}
+            # An operator-set alias points deliberately at another speaker's
+            # voice. It has no voice of its own by design, and must not be
+            # mistaken for a persona failure and overwritten.
+            if existing.get("alias_of") or existing.get("alias"):
+                continue
+            if _entry_has_voice(existing):
                 continue
             entry = dict(narrator_entry)
             entry["defaulted_from_narrator"] = True

--- a/app/generate_personas.py
+++ b/app/generate_personas.py
@@ -687,7 +687,12 @@ def main():
     api_key = llm_cfg.get("api_key", "local")
     model_name = llm_cfg.get("model_name", "richardyoung/qwen3-14b-abliterated:Q8_0")
 
-    client = OpenAI(base_url=base_url, api_key=api_key)
+    # llm.timeout: see generate_script.main. Omitted when unset.
+    _client_kwargs = {"base_url": base_url, "api_key": api_key}
+    _timeout = llm_cfg.get("timeout")
+    if _timeout:
+        _client_kwargs["timeout"] = _timeout
+    client = OpenAI(**_client_kwargs)
 
     # Load persona prompts from config, fall back to defaults
     prompts_cfg = config.get("prompts", {})

--- a/app/generate_personas.py
+++ b/app/generate_personas.py
@@ -750,13 +750,27 @@ def main():
 
     print(f"Processing {len(selected_speakers)} speakers")
 
-    # Step 1: Pre-process with exact heuristic + high-confidence fuzzy matching
+    # Step 1: Pre-process with an EXACT normalized-name check only.
+    #
+    # A fuzzy pass (rapidfuzz at 0.8) used to run here and decided identity
+    # between two roster entries on similarity alone. That is the banned
+    # approach: measured on one book it merged 31 pairs, including NITA ->
+    # NITA'S DAD, KIT -> KIT'S MOTHER and ROSHAUN -> ROSHAUN'S FATHER -- a
+    # possessive relation scores high against the person it refers to while
+    # being a different character. It was also cyclic (SWALE -> TOM SWALE and
+    # TOM SWALE -> SWALE), so the winner depended on iteration order. Every
+    # merged speaker is SKIPPED here, so it silently left 28 of 65 speakers
+    # with no voice at all, ROSHAUN's 272 lines among them.
+    #
+    # Exact equality after normalization is the same rule the rest of the
+    # pipeline uses (speaker_canon.roster_key). Genuine aliases that differ by
+    # more than that are a human decision: suggest_aliases() offers them and
+    # nothing acts on them automatically.
     resolved_aliases = {}
     remaining_speakers = []
 
     for speaker in selected_speakers:
         existing_names = [n for n in _configured_speaker_names(voice_config) if n != speaker]
-        # Fast heuristic exact check
         norm_self = normalize_speaker_name(speaker)
         heuristic_alias = ""
         for candidate in existing_names:
@@ -764,12 +778,8 @@ def main():
                 heuristic_alias = candidate
                 break
 
-        if not heuristic_alias and existing_names:
-            # High-confidence fuzzy check
-            heuristic_alias = _resolve_to_canonical(speaker, existing_names, threshold=0.8)
-
         if heuristic_alias:
-            print(f"Fast heuristic/fuzzy alias detected: {speaker} -> {heuristic_alias}")
+            print(f"Exact-name alias detected: {speaker} -> {heuristic_alias}")
             resolved_aliases[speaker] = heuristic_alias
         else:
             remaining_speakers.append(speaker)

--- a/app/generate_personas.py
+++ b/app/generate_personas.py
@@ -61,6 +61,16 @@ def normalize_speaker_name(name):
     return s
 
 
+def _configured_speaker_names(voice_config):
+    """The voice_config keys that are speakers.
+
+    Keys beginning with "_" are file metadata (e.g. the "_canon_version" stamp
+    app.py writes when saving voice_config.json), never characters, and must
+    never be offered to the alias matcher as an existing name.
+    """
+    return [k for k in voice_config if not k.startswith("_")]
+
+
 def _token_jaccard(a: str, b: str) -> float:
     """Jaccard similarity on normalized name tokens."""
     norm_a = normalize_speaker_name(a)
@@ -740,7 +750,7 @@ def main():
     remaining_speakers = []
 
     for speaker in selected_speakers:
-        existing_names = [n for n in voice_config.keys() if n != speaker]
+        existing_names = [n for n in _configured_speaker_names(voice_config) if n != speaker]
         # Fast heuristic exact check
         norm_self = normalize_speaker_name(speaker)
         heuristic_alias = ""
@@ -777,7 +787,7 @@ def main():
                 }
             
             # Use current configured names plus any previously resolved canonical names as existing references
-            existing_configured = list(voice_config.keys()) + list(batch_mapping.values())
+            existing_configured = _configured_speaker_names(voice_config) + list(batch_mapping.values())
             
             print(f"Resolving alias batch {idx//chunk_size + 1} ({len(chunk)} speakers)...")
             chunk_mapping = _resolve_aliases_batch(client, model_name, speakers_info, existing_configured)
@@ -794,7 +804,7 @@ def main():
             resolved_name = normalized_mapping.get(norm_speaker, speaker)
             if resolved_name != speaker:
                 # LLM identified this as an alias!
-                all_possible = list(voice_config.keys()) + remaining_speakers
+                all_possible = _configured_speaker_names(voice_config) + remaining_speakers
                 canonical_target = _resolve_to_canonical(resolved_name, all_possible, threshold=0.6)
                 if canonical_target and canonical_target != speaker:
                     print(f"Batch LLM alias detected: {speaker} -> {canonical_target}")

--- a/app/generate_personas.py
+++ b/app/generate_personas.py
@@ -13,6 +13,23 @@ from utils import atomic_json_write as _atomic_json_write
 from persona_prompts import PERSONA_SYSTEM_PROMPT, PERSONA_USER_PROMPT, PERSONA_ADVANCED_PROMPT
 
 
+# Canonical narrator label. Matches generate_script.NARRATOR; casing is
+# load-bearing across the pipeline.
+NARRATOR_KEY = "NARRATOR"
+
+
+def _entry_has_voice(entry):
+    """True if a voice_config entry can actually synthesize something.
+
+    A cloned/designed entry carries ref_audio; a built-in one carries a voice
+    name. An entry that is missing, empty, or aliased away has neither.
+    """
+    if not isinstance(entry, dict) or entry.get("alias_of"):
+        return False
+    return bool(str(entry.get("ref_audio") or "").strip()
+                or str(entry.get("voice") or "").strip())
+
+
 def extract_json_object(text):
     # Find first JSON object in text
     start = text.find('{')
@@ -891,6 +908,41 @@ def main():
 
         except Exception as e:
             print(f"Unhandled error for {speaker}: {e}")
+
+    # Any speaker still without a voice gets the NARRATOR's, as a DEFAULT rather
+    # than an alias: it keeps its own voice_config key, so the operator can
+    # override it in the Voices UI. An alias would fold the entry into NARRATOR,
+    # and nothing in this pipeline can split a merged entry back apart.
+    #
+    # Reading a character's lines in the narrator's voice is the safe failure for
+    # an audiobook -- it is what an unlabelled span already does -- whereas no
+    # entry at all means the renderer falls through to whatever default voice it
+    # happens to have. Loud, not silent: a persona failure on a major character
+    # is worth seeing before rendering, not after.
+    narrator_entry = voice_config.get(NARRATOR_KEY) or {}
+    defaulted = []
+    if _entry_has_voice(narrator_entry):
+        for speaker in selected_speakers:
+            if speaker == NARRATOR_KEY or speaker in resolved_aliases:
+                continue
+            if _entry_has_voice(voice_config.get(speaker)):
+                continue
+            entry = dict(narrator_entry)
+            entry["defaulted_from_narrator"] = True
+            voice_config[speaker] = entry
+            defaulted.append(speaker)
+
+    if defaulted:
+        print("!" * 58)
+        print(f"{len(defaulted)} speaker(s) got no persona and now default to the "
+              f"NARRATOR's voice:")
+        print("  " + ", ".join(sorted(defaulted)))
+        print("They keep their own voice_config entry -- assign a voice in the "
+              "Voices UI to override.")
+        print("!" * 58)
+    elif not _entry_has_voice(narrator_entry):
+        print("Note: NARRATOR has no usable voice entry, so no default could be "
+              "applied to speakers that failed persona generation.")
 
     # Persist voice_config
     try:

--- a/app/generate_script.py
+++ b/app/generate_script.py
@@ -1172,6 +1172,15 @@ def _gate_speaker(canonical, attest_window, roster_index, source_words,
         return canonical, GATE_ESTABLISHED
     verdict = _attestation_verdict(canonical, attest_window, roster_index)
     if verdict == UNATTESTED:
+        # REJECTED WHEN THE REST OF THE GATE CANNOT SAVE IT. A "rescue the
+        # label when its refuted tokens are words the book uses somewhere" rule
+        # was tried here and reverted: checking tokens INDIVIDUALLY against the
+        # whole book is weaker than the window test it bypasses, so it admitted
+        # fabricated names built from real words -- TRANSFORMED PIG (the book
+        # has "Transcendent Pig"; "transformed pig" appears zero times) and the
+        # bare prose word DRAINED, each becoming a character with its own
+        # voice. That is the recombination the phrase-adjacency rule in
+        # attest_label exists to refuse, so a second path must not re-admit it.
         repaired = repair_speaker(
             canonical, [attest_window] if attest_window else [],
             roster_index or {}, source_words or set())
@@ -1435,6 +1444,7 @@ def resolve_span_labels(spans, labels, source=None, roster=None,
             range), OR
         (2) attest_speaker() over ``attest_window`` does not return UNATTESTED.
 
+
     UNVERIFIABLE is ACCEPTED and counted separately: it means the check does
     not apply to this text (a title-only label, or a name present but not at a
     word boundary, as in unsegmented scripts), and rejecting on it would
@@ -1678,16 +1688,83 @@ def resolve_span_labels(spans, labels, source=None, roster=None,
 
 
 def _merge_same_speaker(groups):
-    """Collapse adjacent [speaker, text, instruct] groups sharing a speaker."""
+    """Collapse adjacent [speaker, text, instruct, kind] groups sharing a speaker.
+
+    KIND-AWARE, and that is the point. Two adjacent QUOTED spans by one
+    character are one continuous line and merging them is pure win (one TTS
+    call instead of two). A QUOTED span merged with an adjacent UNQUOTED one is
+    a different animal: the entry now holds a quotation AND the narration
+    around it, and the renderer gives the whole entry ONE voice, so the
+    narration is spoken by the character. So a non-NARRATOR group only absorbs
+    a group of the SAME kind; NARRATOR merges freely, since every kind of text
+    a narrator reads is read in the narrator voice anyway.
+
+    A merged group keeps the kind of its first member, which is well defined
+    precisely because only same-kind groups merge (NARRATOR's kind is never
+    consulted again).
+    """
     merged = []
-    for speaker, text, instruct in groups:
-        if merged and merged[-1][0] == speaker:
+    for speaker, text, instruct, kind in groups:
+        if merged and merged[-1][0] == speaker and (
+            speaker == NARRATOR or merged[-1][3] == kind
+        ):
             merged[-1][1] += text
             if merged[-1][2] is None:
                 merged[-1][2] = instruct
         else:
-            merged.append([speaker, text, instruct])
+            merged.append([speaker, text, instruct, kind])
     return merged
+
+
+def _narrate_attribution_spans(resolved):
+    """Force an UNQUOTED span to NARRATOR when it sits immediately beside a
+    QUOTED span carrying the SAME character label.
+
+    WHY THIS AND NOT "UNQUOTED IMPLIES NARRATOR". The classifier sometimes
+    extends a character label off the end of the quotation and onto the
+    attribution tag or action beat next to it ("said Marcus", " Nita said.").
+    That text is narration and must be narrated. But a blanket
+    unquoted-implies-narrator rule is WRONG and was rejected before: books
+    legitimately contain unquoted character speech -- telepathy, silent speech,
+    an animal's voice, interior monologue -- written with no quote marks at
+    all. Measured on one 8,083-entry artifact: of 65 character-voiced entries
+    containing no quotation mark, roughly 29 were genuine unquoted speech. A
+    blanket rule destroys those.
+
+    ADJACENCY IS THE ONLY STRUCTURAL SIGNAL THAT SEPARATES THEM, and it only
+    separates one of the two cases. An unquoted span pressed directly against a
+    quotation the model gave the same speaker is that quotation's tag or beat;
+    a STANDALONE unquoted span labelled with a character has no structural
+    tell distinguishing "narration the model mislabelled" from "unquoted speech
+    the author wrote". Nothing here guesses at the standalone case: it is left
+    with its label, and the damage is bounded instead by _merge_same_speaker
+    refusing to let it swallow an adjacent quotation.
+
+    A whitespace-only span between the two blocks adjacency, because it is a
+    paragraph break -- the same bound _closing_tag_text_by_id draws for the
+    same reason. Whitespace spans already resolve to NARRATOR, so this falls
+    out of the speaker comparison for free.
+
+    MEASURED on the artifact above: 13,337 chars of narration were read in a
+    character voice; this rule and the kind-aware merge together bring that to
+    8,220 (-38%) and remove every entry that mixes quotation with narration
+    under a character voice (73 -> 0), for +98 entries (+1.2%).
+
+    Text is untouched (contract 2/4) -- only the speaker label changes.
+    """
+    narrated = []
+    for index, (span, speaker, instruct) in enumerate(resolved):
+        if speaker != NARRATOR and span.kind == UNQUOTED:
+            neighbours = (
+                resolved[index - 1] if index else None,
+                resolved[index + 1] if index + 1 < len(resolved) else None,
+            )
+            if any(other and other[0].kind == QUOTED and other[1] == speaker
+                   for other in neighbours):
+                speaker = NARRATOR
+                instruct = None
+        narrated.append((span, speaker, instruct))
+    return narrated
 
 
 def _absorb_whitespace_groups(groups):
@@ -1698,6 +1775,10 @@ def _absorb_whitespace_groups(groups):
     entry it is an unspeakable NARRATOR line that the editor UI can never
     finish rendering -- hundreds per book. It belongs on the PRECEDING entry
     (or the following one when it comes first), which changes no bytes.
+
+    The absorbing group keeps its own kind. That matters: it is what stops the
+    second _merge_same_speaker pass from using an absorbed paragraph break as a
+    bridge between a character's quotation and the narration after it.
     """
     absorbed = []
     for group in groups:
@@ -1720,9 +1801,15 @@ def build_entries(resolved, source):
     Text is the exact concatenation of the group's source slices: quotes,
     attribution tags and whitespace all survive untouched. No entry is ever
     whitespace-only (see _absorb_whitespace_groups).
+
+    Merging is quoted/unquoted aware so that no character-voiced entry ends up
+    holding both a quotation and the narration around it -- see
+    _merge_same_speaker and _narrate_attribution_spans for the evidence. Only
+    speaker labels move; not one byte of text changes.
     """
     groups = _merge_same_speaker(
-        [[speaker, span.text(source), instruct] for span, speaker, instruct in resolved]
+        [[speaker, span.text(source), instruct, span.kind]
+         for span, speaker, instruct in _narrate_attribution_spans(resolved)]
     )
     # Absorbing a whitespace group can make two same-speaker groups adjacent,
     # so merge once more afterwards.
@@ -1737,7 +1824,7 @@ def build_entries(resolved, source):
                 else DEFAULT_CHARACTER_INSTRUCT
             ),
         }
-        for speaker, text, instruct in groups
+        for speaker, text, instruct, _kind in groups
     ]
 
 
@@ -2528,6 +2615,7 @@ def main():
     total_placeholders = 0
     total_unattested = 0
     total_unverifiable = 0
+    source_word_names = {}
     total_repaired = 0
     total_repairs_refused = 0
     total_contradicted = 0
@@ -2617,6 +2705,8 @@ def main():
               "(name absent from the text near its own lines)")
         print(f"  Unverifiable speakers accepted: {total_unverifiable} "
               "(attestation does not apply to this text)")
+        for name, count in sorted(source_word_names.items()):
+            print(f"    - \"{name}\" ({count} span(s))")
         # Loud by design (contract 7): these labels say a name the model never
         # emitted. Not a degradation -- no voice was lost -- but an operator
         # must be able to see, and audit, every rewrite.

--- a/app/generate_script.py
+++ b/app/generate_script.py
@@ -23,7 +23,15 @@ import argparse
 from openai import OpenAI
 from default_prompts import DEFAULT_SYSTEM_PROMPT, DEFAULT_USER_PROMPT
 from span_tokenizer import tokenize, validate_spans
-from speaker_canon import canonicalize, remember_in_roster, resolve_against_roster
+from speaker_canon import (
+    UNATTESTED,
+    UNVERIFIABLE,
+    attest_speaker,
+    canonicalize,
+    remember_in_roster,
+    resolve_against_roster,
+    roster_key,
+)
 
 # Cap for single-speaker mode: entries at this size pass through
 # group_into_chunks (MAX_CHUNK_CHARS=500) as-is without further splitting.
@@ -849,7 +857,7 @@ def _format_id_list(ids):
     return f"{head} (and {len(ids) - _NUDGE_ID_CAP} more)"
 
 
-def _retry_nudge(missing_ids, bad_role_ids):
+def _retry_nudge(missing_ids, bad_role_ids, unattested=None):
     """Correction text appended to the retry prompt.
 
     Appended AFTER .format(), so it cannot interact with the {context}/{chunk}
@@ -862,13 +870,28 @@ def _retry_nudge(missing_ids, bad_role_ids):
     blind re-roll re-rolls the same "I am finished" judgement. Naming the gap
     corrects it instead.
     """
-    parts = ["\n\nCORRECTION: your previous reply did not label every span."]
+    parts = ["\n\nCORRECTION: your previous reply had problems."]
     if missing_ids:
         parts.append("These span ids are still missing a label: "
                      f"{_format_id_list(missing_ids)}.")
     if bad_role_ids:
         parts.append('These span ids had a "role" that was neither "dialogue" nor '
                      f'"narration": {_format_id_list(bad_role_ids)}.')
+    if unattested:
+        # Name the offending spelling AND say what to do instead. A bare "that
+        # name is wrong" makes the model guess again; pointing it at the text
+        # is what turns the rejection into a correction. The correct spelling
+        # is in the text it was shown -- on measured runs the misread spelling
+        # occurred zero times in the book and the right one hundreds of times.
+        detail = "; ".join(f'id {span_id}: "{name}"' for span_id, name in unattested)
+        parts.append(
+            "These speaker names do not appear anywhere in the text you were "
+            f"shown, so they cannot be right: {detail}. For each one, either "
+            "copy the character's name EXACTLY as it is spelled in the span "
+            "text above, or reuse a name from the character roster exactly, or "
+            'label the span "NARRATOR" with role "narration" if the text never '
+            "names the speaker. Do not invent a name and do not guess at a "
+            "spelling.")
     parts.append("Return the JSON array again. It MUST contain one object for every id "
                  'listed above, and every "role" must be exactly "dialogue" or "narration".')
     return " ".join(parts)
@@ -891,7 +914,72 @@ def _label_completeness(label):
     return score
 
 
-def resolve_span_labels(spans, labels, source=None, roster=None):
+def _speaker_is_established(canonical, roster_index):
+    """True when ``canonical`` is already a roster name for this book.
+
+    An established name needs no attestation: it was itself attested when it
+    first entered the roster, so this is BOTH the correctness rule and the
+    long-range attribution mechanism -- a character last named twenty pages
+    ago is accepted at zero token cost, because the roster travels with the
+    book instead of with the prompt.
+    """
+    if not roster_index:
+        return False
+    return roster_key(canonical) in roster_index
+
+
+def _attestation_verdict(canonical, attest_window):
+    """attest_speaker() over the one window the gate uses. Pure passthrough,
+    factored out so the retry predicate and the acceptance gate cannot drift
+    apart (the same mistake _incomplete_span_ids exists to prevent for roles).
+    """
+    return attest_speaker(canonical, [attest_window] if attest_window else [])
+
+
+def _unattested_speaker_ids(spans, merged, source=None, roster=None,
+                            attest_window=None):
+    """Return ``[(span_id, canonical_name), ...]`` for dialogue labels whose
+    speaker the source does not support -- what a retry should ask about.
+
+    Mirrors the acceptance gate in resolve_span_labels exactly: same
+    established-roster shortcut, same verdict function, and only UNATTESTED
+    counts. UNVERIFIABLE never appears here, because a label our check cannot
+    evaluate is not something to nag the model about.
+
+    Read-only. Does not mutate ``roster``; a local copy tracks names accepted
+    earlier in this same chunk so the shortcut behaves as it will at
+    resolution time.
+    """
+    if source is not None:
+        spans = visible_spans(spans, source)
+
+    roster_index = dict(roster) if roster else {}
+    offenders = []
+    for span in spans:
+        label = merged.get(span.id)
+        if label is None:
+            continue
+        role = label.get("role")
+        role = role.strip().lower() if isinstance(role, str) else ""
+        if role != "dialogue":
+            continue
+        raw_speaker = label.get("speaker")
+        canonical = canonicalize(raw_speaker) if isinstance(raw_speaker, str) else ""
+        if not canonical or canonical == NARRATOR:
+            continue
+        if is_placeholder_speaker(canonical):
+            continue  # already rejected on its own terms
+        if _speaker_is_established(canonical, roster_index):
+            continue
+        if _attestation_verdict(canonical, attest_window) == UNATTESTED:
+            offenders.append((span.id, canonical))
+        else:
+            remember_in_roster(roster_index, canonical)
+    return offenders
+
+
+def resolve_span_labels(spans, labels, source=None, roster=None,
+                        attest_window=None, require_attested=False):
     """Resolve each span to (span, speaker, instruct) using the LLM's labels.
 
     A span is NARRATOR unless a label exists for its id AND that label says
@@ -914,6 +1002,31 @@ def resolve_span_labels(spans, labels, source=None, roster=None):
     apostrophes); similar-but-distinct names (JON/JOHN) are never merged. The caller's dict is NOT mutated: a local copy is extended as
     the chunk resolves, so a spelling first seen mid-chunk participates in the
     same selection rule as the rest of the book.
+
+    ATTESTATION GATE (``require_attested``, off by default). The speaker field
+    is the one part of the schema the model still GENERATES rather than
+    selects, and it misreads names: on a measured production run every one of
+    MEMKEI, DARINE, CARMELO and ROSHAAUN occurred ZERO times in the source
+    while the correct spelling occurred 176-721 times. With the gate on, a
+    dialogue speaker is accepted iff
+
+        (1) it is already a roster name for this book (see
+            _speaker_is_established -- born attested, so free and unbounded in
+            range), OR
+        (2) attest_speaker() over ``attest_window`` does not return UNATTESTED.
+
+    UNVERIFIABLE is ACCEPTED and counted separately: it means the check does
+    not apply to this text (a title-only label, or a name present but not at a
+    word boundary, as in unsegmented scripts), and rejecting on it would
+    destroy books this module cannot tokenize. Only UNATTESTED -- positive
+    evidence that the name appears nowhere near its own lines -- is refused.
+
+    A refused speaker becomes NARRATOR, exactly like every other rejection
+    here: prose is preserved verbatim and only the voice is lost. Because that
+    trade is real (narrating a genuine line is itself a loss), the gate is
+    designed to be paired with the retry nudge in process_chunk, which names
+    the offending label and asks the model to copy the spelling from the text
+    it was shown. Rejection is the fallback; re-asking is the fix.
     """
     valid_ids = {span.id for span in spans}
     # Local copy: never mutate the caller's roster index (see docstring).
@@ -939,6 +1052,9 @@ def resolve_span_labels(spans, labels, source=None, roster=None):
     role_missing = 0
     whitespace = 0
     placeholder_rejected = 0
+    unattested_rejected = 0
+    unverifiable_accepted = 0
+    dialogue_without_speaker = 0
 
     for span in spans:
         if source is not None and is_whitespace_span(span, source):
@@ -969,9 +1085,31 @@ def resolve_span_labels(spans, labels, source=None, roster=None):
                 # Roster-aware acceptance point: resolve the spelling against
                 # names already established in this book, then establish this
                 # one for the rest of the chunk.
-                if roster_index is not None:
-                    canonical = remember_in_roster(roster_index, canonical)
-                speaker = canonical
+                #
+                # The attestation gate sits here, as a sibling of the
+                # placeholder rejection above and with the same safe direction
+                # (NARRATOR, prose untouched). An established roster name
+                # skips the check entirely -- see the docstring.
+                accept = True
+                if require_attested and not _speaker_is_established(canonical, roster_index):
+                    verdict = _attestation_verdict(canonical, attest_window)
+                    if verdict == UNATTESTED:
+                        accept = False
+                        unattested_rejected += 1
+                    elif verdict == UNVERIFIABLE:
+                        unverifiable_accepted += 1
+
+                if accept:
+                    if roster_index is not None:
+                        canonical = remember_in_roster(roster_index, canonical)
+                    speaker = canonical
+            elif role == "dialogue" and not canonical:
+                # role says dialogue but there is no usable name, so a voice is
+                # lost. Counted (and reported) rather than silently narrated:
+                # this is where a speaker cleared by the attestation retry ends
+                # up if the retry supplies nothing, and it is also what a model
+                # emitting role=dialogue with an empty speaker has always done.
+                dialogue_without_speaker += 1
             elif role not in ("dialogue", "narration") and canonical and canonical != NARRATOR:
                 # Contract says role decides. Honour it (NARRATOR is the safe
                 # direction: prose is preserved, only the voice changes), but
@@ -994,6 +1132,9 @@ def resolve_span_labels(spans, labels, source=None, roster=None):
         "discarded": discarded,
         "role_missing": role_missing,
         "placeholder_rejected": placeholder_rejected,
+        "unattested_rejected": unattested_rejected,
+        "unverifiable_accepted": unverifiable_accepted,
+        "dialogue_without_speaker": dialogue_without_speaker,
     }
 
 
@@ -1232,7 +1373,7 @@ def build_context(chunk_num, total_chunks, previous_entries=None,
     return "\n".join(context_parts)
 
 
-def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_entries=None, max_retries=2, system_prompt=None, user_prompt_template=None, max_tokens=4096, temperature=0.6, top_p=0.8, top_k=0, min_p=0, presence_penalty=0.0, banned_tokens=None, roster=None, max_context_roster_names=None, num_ctx=None):
+def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_entries=None, max_retries=2, system_prompt=None, user_prompt_template=None, max_tokens=4096, temperature=0.6, top_p=0.8, top_k=0, min_p=0, presence_penalty=0.0, banned_tokens=None, roster=None, max_context_roster_names=None, num_ctx=None, attest_window=None, require_attested=False):
     """Classify one chunk's spans and rebuild its script entries verbatim.
 
     Returns ``(entries, stats)``. ``stats`` reports span counts and whether the
@@ -1395,8 +1536,13 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
             break  # keep whatever earlier attempts recovered
 
         missing_ids, bad_role_ids = _incomplete_span_ids(spans, merged_labels, source=chunk)
+        unattested = (
+            _unattested_speaker_ids(spans, merged_labels, source=chunk,
+                                    roster=roster, attest_window=attest_window)
+            if require_attested else []
+        )
 
-        if not missing_ids and not bad_role_ids:
+        if not missing_ids and not bad_role_ids and not unattested:
             if attempt > 0:
                 print(f"  Succeeded on retry {attempt + 1} -- all {len(spans)} spans labelled")
             break
@@ -1412,9 +1558,28 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
                 gaps.append(f"{len(missing_ids)} span(s) unlabelled")
             if bad_role_ids:
                 gaps.append(f"{len(bad_role_ids)} label(s) with an unusable role")
+            if unattested:
+                gaps.append(f"{len(unattested)} speaker name(s) absent from the text "
+                            f"({', '.join(name for _, name in unattested[:3])}"
+                            f"{', ...' if len(unattested) > 3 else ''})")
             print(f"  {' and '.join(gaps)} -- retrying (attempt {attempt + 2}"
                   f"/{max_retries + 1}), naming the gaps")
-            retry_nudge = _retry_nudge(missing_ids, bad_role_ids)
+            retry_nudge = _retry_nudge(missing_ids, bad_role_ids, unattested)
+            # Clear the refused speakers so the retry's answer can actually
+            # land. _merge_label deliberately never overwrites a usable field
+            # -- that is what makes "a retry can never make things worse" a
+            # structural property -- and a misread name IS a usable string, so
+            # without this the corrected spelling would be discarded and the
+            # nudge would be decorative. Dropping it is consistent with that
+            # property rather than an exception to it: our own gate has just
+            # ruled that this value carries no usable information. If the retry
+            # supplies nothing, the field stays blank and the span is narrated
+            # and counted (see dialogue_without_speaker), so the outcome is
+            # never quieter than a plain rejection.
+            for span_id, _ in unattested:
+                label = merged_labels.get(span_id)
+                if isinstance(label, dict):
+                    label.pop("speaker", None)
             continue
 
         break
@@ -1423,7 +1588,8 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
     # so a failure costs labels, never prose. Phantom ids stay in the merged map
     # on purpose: resolve_span_labels discards and counts them (once each).
     resolved, stats = resolve_span_labels(
-        spans, list(merged_labels.values()), source=chunk, roster=roster)
+        spans, list(merged_labels.values()), source=chunk, roster=roster,
+        attest_window=attest_window, require_attested=require_attested)
     entries = build_entries(resolved, chunk)
     _assert_chunk_verbatim(entries, chunk, chunk_num)
 
@@ -1435,6 +1601,15 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
         reason = "labels recovered via markdown salvage (model returned no JSON)"
     if reason is None and stats["fallback"] > 0:
         reason = "LLM did not label every span"
+    if reason is None and stats["unattested_rejected"] > 0:
+        # Loud by design (contract 7). A rejection does NOT raise `fallback`
+        # -- the span was labelled, the speaker was refused -- so without this
+        # the run would exit 0 with silently narrated dialogue.
+        reason = (f"{stats['unattested_rejected']} speaker label(s) named a "
+                  "character the source text does not support")
+    if reason is None and stats["dialogue_without_speaker"] > 0:
+        reason = (f"{stats['dialogue_without_speaker']} label(s) claimed "
+                  "role=dialogue with no usable speaker name")
     if reason is None and stats["role_missing"] > 0:
         # A model that labels every span but omits "role" produces a fully
         # narrated book. Prose is intact, every voice is gone -- exactly the
@@ -1458,6 +1633,12 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
     if stats["placeholder_rejected"]:
         print(f"  Rejected {stats['placeholder_rejected']} invented placeholder speaker "
               "label(s) (e.g. \"SPEAKER 1\") -- narrated instead")
+    if stats["unattested_rejected"]:
+        print(f"  Rejected {stats['unattested_rejected']} speaker label(s) whose name does "
+              "not appear in the text near their own lines -- narrated instead")
+    if stats["unverifiable_accepted"]:
+        print(f"  Accepted {stats['unverifiable_accepted']} speaker label(s) the source "
+              "cannot confirm or refute (attestation does not apply to this text)")
 
     if stats["degraded"]:
         print(f"  {'!' * 60}")
@@ -1583,6 +1764,22 @@ def main():
     # Optional, best-effort serving-context-window request. Left as None when
     # unset so the outgoing request is unchanged for existing users.
     num_ctx = generation_config.get("num_ctx")
+    # Attestation gate. DEFAULT OFF: it changes which labels survive and can
+    # turn an exit-0 run into exit 3 (degraded), so it is opt-in rather than a
+    # behaviour change existing users get silently. Measure a book first with
+    # tools/verify_attestation.py, which reports the would-be rejection rate
+    # without running the model at all.
+    require_attested = bool(generation_config.get("require_attested_speakers", False))
+    # How much preceding source text joins the current chunk as the
+    # attestation window. Defaults to one chunk, so a name introduced in the
+    # sentence before the chunk boundary still attests. The failure direction
+    # is one-sided and safe: too small means more NARRATOR fallbacks (loud,
+    # prose intact), too large approaches ungated behaviour.
+    # `or chunk_size` (not a .get default) so an explicit null in config.json
+    # -- which is what an unset Optional field round-trips as -- still falls
+    # back rather than becoming a None slice bound.
+    attestation_lookback_chars = (
+        generation_config.get("attestation_lookback_chars") or chunk_size)
 
     print(f"Connecting to: {base_url}")
     print(f"Using model: {model_name}")
@@ -1615,11 +1812,23 @@ def main():
     total_spans = 0
     total_fallback = 0
     total_placeholders = 0
+    total_unattested = 0
+    total_unverifiable = 0
     truncation_events = 0
     prompt_samples = []
 
     for i, chunk in enumerate(chunks, 1):
         print(f"Processing chunk {i}/{total_chunks} ({len(chunk)} chars)...")
+
+        # Attestation window: the chunk the model was shown, plus a tail of the
+        # preceding chunk so a name introduced just before the boundary still
+        # counts. Built from the chunks themselves rather than by re-reading
+        # the source, so it is exactly the text generation saw -- no offsets to
+        # keep in sync and no mojibake mismatch.
+        attest_window = None
+        if require_attested:
+            lookback = chunks[i - 2][-attestation_lookback_chars:] if i > 1 else ""
+            attest_window = lookback + chunk
 
         previous = all_entries if len(all_entries) > 0 else None
         entries, stats = process_chunk(
@@ -1637,6 +1846,8 @@ def main():
             roster=roster_index,
             max_context_roster_names=max_context_roster_names,
             num_ctx=num_ctx,
+            attest_window=attest_window,
+            require_attested=require_attested,
         )
         all_entries.extend(entries)
         for entry in entries:
@@ -1646,6 +1857,8 @@ def main():
         total_spans += stats["spans"]
         total_fallback += stats["fallback"]
         total_placeholders += stats.get("placeholder_rejected", 0)
+        total_unattested += stats.get("unattested_rejected", 0)
+        total_unverifiable += stats.get("unverifiable_accepted", 0)
         truncation_events += stats.get("prompt_truncation_events", 0)
         if stats.get("prompt_tokens"):
             prompt_samples.append((stats.get("prompt_chars", 0), stats["prompt_tokens"]))
@@ -1669,6 +1882,14 @@ def main():
     print(f"  Spans total:             {total_spans}")
     print(f"  Spans fallback-labelled: {total_fallback} (read by NARRATOR)")
     print(f"  Placeholder labels rejected: {total_placeholders}")
+    if require_attested:
+        print(f"  Unattested speakers rejected: {total_unattested} "
+              "(name absent from the text near its own lines)")
+        print(f"  Unverifiable speakers accepted: {total_unverifiable} "
+              "(attestation does not apply to this text)")
+    else:
+        print("  Attestation gate:        off "
+              "(generation.require_attested_speakers)")
     print(f"  Prompt-truncation warnings: {truncation_events}")
     flatline = detect_flatlined_prompt_tokens(prompt_samples)
     if flatline:

--- a/app/generate_script.py
+++ b/app/generate_script.py
@@ -2534,16 +2534,30 @@ def main():
     # Optional, best-effort serving-context-window request. Left as None when
     # unset so the outgoing request is unchanged for existing users.
     num_ctx = generation_config.get("num_ctx")
-    # Attestation gate. DEFAULT OFF: it changes which labels survive and can
-    # turn an exit-0 run into exit 3 (degraded), so it is opt-in rather than a
-    # behaviour change existing users get silently. Measure a book first with
-    # tools/verify_attestation.py, which reports the would-be rejection rate
-    # without running the model at all.
-    require_attested = bool(generation_config.get("require_attested_speakers", False))
-    # Attribution-tag agreement check. DEFAULT OFF for the same reason as the
-    # attestation gate: it spends extra retries and can turn an exit-0 run into
-    # exit 3. Independent of that gate -- a contradicted label is usually a
-    # perfectly attested name, just the wrong one -- so it has its own key.
+    # Attestation gate. DEFAULT ON: it refuses a label the book does not
+    # support near its own lines, which is what stops the classifier inventing
+    # a character out of words the prose supplies. The cost is real and worth
+    # knowing: a real speaker named with a descriptor the book does not use
+    # nearby is refused, and those lines are NARRATED -- 1 span in one run of a
+    # novel, 21 in another, the variance being the model's rather than the
+    # gate's. Rejections are named by chunk and span. Set false to accept every
+    # label the model offers, fabricated ones included. Measure a book first
+    # with tools/verify_attestation.py, which reports the would-be rejection
+    # rate without running the model at all. This default must match
+    # GenerationConfig in app.py -- the UI writes config.json but this
+    # subprocess reads it directly, so a disagreement silently changes
+    # behaviour depending on whether the key was ever saved.
+    require_attested = bool(generation_config.get("require_attested_speakers", True))
+    # Attribution-tag agreement check. DEFAULT ON: the book names the speaker
+    # in the narration beside the line and nothing used to read it -- 5.4% of
+    # checkable pairs carried a label their own tag contradicted, on a run that
+    # reported success; with this on, 0.90%. It costs retries (84 -> 143 on one
+    # book) and reports survivors by chunk and span instead of passing them
+    # silently. Independent of the attestation gate -- a contradicted label is
+    # usually a perfectly attested name, just the wrong one -- so it keeps its
+    # own key. This default must match GenerationConfig in app.py: the UI writes
+    # config.json but this subprocess reads it directly, so a disagreement here
+    # silently changes behaviour depending on whether the key was ever saved.
     #
     # The English speech-verb lexicon it needs is NOT config-exposed. It is a
     # LANGUAGE property, not a per-book tunable, and a per-book verb list is
@@ -2551,7 +2565,7 @@ def main():
     # would produce false accusations, which is the one failure this check must
     # not have. A non-English book needs no setting: no verb matches, so the
     # check finds nothing and costs nothing.
-    check_tags = bool(generation_config.get("check_attribution_tags", False))
+    check_tags = bool(generation_config.get("check_attribution_tags", True))
     # How much preceding source text joins the current chunk as the
     # attestation window. Defaults to one chunk, so a name introduced in the
     # sentence before the chunk boundary still attests. The failure direction

--- a/app/generate_script.py
+++ b/app/generate_script.py
@@ -28,12 +28,13 @@ import argparse
 from openai import OpenAI
 from rapidfuzz.distance import Levenshtein
 from default_prompts import DEFAULT_SYSTEM_PROMPT, DEFAULT_USER_PROMPT
-from span_tokenizer import tokenize, validate_spans
+from span_tokenizer import tokenize, validate_spans, QUOTED, UNQUOTED
 from speaker_canon import (
     UNATTESTED,
     UNVERIFIABLE,
     attest_speaker,
     canonicalize,
+    contradicts_attribution,
     near_spellings,
     remember_in_roster,
     repair_speaker,
@@ -1000,7 +1001,7 @@ def _format_id_list(ids):
 
 
 def _retry_nudge(missing_ids, bad_role_ids, unattested=None, no_speaker_ids=None,
-                 spelling_hints=None):
+                 spelling_hints=None, contradicted=None):
     """Correction text appended to the retry prompt.
 
     Appended AFTER .format(), so it cannot interact with the {context}/{chunk}
@@ -1056,6 +1057,22 @@ def _retry_nudge(missing_ids, bad_role_ids, unattested=None, no_speaker_ids=None
             parts.append("Established character spellings close to the rejected "
                          "names, if one of them is who you meant: "
                          + "; ".join(hints) + ".")
+    if contradicted:
+        # Same shape as the unattested hint above -- name the id, name what was
+        # said, and point at the evidence in the text the model was shown --
+        # because the same thing is true here: a bare "that is wrong" makes the
+        # model guess again. The tag is NOT asserted to be the answer; the
+        # model may re-state its label, and nothing here rewrites it.
+        detail = "; ".join(
+            f'id {span_id}: you said "{speaker}", but the narration right after '
+            f'it attributes the line to "{tagged}"'
+            for span_id, speaker, tagged in contradicted)
+        parts.append(
+            "These spans disagree with their own attribution tag: "
+            f"{detail}. Re-read the narration immediately following each of "
+            "these quotations and give the speaker the text attributes it to. "
+            "If the tag belongs to a DIFFERENT quotation and your original "
+            "answer was right, repeat it.")
     parts.append("Return the JSON array again. It MUST contain one object for every id "
                  'listed above, and every "role" must be exactly "dialogue" or "narration".')
     return " ".join(parts)
@@ -1189,6 +1206,107 @@ def _unattested_speaker_ids(spans, merged, source=None, roster=None,
     return offenders
 
 
+# Closing quote marks a quotation span may end on. A dialogue span that does
+# NOT end on one is mid-quotation, so the narration after it is not a closing
+# attribution tag (see _tag_contradictions' bound).
+_CLOSING_QUOTES = "\"'”’»」』"
+
+
+def _tag_contradictions(spans, speaker_by_id, source, roster_index):
+    """``[(span_id, speaker, tagged_name), ...]`` for dialogue spans whose label
+    is contradicted by the attribution tag in the very next span.
+
+    THE GAP THIS CLOSES. Attestation asks whether the chosen name occurs
+    somewhere nearby; nothing asked whether it is the name the adjacent tag
+    gives. Measured on one clean 8,081-entry artifact: 60 of 1,117 checkable
+    dialogue+tag pairs (5.4%) named a different established character than the
+    tag did, all of them attested and none of them detected.
+
+    DETECTS, NEVER REWRITES. A hit is routed exactly like an unattested
+    speaker: into the retry nudge first (process_chunk), and into the
+    degradation report if the retry does not resolve it (resolve_span_labels).
+    Relabelling the span from the tag would be a second repair_speaker --
+    nearby evidence silently overruling the model -- which is the failure this
+    pipeline keeps trying to eliminate, not add.
+
+    BOUNDS, chosen for PRECISION over recall (a false accusation costs a wasted
+    retry and a false exit-3, which is what erodes trust in exit 3):
+
+      * the labelled span must be a QUOTED span ending on a closing quote mark,
+        so the tag closes it rather than sitting mid-quotation;
+      * the tag must be in the IMMEDIATELY NEXT span, and that span must be
+        UNQUOTED and not whitespace-only. A whitespace-only span between them
+        is the paragraph break, and a tag on the far side of one introduces the
+        NEXT quotation instead of closing this one;
+      * speaker_canon.contradicts_attribution supplies the rest: no possessive
+        tag, no uncapitalized/common-noun tag, no ambiguous name, and
+        granularity/case/apostrophe variants are agreement, not conflict.
+
+    Bound (4) is not perfect: an attributive-looking tag can be a verb with an
+    object ("Kit said the last couple of words of the spell") and is then a
+    false hit. Hand-checking a random 25 of the 64 hits on the artifact above
+    found exactly one such case -- 24/25 genuine.
+
+    ENGLISH-ONLY, degrading to silence: the tag pattern needs an English speech
+    verb, so on a non-English book nothing matches and this returns [] for
+    every span. See speaker_canon's Tier 3c section comment.
+
+    Pure and read-only: ``roster_index`` is not mutated.
+    """
+    if source is None or not roster_index:
+        return []
+
+    contradictions = []
+    for index, span in enumerate(spans[:-1]):
+        speaker = speaker_by_id.get(span.id)
+        if not speaker or speaker == NARRATOR:
+            continue
+        if span.kind != QUOTED:
+            continue
+        if not span.text(source).rstrip().endswith(tuple(_CLOSING_QUOTES)):
+            continue
+        following = spans[index + 1]
+        if following.kind != UNQUOTED or is_whitespace_span(following, source):
+            continue
+        tagged = contradicts_attribution(speaker, following.text(source), roster_index)
+        if tagged:
+            contradictions.append((span.id, speaker, tagged))
+    return contradictions
+
+
+def _contradicted_speaker_ids(spans, merged, source=None, roster=None):
+    """The retry-offender view of _tag_contradictions: run it over the labels a
+    chunk currently holds, before they are resolved.
+
+    Mirrors _unattested_speaker_ids' shape and contract (read-only, dialogue
+    labels only, NARRATOR skipped) so the retry predicate and the degradation
+    count in resolve_span_labels apply the same rule -- the drift
+    _incomplete_span_ids' docstring warns about.
+
+    The roster used is the book's roster PLUS every canonical dialogue name in
+    this chunk, so a character first named in this very chunk can still be the
+    name a tag resolves to.
+    """
+    speaker_by_id = {}
+    roster_index = dict(roster) if roster else {}
+    for span in spans:
+        label = merged.get(span.id)
+        if not isinstance(label, dict):
+            continue
+        role = label.get("role")
+        role = role.strip().lower() if isinstance(role, str) else ""
+        if role != "dialogue":
+            continue
+        raw_speaker = label.get("speaker")
+        canonical = canonicalize(raw_speaker) if isinstance(raw_speaker, str) else ""
+        if not canonical or canonical == NARRATOR or is_placeholder_speaker(canonical):
+            continue
+        speaker_by_id[span.id] = canonical
+        remember_in_roster(roster_index, canonical)
+
+    return _tag_contradictions(spans, speaker_by_id, source, roster_index)
+
+
 def _report_repairs(chunk_num, total_chunks, repairs):
     """Make every speaker repair visible: one console line per distinct repair
     plus a per-repair record in the forensic log.
@@ -1226,7 +1344,7 @@ def _report_repairs(chunk_num, total_chunks, repairs):
 
 def resolve_span_labels(spans, labels, source=None, roster=None,
                         attest_window=None, require_attested=False,
-                        source_words=None):
+                        source_words=None, check_tags=False):
     """Resolve each span to (span, speaker, instruct) using the LLM's labels.
 
     A span is NARRATOR unless a label exists for its id AND that label says
@@ -1285,6 +1403,16 @@ def resolve_span_labels(spans, labels, source=None, roster=None,
     be silent (contract 7). ``source_words`` is speaker_canon.source_word_index()
     over the whole book; without it repair is unavailable and the gate behaves
     exactly as it did before.
+
+    ATTRIBUTION-TAG CHECK (``check_tags``, off by default). After every speaker
+    is decided, _tag_contradictions re-reads the result against the attribution
+    tag in the span right after each quotation and counts the disagreements in
+    ``tag_contradictions`` (itemized in ``contradictions``). Counted ONLY --
+    the label is left exactly as the model gave it, because relabelling a span
+    from adjacent evidence is repair_speaker's job description and this check
+    exists to make wrong answers loud, not to invent new ones. process_chunk
+    asks the model again first; what survives that lands here and degrades the
+    chunk.
     """
     valid_ids = {span.id for span in spans}
     # Local copy: never mutate the caller's roster index (see docstring).
@@ -1425,6 +1553,18 @@ def resolve_span_labels(spans, labels, source=None, roster=None,
 
         resolved.append((span, speaker, instruct))
 
+    # Tag agreement, on the FINAL speakers (post-gate, post-roster-resolution),
+    # so it judges what the script will actually say. Read-only.
+    contradictions = []
+    if check_tags:
+        tag_roster = dict(roster_index) if roster_index else {}
+        speaker_by_id = {}
+        for span, speaker, _ in resolved:
+            if speaker and speaker != NARRATOR:
+                speaker_by_id[span.id] = speaker
+                remember_in_roster(tag_roster, speaker)
+        contradictions = _tag_contradictions(spans, speaker_by_id, source, tag_roster)
+
     return resolved, {
         # Inclusive of auto-resolved whitespace spans, so callers keep the
         # `labelled + fallback == spans` accounting invariant.
@@ -1439,6 +1579,8 @@ def resolve_span_labels(spans, labels, source=None, roster=None,
         "speakers_repaired": len(repairs),
         "repairs": repairs,
         "dialogue_without_speaker": dialogue_without_speaker,
+        "tag_contradictions": len(contradictions),
+        "contradictions": contradictions,
         "unknown_key_labels": unknown_key_labels,
         "unknown_keys": sorted(unknown_keys),
         "text_key_labels": text_key_labels,
@@ -1706,7 +1848,7 @@ def build_context(chunk_num, total_chunks, previous_entries=None,
     return "\n".join(context_parts)
 
 
-def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_entries=None, max_retries=2, system_prompt=None, user_prompt_template=None, max_tokens=4096, temperature=0.6, top_p=0.8, top_k=0, min_p=0, presence_penalty=0.0, banned_tokens=None, roster=None, max_context_roster_names=None, num_ctx=None, attest_window=None, require_attested=False, reasoning_effort=None, source_words=None):
+def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_entries=None, max_retries=2, system_prompt=None, user_prompt_template=None, max_tokens=4096, temperature=0.6, top_p=0.8, top_k=0, min_p=0, presence_penalty=0.0, banned_tokens=None, roster=None, max_context_roster_names=None, num_ctx=None, attest_window=None, require_attested=False, reasoning_effort=None, source_words=None, check_tags=False):
     """Classify one chunk's spans and rebuild its script entries verbatim.
 
     Returns ``(entries, stats)``. ``stats`` reports span counts and whether the
@@ -1924,8 +2066,14 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
                                     source_words=source_words)
             if require_attested else []
         )
+        contradicted = (
+            _contradicted_speaker_ids(spans, merged_labels, source=chunk,
+                                      roster=roster)
+            if check_tags else []
+        )
 
-        if not missing_ids and not bad_role_ids and not no_speaker_ids and not unattested:
+        if (not missing_ids and not bad_role_ids and not no_speaker_ids
+                and not unattested and not contradicted):
             if attempt > 0:
                 print(f"  Succeeded on retry {attempt + 1} -- all {len(spans)} spans labelled")
             break
@@ -1943,6 +2091,11 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
                 gaps.append(f"{len(bad_role_ids)} label(s) with an unusable role")
             if no_speaker_ids:
                 gaps.append(f"{len(no_speaker_ids)} dialogue label(s) with no speaker")
+            if contradicted:
+                gaps.append(f"{len(contradicted)} speaker label(s) contradicted by "
+                            "their own attribution tag "
+                            f"({', '.join(f'{s}/{t}' for _, s, t in contradicted[:3])}"
+                            f"{', ...' if len(contradicted) > 3 else ''})")
             if unattested:
                 gaps.append(f"{len(unattested)} speaker name(s) absent from the text "
                             f"({', '.join(name for _, name in unattested[:3])}"
@@ -1956,7 +2109,8 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
             }
             retry_nudge = _retry_nudge(missing_ids, bad_role_ids, unattested,
                                        no_speaker_ids=no_speaker_ids,
-                                       spelling_hints=spelling_hints)
+                                       spelling_hints=spelling_hints,
+                                       contradicted=contradicted)
             # Clear the refused speakers so the retry's answer can actually
             # land. _merge_label deliberately never overwrites a usable field
             # -- that is what makes "a retry can never make things worse" a
@@ -1968,6 +2122,19 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
             # supplies nothing, the field stays blank and the span is narrated
             # and counted (see dialogue_without_speaker), so the outcome is
             # never quieter than a plain rejection.
+            # Same reason for the tag contradictions, with one difference worth
+            # stating: our check has NOT ruled the value unusable, only that it
+            # disagrees with the adjacent tag. Clearing it is still what makes
+            # the retry able to answer at all (_merge_label never overwrites a
+            # usable field), and the nudge tells the model to repeat its answer
+            # if it was right -- which re-fills the field. The residual cost of
+            # a FALSE detection is therefore one span narrated (loud, counted
+            # as dialogue_without_speaker) when the retry supplies nothing at
+            # all; prose is untouched either way.
+            for span_id, _, _ in contradicted:
+                label = merged_labels.get(span_id)
+                if isinstance(label, dict):
+                    label.pop("speaker", None)
             for span_id, _ in unattested:
                 label = merged_labels.get(span_id)
                 if isinstance(label, dict):
@@ -1982,7 +2149,7 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
     resolved, stats = resolve_span_labels(
         spans, list(merged_labels.values()), source=chunk, roster=roster,
         attest_window=attest_window, require_attested=require_attested,
-        source_words=source_words)
+        source_words=source_words, check_tags=check_tags)
     _report_repairs(chunk_num, total_chunks, stats.get("repairs"))
     entries = build_entries(resolved, chunk)
     _assert_chunk_verbatim(entries, chunk, chunk_num)
@@ -2001,6 +2168,14 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
         # the run would exit 0 with silently narrated dialogue.
         reason = (f"{stats['unattested_rejected']} speaker label(s) named a "
                   "character the source text does not support")
+    if reason is None and stats.get("tag_contradictions", 0) > 0:
+        # The retry did not resolve it, so the script will say a name the
+        # neighbouring attribution tag disagrees with. Nothing was rewritten;
+        # this is the operator's pointer to where to look (contract 7).
+        detail = ", ".join(f"span {span_id}: {speaker} vs tag {tagged}"
+                           for span_id, speaker, tagged in stats["contradictions"][:5])
+        reason = (f"{stats['tag_contradictions']} speaker label(s) contradicted "
+                  f"by the attribution tag next to them ({detail})")
     if reason is None and stats["dialogue_without_speaker"] > 0:
         reason = (f"{stats['dialogue_without_speaker']} label(s) claimed "
                   "role=dialogue with no usable speaker name")
@@ -2039,6 +2214,12 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
     if stats["unattested_rejected"]:
         print(f"  Rejected {stats['unattested_rejected']} speaker label(s) whose name does "
               "not appear in the text near their own lines -- narrated instead")
+    if stats.get("tag_contradictions"):
+        for span_id, speaker, tagged in stats["contradictions"]:
+            print(f"  CONTRADICTED speaker label on span {span_id}: labelled "
+                  f"\"{speaker}\", but the narration right after it attributes "
+                  f"the line to \"{tagged}\" -- label KEPT as the model gave it, "
+                  "reported for review")
     if stats["unverifiable_accepted"]:
         print(f"  Accepted {stats['unverifiable_accepted']} speaker label(s) the source "
               "cannot confirm or refute (attestation does not apply to this text)")
@@ -2178,6 +2359,18 @@ def main():
     # tools/verify_attestation.py, which reports the would-be rejection rate
     # without running the model at all.
     require_attested = bool(generation_config.get("require_attested_speakers", False))
+    # Attribution-tag agreement check. DEFAULT OFF for the same reason as the
+    # attestation gate: it spends extra retries and can turn an exit-0 run into
+    # exit 3. Independent of that gate -- a contradicted label is usually a
+    # perfectly attested name, just the wrong one -- so it has its own key.
+    #
+    # The English speech-verb lexicon it needs is NOT config-exposed. It is a
+    # LANGUAGE property, not a per-book tunable, and a per-book verb list is
+    # precisely the book-fitting this pipeline avoids; a wrong entry there
+    # would produce false accusations, which is the one failure this check must
+    # not have. A non-English book needs no setting: no verb matches, so the
+    # check finds nothing and costs nothing.
+    check_tags = bool(generation_config.get("check_attribution_tags", False))
     # How much preceding source text joins the current chunk as the
     # attestation window. Defaults to one chunk, so a name introduced in the
     # sentence before the chunk boundary still attests. The failure direction
@@ -2242,6 +2435,8 @@ def main():
     total_unattested = 0
     total_unverifiable = 0
     total_repaired = 0
+    total_contradicted = 0
+    contradiction_examples = []
     repair_mappings = {}
     truncation_events = 0
     prompt_samples = []
@@ -2279,6 +2474,7 @@ def main():
             require_attested=require_attested,
             reasoning_effort=reasoning_effort,
             source_words=source_words,
+            check_tags=check_tags,
         )
         all_entries.extend(entries)
         for entry in entries:
@@ -2291,6 +2487,9 @@ def main():
         total_unattested += stats.get("unattested_rejected", 0)
         total_unverifiable += stats.get("unverifiable_accepted", 0)
         total_repaired += stats.get("speakers_repaired", 0)
+        total_contradicted += stats.get("tag_contradictions", 0)
+        contradiction_examples.extend(
+            (i, speaker, tagged) for _, speaker, tagged in stats.get("contradictions") or [])
         for original, repaired in stats.get("repairs") or []:
             repair_mappings[(original, repaired)] = (
                 repair_mappings.get((original, repaired), 0) + 1)
@@ -2332,6 +2531,16 @@ def main():
     else:
         print("  Attestation gate:        off "
               "(generation.require_attested_speakers)")
+    if check_tags:
+        print(f"  Attribution-tag contradictions: {total_contradicted} "
+              "(label kept; the tag next to the line names someone else)")
+        for chunk_num, speaker, tagged in contradiction_examples[:10]:
+            print(f"    - chunk {chunk_num}: labelled \"{speaker}\", tag says \"{tagged}\"")
+        if len(contradiction_examples) > 10:
+            print(f"    - (and {len(contradiction_examples) - 10} more)")
+    else:
+        print("  Attribution-tag check:   off "
+              "(generation.check_attribution_tags)")
     print(f"  Prompt-truncation warnings: {truncation_events}")
     flatline = detect_flatlined_prompt_tokens(prompt_samples)
     if flatline:

--- a/app/generate_script.py
+++ b/app/generate_script.py
@@ -217,25 +217,13 @@ def strip_thinking_tags(text):
     return text
 
 
-def clean_json_string(text):
-    """Clean and extract valid JSON array from LLM response."""
-    text = strip_thinking_tags(text)
+def _balanced_array_end(text, start):
+    """Index just past the ``]`` closing the array opened at ``start``.
 
-    # Remove markdown code blocks
-    if "```" in text:
-        # Find content between ```json and ``` or just ``` and ```
-        match = re.search(r'```(?:json)?\s*([\s\S]*?)```', text)
-        if match:
-            text = match.group(1).strip()
-
-    # Find the JSON array - match from first [ to its closing ]
-    # Use a bracket counter to find the correct closing bracket
-    start = text.find('[')
-    if start == -1:
-        return None
-
+    String-aware (brackets inside JSON strings do not count). Returns -1 when
+    no balanced close exists, i.e. the array was truncated.
+    """
     bracket_count = 0
-    end = -1
     in_string = False
     escape_next = False
 
@@ -246,7 +234,7 @@ def clean_json_string(text):
         if char == '\\':
             escape_next = True
             continue
-        if char == '"' and not escape_next:
+        if char == '"':
             in_string = not in_string
             continue
         if in_string:
@@ -256,43 +244,88 @@ def clean_json_string(text):
         elif char == ']':
             bracket_count -= 1
             if bracket_count == 0:
-                end = i + 1
-                break
+                return i + 1
+    return -1
 
-    if end == -1:
-        # No closing bracket found, try to salvage
-        last_complete = text.rfind('},')
-        if last_complete > start:
-            return text[start:last_complete+1] + ']'
-        return None
 
-    json_text = text[start:end]
-
-    # Clean control characters inside strings (common LLM issue)
-    # Replace literal newlines/tabs inside JSON strings with escaped versions
+def _escape_control_chars(json_text):
+    """Escape literal newlines/tabs inside JSON string values (common LLM bug)."""
     def fix_control_chars(match):
         s = match.group(0)
-        # Replace unescaped control characters
         s = s.replace('\n', '\\n')
         s = s.replace('\r', '\\r')
         s = s.replace('\t', '\\t')
         return s
 
-    # Fix control characters inside string values
-    json_text = re.sub(r'"[^"\\]*(?:\\.[^"\\]*)*"', fix_control_chars, json_text)
-
-    return json_text
+    return re.sub(r'"[^"\\]*(?:\\.[^"\\]*)*"', fix_control_chars, json_text)
 
 
-def repair_json_array(json_text):
-    """Attempt to repair common JSON array issues from LLM output."""
+def clean_json_string(text):
+    """Extract the JSON array from an LLM response.
+
+    Tries EVERY ``[`` in the response, in order, and returns the first whose
+    balanced slice actually parses as a list -- not merely the first ``[``
+    character. A model that prefaces its array with prose containing brackets
+    ("Sure! Here are the labels [see list below]:") used to hand back
+    ``'[see list below]'``, a truthy string that then displaced the raw text
+    in extract_labels' salvage step and cost the chunk EVERY label, even
+    though the real array sat intact a few characters later.
+
+    Falls back to the first syntactically-balanced candidate (or a truncated
+    tail repaired with a closing bracket) when none of them parse, so callers
+    that do their own repair -- review_script.py drives this same function --
+    still receive what they used to.
+    """
+    text = strip_thinking_tags(text)
+
+    # Remove markdown code blocks
+    if "```" in text:
+        # Find content between ```json and ``` or just ``` and ```
+        match = re.search(r'```(?:json)?\s*([\s\S]*?)```', text)
+        if match:
+            text = match.group(1).strip()
+
+    fallback = None
+    search_from = 0
+
+    while True:
+        start = text.find('[', search_from)
+        if start == -1:
+            break
+        search_from = start + 1
+
+        end = _balanced_array_end(text, start)
+        if end == -1:
+            # Truncated: repair by closing after the last complete object.
+            last_complete = text.rfind('},')
+            if last_complete > start and fallback is None:
+                fallback = text[start:last_complete + 1] + ']'
+            continue
+
+        candidate = _escape_control_chars(text[start:end])
+        if repair_json_array(candidate, quiet=True):
+            return candidate
+        if fallback is None:
+            fallback = candidate
+
+    return fallback
+
+
+def repair_json_array(json_text, quiet=False):
+    """Attempt to repair common JSON array issues from LLM output.
+
+    ``quiet`` suppresses the dropped-entry warning. clean_json_string() uses
+    this function to PROBE candidate slices, and a probe that rejects a
+    bracketed fragment of prose must not report it as damage to the model's
+    real array.
+    """
     if not json_text:
         return None
 
     def _filter_entries(lst):
         """Keep only dict entries; LLMs sometimes emit bare strings in the array."""
         filtered = [e for e in lst if isinstance(e, dict)]
-        if len(filtered) < len(lst):
+        if len(filtered) < len(lst) and not quiet:
             print(f"  Warning: Dropped {len(lst) - len(filtered)} non-object entries from LLM JSON array")
         return filtered if filtered else None
 
@@ -645,10 +678,14 @@ def extract_labels(text):
     if labels:
         return labels, LABEL_MODE_OBJECT
 
-    # Salvage the cleaned array text when we have it, else the raw response:
-    # clean_json_string() returns None for a hard truncation with no closing
-    # bracket, which is exactly when salvage matters most.
-    labels = salvage_label_entries(json_text or text)
+    # Salvage the cleaned array text first, then ALWAYS retry against the raw
+    # response if that yielded nothing. Falling back only when json_text was
+    # None was too narrow: a wrong-but-truthy cleaned slice (prose brackets --
+    # see clean_json_string) displaced the raw text and cost the chunk every
+    # label, even though salvaging the raw text would have recovered them all.
+    labels = salvage_label_entries(json_text) if json_text else None
+    if not labels:
+        labels = salvage_label_entries(text)
     if labels:
         return labels, LABEL_MODE_SALVAGE
 
@@ -1044,23 +1081,51 @@ def _assert_chunk_verbatim(entries, chunk, chunk_num):
     )
 
 
-def fix_mojibake(text):
-    """Fix common mojibake characters resulting from CP1252-as-UTF8."""
-    replacements = {
-        'â€™': ''',  # Right single quote
-        'â€˜': ''',  # Left single quote
-        'â€œ': '"',  # Left double quote
-        'â€\x9d': '"', # Right double quote
-        'â€?': '"', # Sometimes ? if undefined
-        'â€"': '—',  # Em dash
-        'â€"': '–',  # En dash
-        'â€¦': '…',  # Ellipsis
-    }
+# CP1252-as-UTF8 mojibake repair table; see fix_mojibake() for why every
+# literal is written as an escape. Each key is 3 characters: "\u00e2\u20ac"
+# (UTF-8 bytes E2 80 read as CP1252) plus whatever CP1252 maps the third
+# byte to.
+MOJIBAKE_REPLACEMENTS = {
+    "\u00e2\u20ac\u2122": "\u2019",   # 0x99 -> right single quote
+    "\u00e2\u20ac\u02dc": "\u2018",   # 0x98 -> left single quote
+    "\u00e2\u20ac\u0153": "\u201c",   # 0x9c -> left double quote
+    "\u00e2\u20ac\u009d": "\u201d",   # 0x9d is undefined in CP1252
+    "\u00e2\u20ac?": "\u201d",         # ...and is sometimes rendered "?"
+    "\u00e2\u20ac\u201d": "\u2014",   # 0x94 -> em dash
+    "\u00e2\u20ac\u201c": "\u2013",   # 0x93 -> en dash
+    "\u00e2\u20ac\u00a6": "\u2026",   # 0xa6 -> ellipsis
+}
 
-    for bad, good in replacements.items():
+
+def fix_mojibake(text):
+    """Fix common mojibake characters resulting from CP1252-as-UTF8.
+
+    Every key and value in MOJIBAKE_REPLACEMENTS is written as an explicit
+    \\u escape. That is not stylistic: the literals are themselves mojibake,
+    so any editor, terminal or copy-paste that re-encodes this file silently
+    rewrites them -- which had already happened twice here:
+
+      * the right-single-quote entry's VALUE had decayed to three ASCII
+        apostrophes, which Python read as the start of a triple-quoted
+        string. It swallowed its own comment AND the whole next entry, so
+        the left-single-quote mapping did not exist at all; and
+      * the em-dash and en-dash KEYS had both decayed to the same ASCII
+        double-quote byte, making them duplicate dict keys -- 7 literal
+        entries collapsed to 6, and the en-dash mapping shadowed the em-dash
+        one, so em-dash mojibake was never repaired.
+
+    Escapes cannot decay this way, and a test asserts the dict holds exactly
+    one entry per literal.
+
+    Each key is what a UTF-8 byte sequence looks like decoded as CP1252:
+    U+2014 EM DASH is E2 80 94, and CP1252 maps 0x94 to U+201D, hence
+    "\\u00e2\\u20ac\\u201d".
+    """
+    for bad, good in MOJIBAKE_REPLACEMENTS.items():
         text = text.replace(bad, good)
 
     return text
+
 
 def split_into_chunks(text, max_size=3000):
     """Split text into chunks at paragraph/sentence boundaries."""

--- a/app/generate_script.py
+++ b/app/generate_script.py
@@ -51,6 +51,18 @@ PROMPT_SCHEMA_MARKER = "span-labels-v1"
 # input, not output -- a snippet is enough and keeps the prompt cheap.
 CONTEXT_SNIPPET_CHARS = 120
 
+# Where raw LLM responses are logged. Production default; the test suite points
+# ALEXANDRIA_LLM_LOG_DIR at a tempdir so fixture responses never pollute the
+# real forensic log (it had accumulated 1200+ test records).
+LLM_LOG_DIR = os.path.join(os.path.dirname(__file__), "..", "logs")
+LLM_LOG_DIR_ENV = "ALEXANDRIA_LLM_LOG_DIR"
+
+
+def llm_log_dir():
+    """Directory for llm_responses.log. Read per call so an override set after
+    import (e.g. by a test harness) still takes effect."""
+    return os.environ.get(LLM_LOG_DIR_ENV) or LLM_LOG_DIR
+
 def strip_thinking_tags(text):
     """Remove reasoning-model thinking blocks from a raw response.
 
@@ -539,11 +551,32 @@ def select_prompt(custom_prompt, default_prompt, config_key):
     return default_prompt
 
 
+def is_whitespace_span(span, source):
+    """True for a span with no audible content (e.g. the "\\n\\n" between two
+    quoted paragraphs).
+
+    Such spans are excluded from the LLM loop entirely: the model never sees
+    them, is never asked to label them, is never retried for skipping them, and
+    they never degrade a chunk. Their label would be thrown away regardless --
+    _absorb_whitespace_groups folds a whitespace-only group's TEXT into a
+    neighbour and drops its speaker/instruct. They stay in the span list, so
+    byte-identity and whitespace absorption are unaffected.
+    """
+    return not span.text(source).strip()
+
+
+def visible_spans(spans, source):
+    """The spans worth asking the LLM about."""
+    return [span for span in spans if not is_whitespace_span(span, source)]
+
+
 def build_span_payload(spans, source):
     """Render spans as the numbered listing the classifier receives.
 
     One JSON object per line: {"id", "kind", "text"}. The LLM sees the text so
-    it can classify it; it is instructed never to send text back.
+    it can classify it; it is instructed never to send text back. Whitespace-only
+    spans are omitted -- they cost tokens and invite phantom skips, and their
+    ids stay the tokenizer's, so the visible ids simply have gaps.
     """
     return "\n".join(
         json.dumps(
@@ -551,7 +584,126 @@ def build_span_payload(spans, source):
             ensure_ascii=False,
         )
         for span in spans
+        if not is_whitespace_span(span, source)
     )
+
+
+# Recovery modes ranked by fidelity, worst-last. When labels for one chunk are
+# merged across attempts, the WORST contributing mode is reported, so an
+# attempt-1 array followed by an attempt-2 markdown salvage still surfaces the
+# markdown contract violation instead of hiding it behind the array.
+_MODE_FIDELITY = {
+    "array": 0,
+    "id-keyed object": 1,
+    "regex salvage": 2,
+    "markdown salvage": 3,
+}
+
+
+def _worst_mode(current, new):
+    """Return the lower-fidelity of two recovery modes."""
+    if new is None:
+        return current
+    if current is None:
+        return new
+    return new if _MODE_FIDELITY.get(new, 0) > _MODE_FIDELITY.get(current, 0) else current
+
+
+def _usable_field(name, value):
+    """True when a label field carries information we can actually act on.
+
+    ``role`` is special: only the two contract values mean anything, so an
+    invented value ("thought" was observed live on a genuinely spoken line)
+    counts as absent and is therefore fillable by a retry.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return False
+    if name == "role":
+        return value.strip().lower() in ("dialogue", "narration")
+    return True
+
+
+def _merge_label(old, new):
+    """Fill blank fields from ``new``; never overwrite information already held.
+
+    This is the cross-attempt merge, and it is deliberately NOT
+    _label_completeness (which ranks whole labels and would let a retry replace
+    a correct label with a differently-shaped one). Filling blanks makes
+    "a retry can never make things worse" a structural property: a later
+    attempt can only add ids, or fill fields that were missing, empty or --
+    for role -- outside the contract.
+    """
+    if old is None:
+        return dict(new)
+    merged = dict(old)
+    for field in ("speaker", "role", "instruct"):
+        if not _usable_field(field, merged.get(field)) and _usable_field(field, new.get(field)):
+            merged[field] = new[field]
+    return merged
+
+
+def _incomplete_span_ids(spans, merged, source=None):
+    """Return ``(missing_ids, bad_role_ids)`` -- what a retry should ask for.
+
+    Membership, never a count: live responses hallucinate ids past N (137
+    labels for 41 spans in one logged response), so ``len(merged) >= len(spans)``
+    would fake completeness. ``bad_role_ids`` mirrors resolve_span_labels'
+    role_missing condition exactly, so the retry predicate and the degradation
+    reason can never disagree.
+
+    When ``source`` is given, whitespace-only spans are skipped: the model was
+    never shown them, so it cannot be "missing" one.
+    """
+    if source is not None:
+        spans = visible_spans(spans, source)
+
+    missing = [span.id for span in spans if span.id not in merged]
+    bad_role = []
+    for span in spans:
+        label = merged.get(span.id)
+        if label is None or _usable_field("role", label.get("role")):
+            continue
+        raw_speaker = label.get("speaker")
+        canonical = canonicalize(raw_speaker) if isinstance(raw_speaker, str) else ""
+        if canonical and canonical != NARRATOR:
+            bad_role.append(span.id)
+    return missing, bad_role
+
+
+# Cap the id list in a nudge so a wholly-unlabelled chunk cannot balloon the prompt.
+_NUDGE_ID_CAP = 50
+
+
+def _format_id_list(ids):
+    if len(ids) <= _NUDGE_ID_CAP:
+        return ", ".join(str(i) for i in ids)
+    head = ", ".join(str(i) for i in ids[:_NUDGE_ID_CAP])
+    return f"{head} (and {len(ids) - _NUDGE_ID_CAP} more)"
+
+
+def _retry_nudge(missing_ids, bad_role_ids):
+    """Correction text appended to the retry prompt.
+
+    Appended AFTER .format(), so it cannot interact with the {context}/{chunk}
+    placeholders or the doubled braces in the template, and nothing is stored
+    in config.json -- select_prompt / PROMPT_SCHEMA_MARKER are untouched, and a
+    marker-bearing custom prompt keeps working.
+
+    Naming the ids matters: logged misses are a contiguous SUFFIX of the id
+    sequence (the model closes the array early, well under max_tokens), so a
+    blind re-roll re-rolls the same "I am finished" judgement. Naming the gap
+    corrects it instead.
+    """
+    parts = ["\n\nCORRECTION: your previous reply did not label every span."]
+    if missing_ids:
+        parts.append("These span ids are still missing a label: "
+                     f"{_format_id_list(missing_ids)}.")
+    if bad_role_ids:
+        parts.append('These span ids had a "role" that was neither "dialogue" nor '
+                     f'"narration": {_format_id_list(bad_role_ids)}.')
+    parts.append("Return the JSON array again. It MUST contain one object for every id "
+                 'listed above, and every "role" must be exactly "dialogue" or "narration".')
+    return " ".join(parts)
 
 
 def _label_completeness(label):
@@ -571,13 +723,19 @@ def _label_completeness(label):
     return score
 
 
-def resolve_span_labels(spans, labels):
+def resolve_span_labels(spans, labels, source=None):
     """Resolve each span to (span, speaker, instruct) using the LLM's labels.
 
     A span is NARRATOR unless a label exists for its id AND that label says
     role == "dialogue" AND its speaker canonicalizes to a non-empty name.
     Labels for ids that do not exist are discarded. Returns
     (resolved, stats_dict).
+
+    When ``source`` is given, whitespace-only spans are auto-resolved to
+    NARRATOR with no instruct and counted in ``whitespace`` rather than
+    ``fallback``: the model was never shown them, so a missing label is not a
+    failure. ``labelled`` stays inclusive of them so callers may continue to
+    rely on ``labelled + fallback == spans``.
     """
     valid_ids = {span.id for span in spans}
     by_id = {}
@@ -599,8 +757,17 @@ def resolve_span_labels(spans, labels):
     resolved = []
     labelled = 0
     role_missing = 0
+    whitespace = 0
 
     for span in spans:
+        if source is not None and is_whitespace_span(span, source):
+            # Never shown to the model; its label would be discarded by
+            # _absorb_whitespace_groups anyway. Any label sent for this id is
+            # ignored here, exactly as a phantom label would be.
+            resolved.append((span, NARRATOR, None))
+            whitespace += 1
+            continue
+
         label = by_id.get(span.id)
         speaker = NARRATOR
         instruct = None
@@ -628,8 +795,11 @@ def resolve_span_labels(spans, labels):
         resolved.append((span, speaker, instruct))
 
     return resolved, {
-        "labelled": labelled,
-        "fallback": len(spans) - labelled,
+        # Inclusive of auto-resolved whitespace spans, so callers keep the
+        # `labelled + fallback == spans` accounting invariant.
+        "labelled": labelled + whitespace,
+        "fallback": len(spans) - labelled - whitespace,
+        "whitespace": whitespace,
         "discarded": discarded,
         "role_missing": role_missing,
     }
@@ -828,17 +998,33 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
     validate_spans(spans, chunk)
 
     if not spans:
-        return [], {"spans": 0, "labelled": 0, "fallback": 0, "discarded": 0,
-                    "role_missing": 0, "degraded": False, "reason": None,
-                    "recovery": None}
+        return [], {"spans": 0, "labelled": 0, "fallback": 0, "whitespace": 0,
+                    "discarded": 0, "role_missing": 0, "degraded": False,
+                    "reason": None, "recovery": None}
+
+    if not visible_spans(spans, chunk):
+        # Nothing audible to classify (a chunk of pure whitespace). Resolve
+        # locally rather than spending an LLM call on an empty span listing.
+        resolved, stats = resolve_span_labels(spans, None, source=chunk)
+        entries = build_entries(resolved, chunk)
+        _assert_chunk_verbatim(entries, chunk, chunk_num)
+        stats.update({"spans": len(spans), "degraded": False,
+                      "reason": None, "recovery": None})
+        return entries, stats
 
     context = build_context(chunk_num, total_chunks, previous_entries)
-    user_prompt = usr_template.format(context=context, chunk=build_span_payload(spans, chunk))
+    base_prompt = usr_template.format(context=context, chunk=build_span_payload(spans, chunk))
 
-    labels = None
+    # Labels accumulate ACROSS attempts, filling blanks only (see _merge_label),
+    # so a retry can only ever improve the result. Live runs showed the model
+    # closing the array early -- dropping a contiguous SUFFIX of ids with
+    # finish_reason=stop, nowhere near max_tokens -- and separately inventing
+    # role values ("thought"). Both are recoverable by re-asking for the gap.
+    merged_labels = {}
     recovery = None
     truncated = False
     reason = None
+    retry_nudge = ""
 
     for attempt in range(max_retries + 1):
         try:
@@ -846,7 +1032,7 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
                 model=model_name,
                 messages=[
                     {"role": "system", "content": sys_prompt},
-                    {"role": "user", "content": user_prompt}
+                    {"role": "user", "content": base_prompt + retry_nudge}
                 ],
                 temperature=temperature,
                 top_p=top_p,
@@ -867,7 +1053,7 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
             usage = getattr(response, 'usage', None)
 
             # Log raw response for debugging
-            log_dir = os.path.join(os.path.dirname(__file__), "..", "logs")
+            log_dir = llm_log_dir()
             os.makedirs(log_dir, exist_ok=True)
             log_path = os.path.join(log_dir, "llm_responses.log")
             with open(log_path, "a", encoding="utf-8") as lf:
@@ -897,32 +1083,65 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
             break
 
         # Recover labels from whatever shape the model actually produced.
-        labels, recovery = extract_labels(text)
+        labels, mode = extract_labels(text)
 
         if labels:
-            if attempt > 0:
-                print(f"  Succeeded on retry {attempt + 1}")
-            if recovery == LABEL_MODE_OBJECT:
+            recovery = _worst_mode(recovery, mode)
+            if mode == LABEL_MODE_OBJECT:
                 print(f"  Note: model returned an id-keyed JSON object instead of an array; "
                       f"recovered all {len(labels)} label(s) from it")
-            elif recovery == LABEL_MODE_SALVAGE:
+            elif mode == LABEL_MODE_SALVAGE:
                 print(f"  Regex-salvaged {len(labels)} label(s) from a malformed/truncated response")
-            elif recovery == LABEL_MODE_MARKDOWN:
+            elif mode == LABEL_MODE_MARKDOWN:
                 print(f"  Recovered {len(labels)} label(s) from markdown blocks "
                       "(model ignored the JSON output contract)")
+
+            before = len(merged_labels)
+            for label in labels:
+                label_id = _label_id(label)
+                if label_id is not None:
+                    merged_labels[label_id] = _merge_label(merged_labels.get(label_id), label)
+            if attempt > 0:
+                print(f"  Retry recovered {len(merged_labels) - before} new label(s)")
+        else:
+            print(f"Warning: Could not recover labels from chunk {chunk_num} response (attempt {attempt + 1})")
+            print(f"Response preview: {text[:300]}...")
+            if attempt < max_retries:
+                print("Retrying...")
+                continue
+            if not merged_labels:
+                reason = "no usable labels recovered from LLM response"
+            break  # keep whatever earlier attempts recovered
+
+        missing_ids, bad_role_ids = _incomplete_span_ids(spans, merged_labels, source=chunk)
+
+        if not missing_ids and not bad_role_ids:
+            if attempt > 0:
+                print(f"  Succeeded on retry {attempt + 1} -- all {len(spans)} spans labelled")
             break
 
-        print(f"Warning: Could not recover labels from chunk {chunk_num} response (attempt {attempt + 1})")
-        print(f"Response preview: {text[:300]}...")
+        if truncated:
+            # Re-rolling at the same max_tokens genuinely is pointless: accept
+            # the partial labels and let the rest fall back to NARRATOR.
+            break
 
         if attempt < max_retries:
-            print("Retrying...")
-        else:
-            reason = "no usable labels recovered from LLM response"
+            gaps = []
+            if missing_ids:
+                gaps.append(f"{len(missing_ids)} span(s) unlabelled")
+            if bad_role_ids:
+                gaps.append(f"{len(bad_role_ids)} label(s) with an unusable role")
+            print(f"  {' and '.join(gaps)} -- retrying (attempt {attempt + 2}"
+                  f"/{max_retries + 1}), naming the gaps")
+            retry_nudge = _retry_nudge(missing_ids, bad_role_ids)
+            continue
+
+        break
 
     # Reassemble regardless of what came back. Unlabelled spans -> NARRATOR,
-    # so a failure costs labels, never prose.
-    resolved, stats = resolve_span_labels(spans, labels)
+    # so a failure costs labels, never prose. Phantom ids stay in the merged map
+    # on purpose: resolve_span_labels discards and counts them (once each).
+    resolved, stats = resolve_span_labels(spans, list(merged_labels.values()), source=chunk)
     entries = build_entries(resolved, chunk)
     _assert_chunk_verbatim(entries, chunk, chunk_num)
 

--- a/app/generate_script.py
+++ b/app/generate_script.py
@@ -28,9 +28,12 @@ from speaker_canon import (
     UNVERIFIABLE,
     attest_speaker,
     canonicalize,
+    near_spellings,
     remember_in_roster,
+    repair_speaker,
     resolve_against_roster,
     roster_key,
+    source_word_index,
 )
 
 # Cap for single-speaker mode: entries at this size pass through
@@ -432,6 +435,29 @@ _LABEL_STRING_FIELD_RE = {
     "instruct": re.compile(r'"instruct"\s*:\s*"((?:[^"\\]|\\.)*)"'),
 }
 
+# Bareword fallback for models that emit complete-but-JSON-invalid output with
+# UNQUOTED values: {"id": 1, "speaker": KIT, "role": dialogue, "instruct": "..."}.
+# Observed live on 2 of 281 chunks (90 bareword values across them, all with
+# finish_reason=stop -- not truncation). Without this the quoted pattern simply
+# failed to match, the key was dropped in silence, and the whole chunk collapsed
+# into one NARRATOR entry, costing 53 dialogue labels their voice.
+#
+# Only "speaker" and "role" get the fallback. They are the two fields that decide
+# the cast, and in the logged responses they are exactly the two that appeared
+# unquoted; "instruct" was always quoted, and it is free prose whose commas and
+# braces make an unterminated bareword scan unsafe for no fidelity gain.
+#
+# The value stops at , } ] or a newline so it cannot swallow the following key,
+# and must not begin with a quote so a well-formed value never takes this path.
+_LABEL_BAREWORD_FIELD_RE = {
+    "speaker": re.compile(r'"speaker"\s*:\s*([^"\s,}\]\n][^,}\]\n]*)'),
+    "role": re.compile(r'"role"\s*:\s*([^"\s,}\]\n][^,}\]\n]*)'),
+}
+
+# JSON literals are not names. A bareword `null` means the model declined to
+# answer, not that the character is called "Null".
+_BAREWORD_NON_VALUES = {"null", "none", "nil", "undefined", "true", "false"}
+
 
 def _unescape_json_string(raw):
     """Decode a JSON string body (the bit between the quotes)."""
@@ -439,6 +465,11 @@ def _unescape_json_string(raw):
         return json.loads('"' + raw + '"')
     except (json.JSONDecodeError, ValueError):
         return raw.replace('\\"', '"').replace('\\n', '\n').replace('\\\\', '\\')
+
+
+# The entire label schema. Anything else the model sends is ignored on read;
+# resolve_span_labels counts it so the discard is visible in the run log.
+_LABEL_SCHEMA_KEYS = frozenset(("id", "speaker", "role", "instruct"))
 
 
 def _label_id(label):
@@ -467,6 +498,22 @@ def _extract_label_object(raw):
         match = pattern.search(raw)
         if match:
             label[key] = _unescape_json_string(match.group(1))
+            continue
+        # Quoted form wins; only an unquoted value reaches the fallback. The
+        # bareword is NOT run through _unescape_json_string, which assumes a
+        # JSON string body and would mangle a value containing a backslash.
+        bareword = _LABEL_BAREWORD_FIELD_RE.get(key)
+        if bareword is None:
+            continue
+        match = bareword.search(raw)
+        if match:
+            value = match.group(1).strip()
+            if value and value.lower() not in _BAREWORD_NON_VALUES:
+                label[key] = value
+                # Loud, not silent: this is how a recurring formatting failure
+                # stays visible instead of quietly costing labels again.
+                print(f'  Salvaged unquoted "{key}" value {value!r} from a '
+                      "malformed label object")
     return label
 
 
@@ -819,13 +866,21 @@ def _merge_label(old, new):
 
 
 def _incomplete_span_ids(spans, merged, source=None):
-    """Return ``(missing_ids, bad_role_ids)`` -- what a retry should ask for.
+    """Return ``(missing_ids, bad_role_ids, no_speaker_ids)`` -- what a retry asks for.
 
     Membership, never a count: live responses hallucinate ids past N (137
     labels for 41 spans in one logged response), so ``len(merged) >= len(spans)``
     would fake completeness. ``bad_role_ids`` mirrors resolve_span_labels'
-    role_missing condition exactly, so the retry predicate and the degradation
-    reason can never disagree.
+    role_missing condition exactly, and ``no_speaker_ids`` mirrors its
+    dialogue_without_speaker condition exactly, so the retry predicate and the
+    degradation reason can never disagree.
+
+    ``no_speaker_ids`` is the mirror image of ``bad_role_ids``: role is good and
+    says "dialogue", but no usable name came with it, so a voice is lost. Before
+    it existed such a label was neither missing, nor bad-role, nor unattested
+    (the attestation pass skips a label with no speaker), so the attempt loop
+    broke on attempt 1 and the span was narrated in silence -- observed on two
+    live chunks with 26/27 such labels and ZERO retry lines.
 
     When ``source`` is given, whitespace-only spans are skipped: the model was
     never shown them, so it cannot be "missing" one.
@@ -835,15 +890,26 @@ def _incomplete_span_ids(spans, merged, source=None):
 
     missing = [span.id for span in spans if span.id not in merged]
     bad_role = []
+    no_speaker = []
     for span in spans:
         label = merged.get(span.id)
-        if label is None or _usable_field("role", label.get("role")):
+        if label is None:
             continue
         raw_speaker = label.get("speaker")
         canonical = canonicalize(raw_speaker) if isinstance(raw_speaker, str) else ""
-        if canonical and canonical != NARRATOR:
-            bad_role.append(span.id)
-    return missing, bad_role
+        if not _usable_field("role", label.get("role")):
+            if canonical and canonical != NARRATOR:
+                bad_role.append(span.id)
+            continue
+        # Exactly resolve_span_labels' `role == "dialogue" and not canonical`
+        # branch, including its NARRATOR handling: NARRATOR canonicalizes to a
+        # truthy value, so a NARRATOR label is not asked about there and must
+        # not be asked about here either.
+        role = label.get("role")
+        role = role.strip().lower() if isinstance(role, str) else ""
+        if role == "dialogue" and not canonical:
+            no_speaker.append(span.id)
+    return missing, bad_role, no_speaker
 
 
 # Cap the id list in a nudge so a wholly-unlabelled chunk cannot balloon the prompt.
@@ -857,7 +923,8 @@ def _format_id_list(ids):
     return f"{head} (and {len(ids) - _NUDGE_ID_CAP} more)"
 
 
-def _retry_nudge(missing_ids, bad_role_ids, unattested=None):
+def _retry_nudge(missing_ids, bad_role_ids, unattested=None, no_speaker_ids=None,
+                 spelling_hints=None):
     """Correction text appended to the retry prompt.
 
     Appended AFTER .format(), so it cannot interact with the {context}/{chunk}
@@ -877,6 +944,12 @@ def _retry_nudge(missing_ids, bad_role_ids, unattested=None):
     if bad_role_ids:
         parts.append('These span ids had a "role" that was neither "dialogue" nor '
                      f'"narration": {_format_id_list(bad_role_ids)}.')
+    if no_speaker_ids:
+        parts.append('These span ids had role "dialogue" but no usable "speaker" '
+                     f'name: {_format_id_list(no_speaker_ids)}. For each one, give '
+                     "the speaking character's name exactly as the text spells it, "
+                     'or use "NARRATOR" with role "narration" if the span is not '
+                     "spoken dialogue.")
     if unattested:
         # Name the offending spelling AND say what to do instead. A bare "that
         # name is wrong" makes the model guess again; pointing it at the text
@@ -892,6 +965,21 @@ def _retry_nudge(missing_ids, bad_role_ids, unattested=None):
             'label the span "NARRATOR" with role "narration" if the text never '
             "names the speaker. Do not invent a name and do not guess at a "
             "spelling.")
+        # Candidate spellings, for the offenders where automatic repair DECLINED
+        # (an ambiguous or unsupported repair). A free hint, not a mechanism:
+        # per a28839d the prompt cannot enforce anything, so this only makes the
+        # right answer easier to find -- the gate still re-checks whatever comes
+        # back.
+        hints = []
+        for _, name in unattested:
+            candidates = (spelling_hints or {}).get(name) or []
+            if candidates:
+                hints.append(f'"{name}" (did you mean '
+                             + " or ".join(f'"{c}"' for c in candidates) + ")")
+        if hints:
+            parts.append("Established character spellings close to the rejected "
+                         "names, if one of them is who you meant: "
+                         + "; ".join(hints) + ".")
     parts.append("Return the JSON array again. It MUST contain one object for every id "
                  'listed above, and every "role" must be exactly "dialogue" or "narration".')
     return " ".join(parts)
@@ -928,23 +1016,70 @@ def _speaker_is_established(canonical, roster_index):
     return roster_key(canonical) in roster_index
 
 
-def _attestation_verdict(canonical, attest_window):
+def _attestation_verdict(canonical, attest_window, roster_index=None):
     """attest_speaker() over the one window the gate uses. Pure passthrough,
     factored out so the retry predicate and the acceptance gate cannot drift
     apart (the same mistake _incomplete_span_ids exists to prevent for roles).
+
+    ``roster_index`` enables speaker_canon's roster-name partial attestation:
+    a multi-token label built around an established name is UNVERIFIABLE
+    (accept-and-count) rather than refuted.
     """
-    return attest_speaker(canonical, [attest_window] if attest_window else [])
+    return attest_speaker(canonical, [attest_window] if attest_window else [],
+                          roster_index=roster_index)
+
+
+# Gate outcomes returned by _gate_speaker(). Named so the two call sites
+# compare against the same constants rather than re-spelling them.
+GATE_ESTABLISHED = "established"
+GATE_ATTESTED = "attested"
+GATE_UNVERIFIABLE = "unverifiable"
+GATE_REPAIRED = "repaired"
+GATE_REJECTED = "rejected"
+
+
+def _gate_speaker(canonical, attest_window, roster_index, source_words):
+    """THE attestation decision, in one place: ``(name, outcome)``.
+
+    Both the acceptance gate in resolve_span_labels and the retry predicate in
+    _unattested_speaker_ids call this and nothing else, so they cannot apply
+    different rules -- commit 2809180 exists because they once did, and a
+    property test now pins their agreement. Adding repair here rather than at
+    either call site is what keeps that property true for repaired labels too:
+    a label the gate silently repairs must NOT be one the retry nags about.
+
+    ``source_words`` is the whole book's folded word index; when it is empty
+    repair is simply unavailable and the outcome is a plain rejection, so a
+    caller that cannot supply it is never worse off than before.
+
+    Read-only: ``roster_index`` is not mutated here.
+    """
+    if _speaker_is_established(canonical, roster_index):
+        return canonical, GATE_ESTABLISHED
+    verdict = _attestation_verdict(canonical, attest_window, roster_index)
+    if verdict == UNATTESTED:
+        repaired = repair_speaker(
+            canonical, [attest_window] if attest_window else [],
+            roster_index or {}, source_words or set())
+        if repaired:
+            return repaired, GATE_REPAIRED
+        return canonical, GATE_REJECTED
+    if verdict == UNVERIFIABLE:
+        return canonical, GATE_UNVERIFIABLE
+    return canonical, GATE_ATTESTED
 
 
 def _unattested_speaker_ids(spans, merged, source=None, roster=None,
-                            attest_window=None):
+                            attest_window=None, source_words=None):
     """Return ``[(span_id, canonical_name), ...]`` for dialogue labels whose
     speaker the source does not support -- what a retry should ask about.
 
-    Mirrors the acceptance gate in resolve_span_labels exactly: same
-    established-roster shortcut, same verdict function, and only UNATTESTED
-    counts. UNVERIFIABLE never appears here, because a label our check cannot
-    evaluate is not something to nag the model about.
+    Mirrors the acceptance gate in resolve_span_labels exactly, because both go
+    through _gate_speaker(): same established-roster shortcut, same verdict,
+    same repair. Only a GATE_REJECTED outcome counts. UNVERIFIABLE never
+    appears here, because a label our check cannot evaluate is not something to
+    nag the model about -- and neither does a REPAIRED one, because the gate is
+    about to accept the repaired spelling.
 
     Read-only. Does not mutate ``roster``; a local copy tracks names accepted
     earlier in this same chunk so the shortcut behaves as it will at
@@ -969,17 +1104,53 @@ def _unattested_speaker_ids(spans, merged, source=None, roster=None,
             continue
         if is_placeholder_speaker(canonical):
             continue  # already rejected on its own terms
-        if _speaker_is_established(canonical, roster_index):
-            continue
-        if _attestation_verdict(canonical, attest_window) == UNATTESTED:
+        name, outcome = _gate_speaker(canonical, attest_window, roster_index,
+                                      source_words)
+        if outcome == GATE_REJECTED:
             offenders.append((span.id, canonical))
         else:
-            remember_in_roster(roster_index, canonical)
+            remember_in_roster(roster_index, name)
     return offenders
 
 
+def _report_repairs(chunk_num, total_chunks, repairs):
+    """Make every speaker repair visible: one console line per distinct repair
+    plus a per-repair record in the forensic log.
+
+    Contract 7 says degradation is loud, and a repair is the one gate outcome
+    that is neither a rejection nor an untouched acceptance: the script ends up
+    saying a name the model did not emit. A stat alone would leave an operator
+    unable to answer "where did this name come from?", so the original -> repaired
+    mapping goes into llm_responses.log next to the response it came from.
+    Never raises: a failure to WRITE the log must not lose a chunk's work.
+    """
+    if not repairs:
+        return
+
+    counts = {}
+    for original, repaired in repairs:
+        counts[(original, repaired)] = counts.get((original, repaired), 0) + 1
+
+    for (original, repaired), count in sorted(counts.items()):
+        print(f"  REPAIRED speaker label \"{original}\" -> \"{repaired}\" "
+              f"on {count} span(s): the book never spells it \"{original}\", and "
+              f"exactly one established name is one edit away")
+
+    try:
+        log_dir = llm_log_dir()
+        os.makedirs(log_dir, exist_ok=True)
+        with open(os.path.join(log_dir, "llm_responses.log"), "a",
+                  encoding="utf-8") as handle:
+            for (original, repaired), count in sorted(counts.items()):
+                handle.write(f"SPEAKER REPAIR | chunk {chunk_num}/{total_chunks} | "
+                             f"{original!r} -> {repaired!r} | {count} span(s)\n")
+    except OSError as exc:  # pragma: no cover - depends on the filesystem
+        print(f"  WARNING: could not record speaker repairs in the log ({exc})")
+
+
 def resolve_span_labels(spans, labels, source=None, roster=None,
-                        attest_window=None, require_attested=False):
+                        attest_window=None, require_attested=False,
+                        source_words=None):
     """Resolve each span to (span, speaker, instruct) using the LLM's labels.
 
     A span is NARRATOR unless a label exists for its id AND that label says
@@ -1027,6 +1198,17 @@ def resolve_span_labels(spans, labels, source=None, roster=None,
     designed to be paired with the retry nudge in process_chunk, which names
     the offending label and asks the model to copy the spelling from the text
     it was shown. Rejection is the fallback; re-asking is the fix.
+
+    BOUNDED REPAIR (``source_words``). Before refusing, a refuted label is
+    offered to speaker_canon.repair_speaker(), which folds it onto an already-
+    established spelling when -- and only when -- the whole book never uses the
+    label's spelling and exactly one roster name sits one edit away in the
+    label's own window. Repairs are reported in ``speakers_repaired`` and
+    itemized in ``repairs`` as (original, repaired) pairs; process_chunk prints
+    and logs each one, because rewriting a name the model did not emit must not
+    be silent (contract 7). ``source_words`` is speaker_canon.source_word_index()
+    over the whole book; without it repair is unavailable and the gate behaves
+    exactly as it did before.
     """
     valid_ids = {span.id for span in spans}
     # Local copy: never mutate the caller's roster index (see docstring).
@@ -1047,6 +1229,29 @@ def resolve_span_labels(spans, labels, source=None, roster=None,
             continue
         by_id[label_id] = label
 
+    # Schema hygiene, counted once per label that is actually used (by_id is
+    # already deduplicated). Only the strict-JSON path can carry keys outside
+    # the schema -- _extract_label_object builds its dicts from a fixed list of
+    # field names -- so a clean run stays silent here. Observed in production:
+    # a misspelled "instituct" silently cost the delivery direction on four
+    # chunks. Nothing is repaired and no unknown key is ever read (no fuzzy key
+    # matching -- see the banned approaches); the discard is only made visible.
+    unknown_key_labels = 0
+    unknown_keys = set()
+    text_key_labels = 0
+    for label in by_id.values():
+        extra = {key for key in label if key not in _LABEL_SCHEMA_KEYS}
+        if not extra:
+            continue
+        unknown_key_labels += 1
+        unknown_keys |= extra
+        if "text" in extra:
+            # Contract 1: the model returns labels only. A "text" key is not a
+            # typo, it is the model trying to supply book prose. It is ignored
+            # exactly like any other unknown key (entry text is always
+            # source[span.start:span.end]) but it is reported separately.
+            text_key_labels += 1
+
     resolved = []
     labelled = 0
     role_missing = 0
@@ -1055,6 +1260,7 @@ def resolve_span_labels(spans, labels, source=None, roster=None,
     unattested_rejected = 0
     unverifiable_accepted = 0
     dialogue_without_speaker = 0
+    repairs = []
 
     for span in spans:
         if source is not None and is_whitespace_span(span, source):
@@ -1104,14 +1310,20 @@ def resolve_span_labels(spans, labels, source=None, roster=None,
                 # which always skipped NARRATOR: the two must apply identical
                 # rules or the retry predicate and the degradation reason
                 # disagree, exactly as _incomplete_span_ids' docstring warns.
-                if (require_attested and canonical != NARRATOR
-                        and not _speaker_is_established(canonical, roster_index)):
-                    verdict = _attestation_verdict(canonical, attest_window)
-                    if verdict == UNATTESTED:
+                if require_attested and canonical != NARRATOR:
+                    name, outcome = _gate_speaker(
+                        canonical, attest_window, roster_index, source_words)
+                    if outcome == GATE_REJECTED:
                         accept = False
                         unattested_rejected += 1
-                    elif verdict == UNVERIFIABLE:
+                    elif outcome == GATE_UNVERIFIABLE:
                         unverifiable_accepted += 1
+                    elif outcome == GATE_REPAIRED:
+                        # Accepted, NOT counted as an offender -- but recorded,
+                        # because the script will now say a name the model
+                        # never wrote. process_chunk prints and logs these.
+                        repairs.append((canonical, name))
+                        canonical = name
 
                 if accept:
                     if roster_index is not None:
@@ -1148,7 +1360,12 @@ def resolve_span_labels(spans, labels, source=None, roster=None,
         "placeholder_rejected": placeholder_rejected,
         "unattested_rejected": unattested_rejected,
         "unverifiable_accepted": unverifiable_accepted,
+        "speakers_repaired": len(repairs),
+        "repairs": repairs,
         "dialogue_without_speaker": dialogue_without_speaker,
+        "unknown_key_labels": unknown_key_labels,
+        "unknown_keys": sorted(unknown_keys),
+        "text_key_labels": text_key_labels,
     }
 
 
@@ -1282,39 +1499,65 @@ def fix_mojibake(text):
     return text
 
 
+def _split_keeping_separators(text, separator_pattern):
+    """Split `text` on `separator_pattern`, keeping each separator attached to
+    the piece that PRECEDES it, so that ``"".join(pieces) == text`` exactly.
+
+    Lossless splitting is the whole point: the previous implementation used a
+    plain ``re.split`` + ``strip()``, which discarded the separator entirely on
+    the chunk-boundary path (the "\\n\\n" was only re-inserted when a paragraph
+    was appended to a chunk already in progress). That made the concatenation of
+    all chunks -- and therefore annotated_script.json -- differ from the source
+    file by one paragraph break per chunk seam. No prose was lost (every dropped
+    character was whitespace) but the paragraph-break signal at each seam was,
+    which the TTS layer hears as a missing pause.
+    """
+    pieces = []
+    pos = 0
+    for match in re.finditer(separator_pattern, text):
+        # A zero-width match cannot carry text forward; skip it.
+        if match.end() == pos:
+            continue
+        pieces.append(text[pos:match.end()])
+        pos = match.end()
+    if pos < len(text):
+        pieces.append(text[pos:])
+    return pieces
+
+
 def split_into_chunks(text, max_size=3000):
-    """Split text into chunks at paragraph/sentence boundaries."""
-    paragraphs = re.split(r'\n\s*\n', text)
+    """Split text into chunks at paragraph/sentence boundaries.
+
+    LOSSLESS: ``"".join(split_into_chunks(t)) == t`` for any input, including
+    leading/trailing whitespace, whitespace-only paragraphs and NBSPs. Every
+    character of the source ends up in exactly one chunk, in order; separators
+    ride along at the end of the paragraph they follow. Enforced by
+    test_api.py::test_chunking_is_byte_lossless_over_source.
+    """
+    # Paragraphs, each carrying its own trailing blank-line separator.
+    paragraphs = _split_keeping_separators(text, r'\n\s*\n')
 
     chunks = []
     current_chunk = ""
 
     for para in paragraphs:
-        para = para.strip()
-        if not para:
-            continue
+        if current_chunk and len(current_chunk) + len(para) > max_size:
+            chunks.append(current_chunk)
+            current_chunk = ""
 
-        if len(current_chunk) + len(para) + 2 > max_size:
-            if current_chunk:
-                chunks.append(current_chunk.strip())
-                current_chunk = ""
-
-            if len(para) > max_size:
-                sentences = re.split(r'(?<=[.!?])\s+', para)
-                for sentence in sentences:
-                    if len(current_chunk) + len(sentence) + 1 > max_size:
-                        if current_chunk:
-                            chunks.append(current_chunk.strip())
-                        current_chunk = sentence
-                    else:
-                        current_chunk += " " + sentence if current_chunk else sentence
-            else:
-                current_chunk = para
+        if len(para) > max_size:
+            # Oversized paragraph: fall back to sentence boundaries, again
+            # keeping the inter-sentence whitespace attached.
+            for sentence in _split_keeping_separators(para, r'(?<=[.!?])\s+'):
+                if current_chunk and len(current_chunk) + len(sentence) > max_size:
+                    chunks.append(current_chunk)
+                    current_chunk = ""
+                current_chunk += sentence
         else:
-            current_chunk += "\n\n" + para if current_chunk else para
+            current_chunk += para
 
     if current_chunk:
-        chunks.append(current_chunk.strip())
+        chunks.append(current_chunk)
 
     return chunks
 
@@ -1387,7 +1630,7 @@ def build_context(chunk_num, total_chunks, previous_entries=None,
     return "\n".join(context_parts)
 
 
-def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_entries=None, max_retries=2, system_prompt=None, user_prompt_template=None, max_tokens=4096, temperature=0.6, top_p=0.8, top_k=0, min_p=0, presence_penalty=0.0, banned_tokens=None, roster=None, max_context_roster_names=None, num_ctx=None, attest_window=None, require_attested=False, reasoning_effort=None):
+def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_entries=None, max_retries=2, system_prompt=None, user_prompt_template=None, max_tokens=4096, temperature=0.6, top_p=0.8, top_k=0, min_p=0, presence_penalty=0.0, banned_tokens=None, roster=None, max_context_roster_names=None, num_ctx=None, attest_window=None, require_attested=False, reasoning_effort=None, source_words=None):
     """Classify one chunk's spans and rebuild its script entries verbatim.
 
     Returns ``(entries, stats)``. ``stats`` reports span counts and whether the
@@ -1597,14 +1840,16 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
                 reason = "no usable labels recovered from LLM response"
             break  # keep whatever earlier attempts recovered
 
-        missing_ids, bad_role_ids = _incomplete_span_ids(spans, merged_labels, source=chunk)
+        missing_ids, bad_role_ids, no_speaker_ids = _incomplete_span_ids(
+            spans, merged_labels, source=chunk)
         unattested = (
             _unattested_speaker_ids(spans, merged_labels, source=chunk,
-                                    roster=roster, attest_window=attest_window)
+                                    roster=roster, attest_window=attest_window,
+                                    source_words=source_words)
             if require_attested else []
         )
 
-        if not missing_ids and not bad_role_ids and not unattested:
+        if not missing_ids and not bad_role_ids and not no_speaker_ids and not unattested:
             if attempt > 0:
                 print(f"  Succeeded on retry {attempt + 1} -- all {len(spans)} spans labelled")
             break
@@ -1620,13 +1865,22 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
                 gaps.append(f"{len(missing_ids)} span(s) unlabelled")
             if bad_role_ids:
                 gaps.append(f"{len(bad_role_ids)} label(s) with an unusable role")
+            if no_speaker_ids:
+                gaps.append(f"{len(no_speaker_ids)} dialogue label(s) with no speaker")
             if unattested:
                 gaps.append(f"{len(unattested)} speaker name(s) absent from the text "
                             f"({', '.join(name for _, name in unattested[:3])}"
                             f"{', ...' if len(unattested) > 3 else ''})")
             print(f"  {' and '.join(gaps)} -- retrying (attempt {attempt + 2}"
                   f"/{max_retries + 1}), naming the gaps")
-            retry_nudge = _retry_nudge(missing_ids, bad_role_ids, unattested)
+            spelling_hints = {
+                name: near_spellings(
+                    name, [attest_window] if attest_window else [], roster or {})
+                for _, name in unattested
+            }
+            retry_nudge = _retry_nudge(missing_ids, bad_role_ids, unattested,
+                                       no_speaker_ids=no_speaker_ids,
+                                       spelling_hints=spelling_hints)
             # Clear the refused speakers so the retry's answer can actually
             # land. _merge_label deliberately never overwrites a usable field
             # -- that is what makes "a retry can never make things worse" a
@@ -1651,7 +1905,9 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
     # on purpose: resolve_span_labels discards and counts them (once each).
     resolved, stats = resolve_span_labels(
         spans, list(merged_labels.values()), source=chunk, roster=roster,
-        attest_window=attest_window, require_attested=require_attested)
+        attest_window=attest_window, require_attested=require_attested,
+        source_words=source_words)
+    _report_repairs(chunk_num, total_chunks, stats.get("repairs"))
     entries = build_entries(resolved, chunk)
     _assert_chunk_verbatim(entries, chunk, chunk_num)
 
@@ -1689,6 +1945,15 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
 
     if stats["discarded"]:
         print(f"  Discarded {stats['discarded']} label(s) referring to nonexistent span ids")
+    if stats.get("unknown_key_labels"):
+        print(f"  Ignored unknown key(s) on {stats['unknown_key_labels']} label(s): "
+              + ", ".join(f'"{key}"' for key in stats["unknown_keys"])
+              + " -- not in the schema (id, speaker, role, instruct), so their "
+              "values were discarded (a misspelled key costs that field)")
+    if stats.get("text_key_labels"):
+        print(f"  {stats['text_key_labels']} label(s) carried a \"text\" key -- IGNORED. "
+              "The model must return labels only; entry text is always taken "
+              "verbatim from the source")
     if stats["role_missing"]:
         print(f"  {stats['role_missing']} label(s) named a speaker without role=\"dialogue\" "
               "-- narrated instead (schema violation by the model)")
@@ -1880,6 +2145,14 @@ def main():
 
     print(f"Split into {total_chunks} chunks at paragraph/sentence boundaries")
 
+    # Book-wide word index, built ONCE and only when the gate is on. It is what
+    # lets speaker_canon.repair_speaker() ask "does the author ever spell it
+    # this way?" -- a question a per-chunk window cannot answer, and the guard
+    # that keeps repair off real names that simply are not in their own window.
+    source_words = source_word_index(book_content) if require_attested else None
+    if require_attested:
+        print(f"Attestation gate ON; book word index: {len(source_words)} distinct words")
+
     all_entries = []
     # Roster index of speaker spellings established so far, threaded into every
     # chunk so a later spelling variant is snapped onto the established name
@@ -1892,6 +2165,8 @@ def main():
     total_placeholders = 0
     total_unattested = 0
     total_unverifiable = 0
+    total_repaired = 0
+    repair_mappings = {}
     truncation_events = 0
     prompt_samples = []
 
@@ -1927,6 +2202,7 @@ def main():
             attest_window=attest_window,
             require_attested=require_attested,
             reasoning_effort=reasoning_effort,
+            source_words=source_words,
         )
         all_entries.extend(entries)
         for entry in entries:
@@ -1938,6 +2214,10 @@ def main():
         total_placeholders += stats.get("placeholder_rejected", 0)
         total_unattested += stats.get("unattested_rejected", 0)
         total_unverifiable += stats.get("unverifiable_accepted", 0)
+        total_repaired += stats.get("speakers_repaired", 0)
+        for original, repaired in stats.get("repairs") or []:
+            repair_mappings[(original, repaired)] = (
+                repair_mappings.get((original, repaired), 0) + 1)
         truncation_events += stats.get("prompt_truncation_events", 0)
         if stats.get("prompt_tokens"):
             prompt_samples.append((stats.get("prompt_chars", 0), stats["prompt_tokens"]))
@@ -1966,6 +2246,13 @@ def main():
               "(name absent from the text near its own lines)")
         print(f"  Unverifiable speakers accepted: {total_unverifiable} "
               "(attestation does not apply to this text)")
+        # Loud by design (contract 7): these labels say a name the model never
+        # emitted. Not a degradation -- no voice was lost -- but an operator
+        # must be able to see, and audit, every rewrite.
+        print(f"  Speaker labels repaired:  {total_repaired} "
+              "(refuted spelling folded onto an established name)")
+        for (original, repaired), count in sorted(repair_mappings.items()):
+            print(f"    - \"{original}\" -> \"{repaired}\" ({count} span(s))")
     else:
         print("  Attestation gate:        off "
               "(generation.require_attested_speakers)")

--- a/app/generate_script.py
+++ b/app/generate_script.py
@@ -1373,7 +1373,7 @@ def build_context(chunk_num, total_chunks, previous_entries=None,
     return "\n".join(context_parts)
 
 
-def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_entries=None, max_retries=2, system_prompt=None, user_prompt_template=None, max_tokens=4096, temperature=0.6, top_p=0.8, top_k=0, min_p=0, presence_penalty=0.0, banned_tokens=None, roster=None, max_context_roster_names=None, num_ctx=None, attest_window=None, require_attested=False):
+def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_entries=None, max_retries=2, system_prompt=None, user_prompt_template=None, max_tokens=4096, temperature=0.6, top_p=0.8, top_k=0, min_p=0, presence_penalty=0.0, banned_tokens=None, roster=None, max_context_roster_names=None, num_ctx=None, attest_window=None, require_attested=False, reasoning_effort=None):
     """Classify one chunk's spans and rebuild its script entries verbatim.
 
     Returns ``(entries, stats)``. ``stats`` reports span counts and whether the
@@ -1455,12 +1455,32 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
                         # when unconfigured, so a request is byte-identical to
                         # before for anyone who does not set generation.num_ctx.
                         "options": {"num_ctx": num_ctx} if num_ctx else None,
+                        # Best-effort reasoning suppression, same omit-when-unset
+                        # rule. A "thinking" model can spend its ENTIRE
+                        # completion budget on reasoning and return empty
+                        # content -- see the empty-content check below for the
+                        # measured failure. reasoning_effort is a standard
+                        # OpenAI field, so a backend that does not implement it
+                        # ignores it rather than erroring.
+                        #
+                        # Sent via extra_body rather than as a named argument so
+                        # the value reaches the wire untouched regardless of
+                        # what the installed SDK's type hints allow.
+                        "reasoning_effort": reasoning_effort or None,
                     }.items() if v is not None
                 }
             )
 
             choice = response.choices[0]
-            text = choice.message.content.strip()
+            # `or ""`: a reasoning model returns content=None (not "") when it
+            # never leaves the reasoning phase, which would crash .strip().
+            text = (choice.message.content or "").strip()
+            # Ollama's OpenAI-compat layer puts reasoning in message.reasoning.
+            # Read for DIAGNOSTICS ONLY and never parsed for labels: the
+            # docstring at strip_thinking_tags records a live run where a
+            # <think> block salvaged 96 phantom span ids, so reasoning text is
+            # exactly the id-shaped noise that must not reach extract_labels.
+            reasoning_text = getattr(choice.message, "reasoning", None) or ""
             finish_reason = choice.finish_reason
             usage = getattr(response, 'usage', None)
 
@@ -1478,6 +1498,13 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
                 lf.write(f"CHUNK {chunk_num}/{total_chunks} | attempt {attempt + 1} | finish_reason={finish_reason}\n")
                 if usage:
                     lf.write(f"tokens: prompt={getattr(usage, 'prompt_tokens', '?')} completion={getattr(usage, 'completion_tokens', '?')}\n")
+                if reasoning_text:
+                    # Without this line the catastrophic case is a 166-byte log
+                    # block with no indication that 4096 tokens were spent
+                    # reasoning -- effectively undiagnosable.
+                    lf.write(f"reasoning: {len(reasoning_text)} chars "
+                             f"(not parsed; diagnostics only)\n")
+                    lf.write(f"reasoning_head: {reasoning_text[:300]!r}\n")
                 lf.write(f"{'─'*80}\n")
                 lf.write(text)
                 lf.write(f"\n{'='*80}\n")
@@ -1493,7 +1520,28 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
                     chunk_num, total_chunks, prompt_chars, prompt_tokens)
 
             truncated = finish_reason == "length"
-            if truncated:
+            if truncated and not text:
+                # The whole budget went to reasoning and NOTHING was emitted, so
+                # every span on this chunk is about to be narrated. Distinct from
+                # the ordinary truncation message below, which blames max_tokens
+                # and sends the operator to raise a setting that (a) is clamped
+                # to num_ctx minus the prompt anyway and (b) makes the request
+                # slow enough to hit llm.timeout. Measured: this model spent
+                # 4096 completion tokens and returned zero labels three times.
+                print(f"  {'!' * 60}")
+                print(f"  MODEL RETURNED NO CONTENT on chunk {chunk_num}/{total_chunks}: "
+                      f"finish_reason=length with an empty message body"
+                      + (f", and {len(reasoning_text)} chars of reasoning."
+                         if reasoning_text else "."))
+                print("  The model spent its entire completion budget 'thinking' and never")
+                print("  emitted the label array. Raising generation.max_tokens does NOT fix")
+                print("  this. Suppress reasoning instead:")
+                print('    - set llm.reasoning_effort to "none" in config.json (verified to')
+                print("      remove reasoning entirely on Ollama's /v1 endpoint)")
+                print("    - or use a non-reasoning model for annotation")
+                print("  NOTE: an Ollama-native \"think\": false is silently IGNORED on /v1.")
+                print(f"  {'!' * 60}")
+            elif truncated:
                 print(f"  WARNING: Response was truncated (hit max_tokens={max_tokens}). "
                       "Unlabelled spans will fall back to NARRATOR.")
 
@@ -1741,6 +1789,10 @@ def main():
     api_key = llm_config.get("api_key", "local")
     model_name = llm_config.get("model_name", "richardyoung/qwen3-14b-abliterated:Q8_0")
     timeout = llm_config.get("timeout")
+    # Optional reasoning suppression for "thinking" models. Unset = send
+    # nothing, so the request is unchanged for existing users. "none" is the
+    # value verified to work against Ollama's /v1 endpoint.
+    reasoning_effort = llm_config.get("reasoning_effort")
 
     # Load custom prompts or use defaults. Custom prompts are only honoured
     # when they target the current span-label schema (see select_prompt).
@@ -1860,6 +1912,7 @@ def main():
             num_ctx=num_ctx,
             attest_window=attest_window,
             require_attested=require_attested,
+            reasoning_effort=reasoning_effort,
         )
         all_entries.extend(entries)
         for entry in entries:

--- a/app/generate_script.py
+++ b/app/generate_script.py
@@ -1740,6 +1740,7 @@ def main():
     base_url = llm_config.get("base_url", "http://localhost:11434/v1")
     api_key = llm_config.get("api_key", "local")
     model_name = llm_config.get("model_name", "richardyoung/qwen3-14b-abliterated:Q8_0")
+    timeout = llm_config.get("timeout")
 
     # Load custom prompts or use defaults. Custom prompts are only honoured
     # when they target the current span-label schema (see select_prompt).
@@ -1791,10 +1792,21 @@ def main():
         print(f"Banned tokens: {banned_tokens}")
 
     # Create OpenAI client with custom base URL
-    client = OpenAI(
-        base_url=base_url,
-        api_key=api_key
-    )
+    # llm.timeout (seconds) overrides the OpenAI SDK's 600s default. Left out
+    # of the call entirely when unset, so the constructed client is identical
+    # to before for anyone who does not set it.
+    #
+    # This matters on slow local inference: a completion that needs longer than
+    # the ceiling is killed after producing nothing usable, and the run then
+    # retries it and is killed again. Measured on one local setup: 9.5 tok/s,
+    # so generation.max_tokens=8192 implies ~861s and a guaranteed timeout at
+    # the 600s default. Lowering max_tokens is the better first move -- this is
+    # for machines where even that is not enough.
+    client_kwargs = {"base_url": base_url, "api_key": api_key}
+    if timeout:
+        client_kwargs["timeout"] = timeout
+        print(f"LLM request timeout: {timeout}s (llm.timeout)")
+    client = OpenAI(**client_kwargs)
 
     # Split into chunks at natural boundaries
     chunks = split_into_chunks(book_content, max_size=chunk_size)

--- a/app/generate_script.py
+++ b/app/generate_script.py
@@ -1,3 +1,20 @@
+"""Stage 2b: turn a book into an annotated audiobook script.
+
+The LLM is an ANALYTICAL CLASSIFIER here, never a generator of book text.
+Code tokenizes each chunk into spans (span_tokenizer), sends the LLM span ids
+plus their text, and receives back ONLY labels --
+``{"id", "speaker", "role", "instruct"}``. Code then reassembles the script
+verbatim from the source string by span offsets. Consequences:
+
+* Truncated or malformed LLM output costs LABELS, never PROSE. Any span the
+  LLM did not label falls back to NARRATOR with its text intact.
+* A chunk's entries always concatenate byte-for-byte back to the chunk. That
+  is asserted in code (`_assert_chunk_verbatim`) -- a failure is a bug, not a
+  warning.
+* Degradation is never silent: it is counted, summarised, and surfaced as
+  exit code 3 (see the exit site in main()).
+"""
+
 import os
 import sys
 import json
@@ -5,13 +22,46 @@ import re
 import argparse
 from openai import OpenAI
 from default_prompts import DEFAULT_SYSTEM_PROMPT, DEFAULT_USER_PROMPT
+from span_tokenizer import tokenize, validate_spans
+from speaker_canon import canonicalize
 
 # Cap for single-speaker mode: entries at this size pass through
 # group_into_chunks (MAX_CHUNK_CHARS=500) as-is without further splitting.
 SINGLE_SPEAKER_MAX_CHARS = 500
 
-def clean_json_string(text):
-    """Clean and extract valid JSON array from LLM response."""
+# Canonical narrator label. Compared with `!= "NARRATOR"` in this file and in
+# review_script.py, so casing is load-bearing.
+NARRATOR = "NARRATOR"
+
+# Fallback voice directions when a span carries no usable "instruct".
+DEFAULT_NARRATOR_INSTRUCT = "Neutral, even narration."
+DEFAULT_CHARACTER_INSTRUCT = "Natural, in-character delivery."
+
+# Exit code used when the script was written but one or more chunks degraded.
+EXIT_DEGRADED = 3
+
+# Schema marker carried by BOTH halves of default_prompts.txt. A prompt saved
+# in config.json before this stage existed asks the LLM to rewrite the book
+# into speaker/text/instruct objects, which the span classifier cannot use --
+# every span would fall back to NARRATOR. Requiring the marker makes that
+# mismatch loud and self-healing instead of silent.
+PROMPT_SCHEMA_MARKER = "span-labels-v1"
+
+# How much of a previous entry's text to show as continuity context. Context is
+# input, not output -- a snippet is enough and keeps the prompt cheap.
+CONTEXT_SNIPPET_CHARS = 120
+
+def strip_thinking_tags(text):
+    """Remove reasoning-model thinking blocks from a raw response.
+
+    Factored out of clean_json_string so the regex salvagers can reuse the
+    exact same stripping. Reasoning text is full of id-like JSON fragments
+    ("...span {"id": 12...") that a bare regex salvage happily mistakes for
+    labels -- one live run salvaged 96 phantom ids out of a model's <think>
+    block. Strip first, then salvage.
+    """
+    if not text:
+        return text
     # Remove thinking tags (various formats used by different models)
     # GLM, DeepSeek, Qwen, etc. use different thinking tag formats
     text = re.sub(r'<think>[\s\S]*?</think>', '', text)
@@ -21,6 +71,12 @@ def clean_json_string(text):
     # Handle unclosed thinking tags (model started thinking but didn't close)
     text = re.sub(r'<think>[\s\S]*$', '', text)
     text = re.sub(r'<thinking>[\s\S]*$', '', text)
+    return text
+
+
+def clean_json_string(text):
+    """Clean and extract valid JSON array from LLM response."""
+    text = strip_thinking_tags(text)
 
     # Remove markdown code blocks
     if "```" in text:
@@ -176,6 +232,493 @@ def salvage_json_entries(json_text):
     return entries if entries else None
 
 
+# ---------------------------------------------------------------------------
+# Label schema: {"id", "speaker", "role", "instruct"}
+#
+# salvage_json_entries() above is the OLD speaker/text/instruct schema. It is
+# still exported and still used by review_script.py, so it is left untouched.
+# Everything below is the label schema used by the span classifier.
+# ---------------------------------------------------------------------------
+
+_LABEL_OBJECT_RE = re.compile(r'\{[^{}]*\}')
+_LABEL_ID_RE = re.compile(r'"id"\s*:\s*"?(\d+)"?')
+_LABEL_STRING_FIELD_RE = {
+    "speaker": re.compile(r'"speaker"\s*:\s*"((?:[^"\\]|\\.)*)"'),
+    "role": re.compile(r'"role"\s*:\s*"((?:[^"\\]|\\.)*)"'),
+    "instruct": re.compile(r'"instruct"\s*:\s*"((?:[^"\\]|\\.)*)"'),
+}
+
+
+def _unescape_json_string(raw):
+    """Decode a JSON string body (the bit between the quotes)."""
+    try:
+        return json.loads('"' + raw + '"')
+    except (json.JSONDecodeError, ValueError):
+        return raw.replace('\\"', '"').replace('\\n', '\n').replace('\\\\', '\\')
+
+
+def _label_id(label):
+    """Return a label's span id as an int, or None if it has no usable id."""
+    if not isinstance(label, dict):
+        return None
+    value = label.get("id")
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.isdigit():
+            return int(stripped)
+    return None
+
+
+def _extract_label_object(raw):
+    """Pull one label dict out of a (possibly truncated) JSON object fragment."""
+    id_match = _LABEL_ID_RE.search(raw)
+    if not id_match:
+        return None
+    label = {"id": int(id_match.group(1))}
+    for key, pattern in _LABEL_STRING_FIELD_RE.items():
+        match = pattern.search(raw)
+        if match:
+            label[key] = _unescape_json_string(match.group(1))
+    return label
+
+
+def salvage_label_entries(json_text):
+    """Regex-salvage label objects from malformed / truncated classifier output.
+
+    Field-order agnostic, and recovers a final object whose closing brace was
+    cut off by the token limit. Returns a list of label dicts, or None.
+    """
+    if not json_text:
+        return None
+
+    # Reasoning blocks are pure noise here and their id-like fragments would be
+    # salvaged as phantom labels. Strip before any regex touches the text.
+    json_text = strip_thinking_tags(json_text)
+    if not json_text:
+        return None
+
+    labels = []
+    for raw in _LABEL_OBJECT_RE.findall(json_text):
+        label = _extract_label_object(raw)
+        if label is not None:
+            labels.append(label)
+
+    # A truncated tail such as '{"id": 12, "speaker": "ELENA"' has no closing
+    # brace, so the scan above missed it. Recover it if it carries a speaker.
+    tail_start = json_text.rfind('{')
+    if tail_start > json_text.rfind('}'):
+        tail = _extract_label_object(json_text[tail_start:])
+        if tail is not None and tail.get("speaker"):
+            labels.append(tail)
+
+    return labels or None
+
+
+def parse_label_array(json_text):
+    """Strict array path: parse/repair a JSON array of labels. List or None."""
+    if not json_text:
+        return None
+
+    parsed = repair_json_array(json_text)
+    if parsed:
+        usable = [label for label in parsed if _label_id(label) is not None]
+        if usable:
+            return usable
+    return None
+
+
+def parse_label_response(json_text):
+    """Parse classifier output into label dicts. Returns a list or None."""
+    return parse_label_array(json_text) or salvage_label_entries(json_text)
+
+
+def _find_balanced(text, opener, closer):
+    """Return the first balanced ``opener``...``closer`` slice, string-aware."""
+    start = text.find(opener)
+    if start == -1:
+        return None
+
+    depth = 0
+    in_string = False
+    escape_next = False
+
+    for index, char in enumerate(text[start:], start):
+        if escape_next:
+            escape_next = False
+            continue
+        if char == '\\':
+            escape_next = True
+            continue
+        if char == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if char == opener:
+            depth += 1
+        elif char == closer:
+            depth -= 1
+            if depth == 0:
+                return text[start:index + 1]
+    return None
+
+
+def _strip_code_fences(text):
+    """Return the contents of the first fenced code block, or ``text`` itself."""
+    if "```" not in text:
+        return text
+    match = re.search(r'```(?:json)?\s*([\s\S]*?)```', text)
+    return match.group(1).strip() if match else text
+
+
+def labels_from_id_keyed_object(text):
+    """Recover an id-keyed JSON OBJECT instead of the requested array.
+
+    Observed live from qwen3:30b-a3b (thinking model), repeatedly::
+
+        {"1": {"speaker": "NARRATOR", "role": "narration", "instruct": "..."},
+         "2": {"speaker": "BILL", "role": "dialogue", "instruct": "..."}, ...}
+
+    This is valid JSON with complete, unambiguous labels -- only the envelope
+    is wrong -- so it is a first-class recovery, not a salvage: no prose is at
+    risk and no information is missing. The KEY is authoritative; a conflicting
+    inner "id" field is overwritten.
+    """
+    if not text:
+        return None
+
+    candidate = _strip_code_fences(strip_thinking_tags(text))
+    blob = _find_balanced(candidate, '{', '}')
+    if not blob:
+        return None
+
+    try:
+        parsed = json.loads(blob)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+    if not isinstance(parsed, dict) or not parsed:
+        return None
+
+    labels = []
+    for key, value in parsed.items():
+        # ALL keys must be integer-like, else this is an ordinary object
+        # (e.g. a single {"id": 1, "speaker": ...} label) and not a mapping.
+        if not isinstance(key, str) or not key.strip().isdigit():
+            return None
+        if not isinstance(value, dict):
+            return None
+        label = dict(value)
+        label["id"] = int(key.strip())
+        labels.append(label)
+
+    return labels or None
+
+
+# Markdown fallback. Headers seen live: "**id 1**", "**Span 1**" (both with
+# trailing markdown hard-break spaces); fields as "- **Speaker**: NARRATOR".
+_MD_HEADER_RE = re.compile(
+    r'^[ \t]*(?:#{1,6}[ \t]*)?(?:[-*+][ \t]*)?\*{0,2}[ \t]*(?:span|id)[ \t#]*(\d+)[ \t]*[:.)]?[ \t]*\*{0,2}[ \t]*$',
+    re.IGNORECASE | re.MULTILINE,
+)
+_MD_FIELD_RE = re.compile(
+    r'^[ \t]*(?:[-*+][ \t]*)?\*{0,2}[ \t]*(speaker|role|instruct)[ \t]*\*{0,2}[ \t]*[:=][ \t]*(.*?)[ \t]*$',
+    re.IGNORECASE | re.MULTILINE,
+)
+# Quote/emphasis characters wrapping a markdown field value.
+_MD_VALUE_TRIM = "\"'“”‘’*_`, \t"
+
+
+def salvage_markdown_labels(text):
+    """LAST-RESORT recovery of markdown label blocks (no JSON at all).
+
+    Observed live from qwen3:30b-a3b, consistently structured::
+
+        **id 1**
+        - **Speaker**: NARRATOR
+        - **Role**: narration
+        - **Instruct**: "Neutral, even narration."
+
+    Firing this means the model ignored the output contract, so the caller
+    marks the chunk degraded even though the labels are usable.
+    """
+    if not text:
+        return None
+
+    body = strip_thinking_tags(text)
+    if not body:
+        return None
+
+    headers = list(_MD_HEADER_RE.finditer(body))
+    if not headers:
+        return None
+
+    labels = []
+    for position, header in enumerate(headers):
+        block_end = headers[position + 1].start() if position + 1 < len(headers) else len(body)
+        block = body[header.end():block_end]
+
+        label = {"id": int(header.group(1))}
+        for field in _MD_FIELD_RE.finditer(block):
+            value = field.group(2).strip(_MD_VALUE_TRIM)
+            if value:
+                label[field.group(1).lower()] = value
+
+        # An id alone is not a label; require something to act on.
+        if "speaker" in label or "role" in label:
+            labels.append(label)
+
+    return labels or None
+
+
+# How the labels for a chunk were recovered, most faithful first.
+LABEL_MODE_ARRAY = "array"
+LABEL_MODE_OBJECT = "id-keyed object"
+LABEL_MODE_SALVAGE = "regex salvage"
+LABEL_MODE_MARKDOWN = "markdown salvage"
+
+
+def extract_labels(text):
+    """Recover labels from a raw LLM response. Returns ``(labels, mode)``.
+
+    Tried in descending fidelity: the requested JSON array, an id-keyed JSON
+    object, regex salvage of individual JSON objects (this is what survives a
+    truncation), then markdown blocks. ``(None, None)`` when nothing is usable.
+    """
+    if not text:
+        return None, None
+
+    json_text = clean_json_string(text)
+    if json_text:
+        labels = parse_label_array(json_text)
+        if labels:
+            return labels, LABEL_MODE_ARRAY
+
+    labels = labels_from_id_keyed_object(text)
+    if labels:
+        return labels, LABEL_MODE_OBJECT
+
+    # Salvage the cleaned array text when we have it, else the raw response:
+    # clean_json_string() returns None for a hard truncation with no closing
+    # bracket, which is exactly when salvage matters most.
+    labels = salvage_label_entries(json_text or text)
+    if labels:
+        return labels, LABEL_MODE_SALVAGE
+
+    labels = salvage_markdown_labels(text)
+    if labels:
+        return labels, LABEL_MODE_MARKDOWN
+
+    return None, None
+
+
+def select_prompt(custom_prompt, default_prompt, config_key):
+    """Choose between a saved custom prompt and the built-in default.
+
+    A custom prompt is honoured only when it carries PROMPT_SCHEMA_MARKER,
+    i.e. when it was written for the span-classifier schema. Anything older
+    targets the retired "rewrite the book into speaker/text/instruct" schema
+    and would produce label-less output, so it is rejected loudly and the
+    built-in default is used instead.
+    """
+    if not custom_prompt or not custom_prompt.strip():
+        return default_prompt
+
+    if PROMPT_SCHEMA_MARKER in custom_prompt:
+        return custom_prompt
+
+    print(f"  {'!' * 60}")
+    print(f"  WARNING: saved custom prompt '{config_key}' predates the span-classifier")
+    print(f"  pipeline (missing '{PROMPT_SCHEMA_MARKER}' marker) -- using the built-in")
+    print("  default instead. Re-customize starting from the new default if needed.")
+    print(f"  {'!' * 60}")
+    return default_prompt
+
+
+def build_span_payload(spans, source):
+    """Render spans as the numbered listing the classifier receives.
+
+    One JSON object per line: {"id", "kind", "text"}. The LLM sees the text so
+    it can classify it; it is instructed never to send text back.
+    """
+    return "\n".join(
+        json.dumps(
+            {"id": span.id, "kind": span.kind, "text": span.text(source)},
+            ensure_ascii=False,
+        )
+        for span in spans
+    )
+
+
+def _label_completeness(label):
+    """Rank a label so a complete one beats a truncated fragment for the same id.
+
+    A usable ``role`` is what actually decides the speaker, so it is the field
+    worth ranking on; ``instruct`` breaks remaining ties.
+    """
+    if not isinstance(label, dict):
+        return 0
+    role = label.get("role")
+    role = role.strip().lower() if isinstance(role, str) else ""
+    score = 2 if role in ("dialogue", "narration") else 0
+    raw_instruct = label.get("instruct")
+    if isinstance(raw_instruct, str) and raw_instruct.strip():
+        score += 1
+    return score
+
+
+def resolve_span_labels(spans, labels):
+    """Resolve each span to (span, speaker, instruct) using the LLM's labels.
+
+    A span is NARRATOR unless a label exists for its id AND that label says
+    role == "dialogue" AND its speaker canonicalizes to a non-empty name.
+    Labels for ids that do not exist are discarded. Returns
+    (resolved, stats_dict).
+    """
+    valid_ids = {span.id for span in spans}
+    by_id = {}
+    discarded = 0
+
+    for label in labels or []:
+        label_id = _label_id(label)
+        if label_id is None or label_id not in valid_ids:
+            discarded += 1
+            continue
+        existing = by_id.get(label_id)
+        if existing is not None and _label_completeness(existing) > _label_completeness(label):
+            # salvage_label_entries() can recover a truncated tail object for an
+            # id that already parsed cleanly. Never let the fragment overwrite
+            # the complete label; equal completeness keeps last-write-wins.
+            continue
+        by_id[label_id] = label
+
+    resolved = []
+    labelled = 0
+    role_missing = 0
+
+    for span in spans:
+        label = by_id.get(span.id)
+        speaker = NARRATOR
+        instruct = None
+
+        if label is not None:
+            labelled += 1
+            role = label.get("role")
+            role = role.strip().lower() if isinstance(role, str) else ""
+            raw_speaker = label.get("speaker")
+            canonical = canonicalize(raw_speaker) if isinstance(raw_speaker, str) else ""
+
+            if role == "dialogue" and canonical:
+                speaker = canonical
+            elif role not in ("dialogue", "narration") and canonical and canonical != NARRATOR:
+                # Contract says role decides. Honour it (NARRATOR is the safe
+                # direction: prose is preserved, only the voice changes), but
+                # count it so the warning tells the operator the model is
+                # emitting a schema we cannot fully trust.
+                role_missing += 1
+
+            raw_instruct = label.get("instruct")
+            if isinstance(raw_instruct, str) and raw_instruct.strip():
+                instruct = raw_instruct.strip()
+
+        resolved.append((span, speaker, instruct))
+
+    return resolved, {
+        "labelled": labelled,
+        "fallback": len(spans) - labelled,
+        "discarded": discarded,
+        "role_missing": role_missing,
+    }
+
+
+def _merge_same_speaker(groups):
+    """Collapse adjacent [speaker, text, instruct] groups sharing a speaker."""
+    merged = []
+    for speaker, text, instruct in groups:
+        if merged and merged[-1][0] == speaker:
+            merged[-1][1] += text
+            if merged[-1][2] is None:
+                merged[-1][2] = instruct
+        else:
+            merged.append([speaker, text, instruct])
+    return merged
+
+
+def _absorb_whitespace_groups(groups):
+    """Fold whitespace-only groups into a neighbour, keeping bytes identical.
+
+    The paragraph break between two speakers' lines is its own unquoted span,
+    so it can resolve to a group whose text is just "\\n\\n". Emitted as an
+    entry it is an unspeakable NARRATOR line that the editor UI can never
+    finish rendering -- hundreds per book. It belongs on the PRECEDING entry
+    (or the following one when it comes first), which changes no bytes.
+    """
+    absorbed = []
+    for group in groups:
+        if not group[1].strip() and absorbed:
+            absorbed[-1][1] += group[1]
+        else:
+            absorbed.append(group)
+
+    # A leading whitespace-only group has no predecessor: push it forward.
+    while len(absorbed) > 1 and not absorbed[0][1].strip():
+        absorbed[1][1] = absorbed[0][1] + absorbed[1][1]
+        del absorbed[0]
+
+    return absorbed
+
+
+def build_entries(resolved, source):
+    """Merge consecutive same-speaker spans into verbatim script entries.
+
+    Text is the exact concatenation of the group's source slices: quotes,
+    attribution tags and whitespace all survive untouched. No entry is ever
+    whitespace-only (see _absorb_whitespace_groups).
+    """
+    groups = _merge_same_speaker(
+        [[speaker, span.text(source), instruct] for span, speaker, instruct in resolved]
+    )
+    # Absorbing a whitespace group can make two same-speaker groups adjacent,
+    # so merge once more afterwards.
+    groups = _merge_same_speaker(_absorb_whitespace_groups(groups))
+
+    return [
+        {
+            "speaker": speaker,
+            "text": text,
+            "instruct": instruct or (
+                DEFAULT_NARRATOR_INSTRUCT if speaker == NARRATOR
+                else DEFAULT_CHARACTER_INSTRUCT
+            ),
+        }
+        for speaker, text, instruct in groups
+    ]
+
+
+def _assert_chunk_verbatim(entries, chunk, chunk_num):
+    """Byte-identity check. A mismatch is a bug in reassembly -- raise, never warn."""
+    rebuilt = "".join(entry["text"] for entry in entries)
+    if rebuilt == chunk:
+        return
+
+    offset = 0
+    limit = min(len(rebuilt), len(chunk))
+    while offset < limit and rebuilt[offset] == chunk[offset]:
+        offset += 1
+
+    raise AssertionError(
+        f"VERBATIM INVARIANT VIOLATED on chunk {chunk_num}: reassembled text "
+        f"({len(rebuilt)} chars) differs from source chunk ({len(chunk)} chars) "
+        f"at offset {offset}.\n"
+        f"  source   : {chunk[offset:offset + 80]!r}\n"
+        f"  rebuilt  : {rebuilt[offset:offset + 80]!r}"
+    )
+
+
 def fix_mojibake(text):
     """Fix common mojibake characters resulting from CP1252-as-UTF8."""
     replacements = {
@@ -230,12 +773,13 @@ def split_into_chunks(text, max_size=3000):
 
     return chunks
 
-def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_entries=None, max_retries=2, system_prompt=None, user_prompt_template=None, max_tokens=4096, temperature=0.6, top_p=0.8, top_k=0, min_p=0, presence_penalty=0.0, banned_tokens=None):
-    """Process a text chunk and return JSON script entries"""
-    # Use provided prompts or fall back to defaults
-    sys_prompt = system_prompt or DEFAULT_SYSTEM_PROMPT
-    usr_template = user_prompt_template or DEFAULT_USER_PROMPT
+def build_context(chunk_num, total_chunks, previous_entries=None):
+    """Positional note + speaker roster + a short tail of previous entries.
 
+    Context is INPUT, not output: a truncated snippet of each recent entry is
+    enough for tone/roster continuity and keeps the prompt cheap now that
+    narration entries can be long.
+    """
     context_parts = []
 
     if chunk_num == 1:
@@ -258,10 +802,43 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
         tail = previous_entries[-3:]
         context_parts.append("\nPrevious section ended with:")
         for entry in tail:
-            context_parts.append(json.dumps(entry, ensure_ascii=False))
+            text = entry.get("text", "")
+            if len(text) > CONTEXT_SNIPPET_CHARS:
+                text = text[:CONTEXT_SNIPPET_CHARS].rstrip() + "..."
+            context_parts.append(json.dumps(
+                {"speaker": entry.get("speaker", NARRATOR), "text": text},
+                ensure_ascii=False,
+            ))
 
-    context = "\n".join(context_parts)
-    user_prompt = usr_template.format(context=context, chunk=chunk)
+    return "\n".join(context_parts)
+
+
+def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_entries=None, max_retries=2, system_prompt=None, user_prompt_template=None, max_tokens=4096, temperature=0.6, top_p=0.8, top_k=0, min_p=0, presence_penalty=0.0, banned_tokens=None):
+    """Classify one chunk's spans and rebuild its script entries verbatim.
+
+    Returns ``(entries, stats)``. ``stats`` reports span counts and whether the
+    chunk degraded; ``entries`` ALWAYS reproduces the chunk byte-for-byte, even
+    when the LLM failed outright (the whole chunk then becomes NARRATOR).
+    """
+    # Use provided prompts or fall back to defaults
+    sys_prompt = system_prompt or DEFAULT_SYSTEM_PROMPT
+    usr_template = user_prompt_template or DEFAULT_USER_PROMPT
+
+    spans = tokenize(chunk)
+    validate_spans(spans, chunk)
+
+    if not spans:
+        return [], {"spans": 0, "labelled": 0, "fallback": 0, "discarded": 0,
+                    "role_missing": 0, "degraded": False, "reason": None,
+                    "recovery": None}
+
+    context = build_context(chunk_num, total_chunks, previous_entries)
+    user_prompt = usr_template.format(context=context, chunk=build_span_payload(spans, chunk))
+
+    labels = None
+    recovery = None
+    truncated = False
+    reason = None
 
     for attempt in range(max_retries + 1):
         try:
@@ -307,48 +884,83 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
                 print(f" | tokens: prompt={getattr(usage, 'prompt_tokens', '?')} completion={getattr(usage, 'completion_tokens', '?')}", end="")
             print()
 
-            if finish_reason == "length":
-                print(f"  WARNING: Response was truncated (hit max_tokens={max_tokens}). Consider increasing max_tokens.")
+            truncated = finish_reason == "length"
+            if truncated:
+                print(f"  WARNING: Response was truncated (hit max_tokens={max_tokens}). "
+                      "Unlabelled spans will fall back to NARRATOR.")
 
         except Exception as e:
             print(f"Error calling LLM API (attempt {attempt + 1}): {e}")
             if attempt < max_retries:
                 continue
-            return []
+            reason = f"LLM call failed on all {max_retries + 1} attempts ({e})"
+            break
 
-        # Clean and extract JSON from response
-        json_text = clean_json_string(text)
+        # Recover labels from whatever shape the model actually produced.
+        labels, recovery = extract_labels(text)
 
-        if not json_text:
-            print(f"Warning: Could not find JSON array in chunk {chunk_num} response (attempt {attempt + 1})")
-            if attempt < max_retries:
-                print("Retrying...")
-                continue
-            print(f"Response preview: {text[:300]}...")
-            return []
-
-        # Try to parse, with repair attempts
-        entries = repair_json_array(json_text)
-
-        if entries and len(entries) > 0:
+        if labels:
             if attempt > 0:
                 print(f"  Succeeded on retry {attempt + 1}")
-            return entries
+            if recovery == LABEL_MODE_OBJECT:
+                print(f"  Note: model returned an id-keyed JSON object instead of an array; "
+                      f"recovered all {len(labels)} label(s) from it")
+            elif recovery == LABEL_MODE_SALVAGE:
+                print(f"  Regex-salvaged {len(labels)} label(s) from a malformed/truncated response")
+            elif recovery == LABEL_MODE_MARKDOWN:
+                print(f"  Recovered {len(labels)} label(s) from markdown blocks "
+                      "(model ignored the JSON output contract)")
+            break
 
-        # If repair failed, show warning
-        print(f"Warning: Could not parse chunk {chunk_num} response as JSON (attempt {attempt + 1})")
-        print(f"JSON preview: {json_text[:300]}...")
+        print(f"Warning: Could not recover labels from chunk {chunk_num} response (attempt {attempt + 1})")
+        print(f"Response preview: {text[:300]}...")
 
         if attempt < max_retries:
-            print("Retrying with lower temperature...")
+            print("Retrying...")
+        else:
+            reason = "no usable labels recovered from LLM response"
 
-        # Last resort: extract individual valid entries with regex
-        salvaged_entries = salvage_json_entries(json_text)
-        if salvaged_entries:
-            print(f"Regex-salvaged {len(salvaged_entries)} entries from malformed response")
-            return salvaged_entries
+    # Reassemble regardless of what came back. Unlabelled spans -> NARRATOR,
+    # so a failure costs labels, never prose.
+    resolved, stats = resolve_span_labels(spans, labels)
+    entries = build_entries(resolved, chunk)
+    _assert_chunk_verbatim(entries, chunk, chunk_num)
 
-    return []
+    if truncated and reason is None:
+        reason = "response truncated at max_tokens"
+    if reason is None and recovery == LABEL_MODE_MARKDOWN:
+        # Labels are usable, but the model ignored the output contract entirely.
+        # Surface it: the next run may not be so structured.
+        reason = "labels recovered via markdown salvage (model returned no JSON)"
+    if reason is None and stats["fallback"] > 0:
+        reason = "LLM did not label every span"
+    if reason is None and stats["role_missing"] > 0:
+        # A model that labels every span but omits "role" produces a fully
+        # narrated book. Prose is intact, every voice is gone -- exactly the
+        # silent failure this stage exists to eliminate, so it degrades.
+        reason = (f"{stats['role_missing']} label(s) named a speaker without "
+                  "role=dialogue")
+
+    stats["spans"] = len(spans)
+    stats["recovery"] = recovery
+    stats["degraded"] = reason is not None
+    stats["reason"] = reason
+
+    if stats["discarded"]:
+        print(f"  Discarded {stats['discarded']} label(s) referring to nonexistent span ids")
+    if stats["role_missing"]:
+        print(f"  {stats['role_missing']} label(s) named a speaker without role=\"dialogue\" "
+              "-- narrated instead (schema violation by the model)")
+
+    if stats["degraded"]:
+        print(f"  {'!' * 60}")
+        print(f"  DEGRADED chunk {chunk_num}/{total_chunks}: {reason}.")
+        print(f"  {stats['labelled']}/{len(spans)} spans labelled, "
+              f"{stats['fallback']} fell back to NARRATOR. "
+              "All prose is preserved verbatim; only voice assignment is lost.")
+        print(f"  {'!' * 60}")
+
+    return entries, stats
 
 def _write_script_output(all_entries):
     """Write annotated_script.json and clear stale chunks.json."""
@@ -371,11 +983,18 @@ def run_single_speaker(book_content, speaker_name, instruct):
     """Bypass the LLM and emit one entry per text segment, all attributed
     to a single speaker. Used for first-person memoirs, non-fiction, etc.,
     where character detection is unnecessary."""
+    # Canonicalize: the default "Narrator" fails every `!= "NARRATOR"` literal
+    # comparison downstream (review_script.py) and misses voice-config lookups
+    # keyed on the canonical form.
+    canonical_speaker = canonicalize(speaker_name) or NARRATOR
+    if canonical_speaker != speaker_name:
+        print(f"Canonicalized speaker name: {speaker_name!r} -> {canonical_speaker!r}")
+
     segments = split_into_chunks(book_content, max_size=SINGLE_SPEAKER_MAX_CHARS)
     print(f"Split into {len(segments)} narration segments at paragraph/sentence boundaries")
 
     entries = [
-        {"speaker": speaker_name, "text": segment, "instruct": instruct}
+        {"speaker": canonical_speaker, "text": segment, "instruct": instruct}
         for segment in segments
     ]
 
@@ -434,10 +1053,13 @@ def main():
     api_key = llm_config.get("api_key", "local")
     model_name = llm_config.get("model_name", "richardyoung/qwen3-14b-abliterated:Q8_0")
 
-    # Load custom prompts or use defaults
+    # Load custom prompts or use defaults. Custom prompts are only honoured
+    # when they target the current span-label schema (see select_prompt).
     prompts_config = config.get("prompts", {})
-    system_prompt = prompts_config.get("system_prompt") or DEFAULT_SYSTEM_PROMPT
-    user_prompt_template = prompts_config.get("user_prompt") or DEFAULT_USER_PROMPT
+    system_prompt = select_prompt(
+        prompts_config.get("system_prompt"), DEFAULT_SYSTEM_PROMPT, "prompts.system_prompt")
+    user_prompt_template = select_prompt(
+        prompts_config.get("user_prompt"), DEFAULT_USER_PROMPT, "prompts.user_prompt")
 
     # Load generation settings
     generation_config = config.get("generation", {})
@@ -469,11 +1091,15 @@ def main():
     print(f"Split into {total_chunks} chunks at paragraph/sentence boundaries")
 
     all_entries = []
+    degraded_chunks = []
+    total_spans = 0
+    total_fallback = 0
+
     for i, chunk in enumerate(chunks, 1):
         print(f"Processing chunk {i}/{total_chunks} ({len(chunk)} chars)...")
 
         previous = all_entries if len(all_entries) > 0 else None
-        entries = process_chunk(
+        entries, stats = process_chunk(
             client, model_name, chunk, i, total_chunks,
             previous_entries=previous,
             system_prompt=system_prompt,
@@ -487,13 +1113,42 @@ def main():
             banned_tokens=banned_tokens
         )
         all_entries.extend(entries)
-        print(f"  Got {len(entries)} entries")
+        total_spans += stats["spans"]
+        total_fallback += stats["fallback"]
+        if stats["degraded"]:
+            degraded_chunks.append((i, stats["reason"]))
+
+        print(f"  Got {len(entries)} entries from {stats['spans']} spans "
+              f"({stats['labelled']} labelled, {stats['fallback']} narrator fallback)")
 
     if not all_entries:
         print("Error: No script entries generated")
         sys.exit(1)
 
+    # Always write the output first: the audiobook is complete either way.
     _write_script_output(all_entries)
+
+    print(f"\n{'=' * 60}")
+    print("Generation summary")
+    print(f"  Chunks processed:        {total_chunks}")
+    print(f"  Chunks degraded:         {len(degraded_chunks)}")
+    print(f"  Spans total:             {total_spans}")
+    print(f"  Spans fallback-labelled: {total_fallback} (read by NARRATOR)")
+    if degraded_chunks:
+        print("  Degradation events:")
+        for chunk_num, reason in degraded_chunks:
+            print(f"    - chunk {chunk_num}: {reason}")
+    print(f"{'=' * 60}")
+
+    if degraded_chunks:
+        print("\nWARNING: the script is COMPLETE (no prose was lost -- every span was "
+              "reassembled verbatim), but some spans could not be classified and are "
+              "attributed to NARRATOR. Review the script before rendering audio.")
+        # Exit 3 = "output written, but degraded". Distinct from 0 (clean) and
+        # from 1 (nothing produced). app.py's run_process() logs a nonzero code
+        # as "failed with return code 3", which is exactly the intent: silent
+        # degradation is what this stage exists to eliminate.
+        sys.exit(EXIT_DEGRADED)
 
 
 if __name__ == '__main__':

--- a/app/generate_script.py
+++ b/app/generate_script.py
@@ -13,6 +13,11 @@ verbatim from the source string by span offsets. Consequences:
   warning.
 * Degradation is never silent: it is counted, summarised, and surfaced as
   exit code 3 (see the exit site in main()).
+* A misspelled schema KEY is recovered (_recover_label_keys), a misspelled
+  speaker NAME is not (that is speaker_canon's job, under much tighter rules).
+  Keys come from this module's own four-word vocabulary; names come from the
+  book, where two near-identical spellings are routinely two people. "text" is
+  never a recovery target, so key recovery can never admit model prose.
 """
 
 import os
@@ -21,6 +26,7 @@ import json
 import re
 import argparse
 from openai import OpenAI
+from rapidfuzz.distance import Levenshtein
 from default_prompts import DEFAULT_SYSTEM_PROMPT, DEFAULT_USER_PROMPT
 from span_tokenizer import tokenize, validate_spans
 from speaker_canon import (
@@ -471,6 +477,64 @@ def _unescape_json_string(raw):
 # resolve_span_labels counts it so the discard is visible in the run log.
 _LABEL_SCHEMA_KEYS = frozenset(("id", "speaker", "role", "instruct"))
 
+# Keys a misspelling may be recovered onto. "text" is deliberately absent: under
+# contract 1 it is never read, so no recovery path can resurrect model-supplied
+# prose no matter what the model calls the field.
+_RECOVERABLE_LABEL_KEYS = ("id", "speaker", "role", "instruct")
+
+# Distance budget per target key: one edit per four characters, so the budget
+# grows with the room a key has to be misspelled in. "instruct" gets 2, "role"
+# and "speaker" get 1, "id" gets 0 -- "in" must never be recovered as "id".
+_KEY_EDIT_BUDGET = {key: len(key) // 4 for key in _RECOVERABLE_LABEL_KEYS}
+
+_NON_ALNUM_RE = re.compile(r"[^0-9a-z]+")
+
+
+def _normalize_key(key):
+    """Fold a key for comparison: case, spacing and punctuation are noise."""
+    return _NON_ALNUM_RE.sub("", key.lower())
+
+
+def _recover_label_keys(labels):
+    """Fold misspelled schema keys back onto the key they can only have meant.
+
+    This is NOT the banned fuzzy merging of speaker names. Names come from the
+    book and two near-identical ones are routinely two different people
+    (JON/JOHN); schema keys come from a four-word vocabulary this code publishes
+    in its own prompt, so a near miss has exactly one possible intended meaning.
+    The rule mirrors ``repair_speaker``: a bounded, exact edit distance (never a
+    similarity ratio), and a uniqueness guard -- a key near two schema keys, or
+    near none, is left alone for the unknown-key report in resolve_span_labels.
+
+    Measured cost of not doing this: in one 281-chunk run, 31 labels across 13
+    spellings ("instructor", "instruc", "in instruct", "instituct", ...) each
+    silently lost their delivery direction.
+    """
+    recovered = {}
+    for label in labels:
+        if not isinstance(label, dict):
+            continue
+        for key in [k for k in label if isinstance(k, str) and k not in _LABEL_SCHEMA_KEYS]:
+            normalized = _normalize_key(key)
+            if not normalized:
+                continue
+            near = [
+                target for target in _RECOVERABLE_LABEL_KEYS
+                if Levenshtein.distance(
+                    normalized, target, score_cutoff=_KEY_EDIT_BUDGET[target]
+                ) <= _KEY_EDIT_BUDGET[target]
+            ]
+            if len(near) != 1 or near[0] in label:
+                continue
+            label[near[0]] = label.pop(key)
+            recovered[(key, near[0])] = recovered.get((key, near[0]), 0) + 1
+
+    # Loud, not silent -- same reason as the salvaged-bareword print above.
+    for (key, target), count in sorted(recovered.items()):
+        print(f'  Recovered misspelled key "{key}" as "{target}" on '
+              f"{count} label(s)")
+    return labels
+
 
 def _label_id(label):
     """Return a label's span id as an int, or None if it has no usable id."""
@@ -564,7 +628,8 @@ def parse_label_array(json_text):
 
 def parse_label_response(json_text):
     """Parse classifier output into label dicts. Returns a list or None."""
-    return parse_label_array(json_text) or salvage_label_entries(json_text)
+    labels = parse_label_array(json_text) or salvage_label_entries(json_text)
+    return _recover_label_keys(labels) if labels else labels
 
 
 def _find_balanced(text, opener, closer):
@@ -719,7 +784,18 @@ def extract_labels(text):
     Tried in descending fidelity: the requested JSON array, an id-keyed JSON
     object, regex salvage of individual JSON objects (this is what survives a
     truncation), then markdown blocks. ``(None, None)`` when nothing is usable.
+
+    Misspelled schema keys are recovered here, at the one point every parse mode
+    passes through, so the retry predicate and the resolver always see the same
+    labels -- they have diverged twice before, and a key recovered on only one
+    side would be a third divergence.
     """
+    labels, mode = _extract_labels(text)
+    return (_recover_label_keys(labels) if labels else labels), mode
+
+
+def _extract_labels(text):
+    """extract_labels() without key recovery. See its docstring."""
     if not text:
         return None, None
 
@@ -1232,10 +1308,10 @@ def resolve_span_labels(spans, labels, source=None, roster=None,
     # Schema hygiene, counted once per label that is actually used (by_id is
     # already deduplicated). Only the strict-JSON path can carry keys outside
     # the schema -- _extract_label_object builds its dicts from a fixed list of
-    # field names -- so a clean run stays silent here. Observed in production:
-    # a misspelled "instituct" silently cost the delivery direction on four
-    # chunks. Nothing is repaired and no unknown key is ever read (no fuzzy key
-    # matching -- see the banned approaches); the discard is only made visible.
+    # field names -- so a clean run stays silent here. What reaches this point
+    # is what _recover_label_keys could NOT place: a key near two schema keys,
+    # or near none ("inquest", "infty"). Those are still never read; the discard
+    # is only made visible, so the residue of key recovery stays measurable.
     unknown_key_labels = 0
     unknown_keys = set()
     text_key_labels = 0

--- a/app/generate_script.py
+++ b/app/generate_script.py
@@ -1091,7 +1091,21 @@ def resolve_span_labels(spans, labels, source=None, roster=None,
                 # (NARRATOR, prose untouched). An established roster name
                 # skips the check entirely -- see the docstring.
                 accept = True
-                if require_attested and not _speaker_is_established(canonical, roster_index):
+                # NARRATOR is the narrator SENTINEL, not a character name, so it
+                # is never attested: the word "Narrator" does not appear in a
+                # novel, and gating it rejected the narrator itself. The outcome
+                # was unchanged (a refused speaker becomes NARRATOR, which it
+                # already was), but every chunk where the model wrote
+                # speaker=NARRATOR with role=dialogue -- which the prompt itself
+                # invites for an unidentifiable speaker -- was falsely reported
+                # DEGRADED, inflating unattested_rejected and forcing exit 3.
+                #
+                # This also restores agreement with _unattested_speaker_ids,
+                # which always skipped NARRATOR: the two must apply identical
+                # rules or the retry predicate and the degradation reason
+                # disagree, exactly as _incomplete_span_ids' docstring warns.
+                if (require_attested and canonical != NARRATOR
+                        and not _speaker_is_established(canonical, roster_index)):
                     verdict = _attestation_verdict(canonical, attest_window)
                     if verdict == UNATTESTED:
                         accept = False

--- a/app/generate_script.py
+++ b/app/generate_script.py
@@ -1128,10 +1128,12 @@ GATE_ESTABLISHED = "established"
 GATE_ATTESTED = "attested"
 GATE_UNVERIFIABLE = "unverifiable"
 GATE_REPAIRED = "repaired"
+GATE_REPAIR_REFUSED = "repair_refused"
 GATE_REJECTED = "rejected"
 
 
-def _gate_speaker(canonical, attest_window, roster_index, source_words):
+def _gate_speaker(canonical, attest_window, roster_index, source_words,
+                  following_text=None):
     """THE attestation decision, in one place: ``(name, outcome)``.
 
     Both the acceptance gate in resolve_span_labels and the retry predicate in
@@ -1145,6 +1147,25 @@ def _gate_speaker(canonical, attest_window, roster_index, source_words):
     repair is simply unavailable and the outcome is a plain rejection, so a
     caller that cannot supply it is never worse off than before.
 
+    ``following_text`` is the narration immediately after this span's quotation
+    (_closing_tag_text_by_id), or None when there is none. It VETOES a repair:
+    repair_speaker's guards are all about SPELLING -- is this spelling in the
+    book, is exactly one roster name one edit away, does the target appear in
+    this window -- and in a two-character scene both candidates appear in the
+    window, so the spelling evidence picks the wrong character as readily as the
+    right one. The adjacent attribution tag is the only cheap evidence about who
+    speaks THIS span, and it is checked against the REPAIRED name: when the tag
+    names a different established character, the repair is refused and the label
+    falls back to the plain rejection it would have had before repair existed
+    (GATE_REPAIR_REFUSED -> NARRATOR, counted, loud, contract 7).
+
+    That veto is deliberately NOT behind generation.check_attribution_tags. That
+    flag guards a check that JUDGES THE MODEL -- it spends retries and can
+    degrade a chunk over a label the model actually emitted. This one guards a
+    rewrite THIS PIPELINE performs: it can only withhold a name the model never
+    wrote, and its worst case is the behaviour the gate already promises. A
+    guard on our own rewrite needs no opt-in.
+
     Read-only: ``roster_index`` is not mutated here.
     """
     if _speaker_is_established(canonical, roster_index):
@@ -1155,6 +1176,8 @@ def _gate_speaker(canonical, attest_window, roster_index, source_words):
             canonical, [attest_window] if attest_window else [],
             roster_index or {}, source_words or set())
         if repaired:
+            if contradicts_attribution(repaired, following_text, roster_index or {}):
+                return canonical, GATE_REPAIR_REFUSED
             return repaired, GATE_REPAIRED
         return canonical, GATE_REJECTED
     if verdict == UNVERIFIABLE:
@@ -1169,7 +1192,10 @@ def _unattested_speaker_ids(spans, merged, source=None, roster=None,
 
     Mirrors the acceptance gate in resolve_span_labels exactly, because both go
     through _gate_speaker(): same established-roster shortcut, same verdict,
-    same repair. Only a GATE_REJECTED outcome counts. UNVERIFIABLE never
+    same repair, same adjacent-tag veto on that repair. A rejection counts
+    whether it is plain (GATE_REJECTED) or a refused repair
+    (GATE_REPAIR_REFUSED) -- both narrate the span, so both are worth a retry.
+    UNVERIFIABLE never
     appears here, because a label our check cannot evaluate is not something to
     nag the model about -- and neither does a REPAIRED one, because the gate is
     about to accept the repaired spelling.
@@ -1178,6 +1204,9 @@ def _unattested_speaker_ids(spans, merged, source=None, roster=None,
     earlier in this same chunk so the shortcut behaves as it will at
     resolution time.
     """
+    # Built from the FULL span list (before the visible filter) so adjacency is
+    # the tokenizer's, exactly as _tag_contradictions sees it.
+    tag_texts = _closing_tag_text_by_id(spans, source)
     if source is not None:
         spans = visible_spans(spans, source)
 
@@ -1198,8 +1227,8 @@ def _unattested_speaker_ids(spans, merged, source=None, roster=None,
         if is_placeholder_speaker(canonical):
             continue  # already rejected on its own terms
         name, outcome = _gate_speaker(canonical, attest_window, roster_index,
-                                      source_words)
-        if outcome == GATE_REJECTED:
+                                      source_words, tag_texts.get(span.id))
+        if outcome in (GATE_REJECTED, GATE_REPAIR_REFUSED):
             offenders.append((span.id, canonical))
         else:
             remember_in_roster(roster_index, name)
@@ -1210,6 +1239,39 @@ def _unattested_speaker_ids(spans, merged, source=None, roster=None,
 # NOT end on one is mid-quotation, so the narration after it is not a closing
 # attribution tag (see _tag_contradictions' bound).
 _CLOSING_QUOTES = "\"'”’»」』"
+
+
+def _closing_tag_text_by_id(spans, source):
+    """``{span_id: the narration right after this quotation}`` for every span a
+    closing attribution tag can be read from.
+
+    THE bounds, in one place, so the two consumers -- the post-hoc contradiction
+    report (_tag_contradictions) and the repair veto in _gate_speaker -- cannot
+    drift apart, and so there is exactly one tag-adjacency rule in the pipeline:
+
+      * the span must be QUOTED and end on a closing quote mark, so the tag
+        closes it rather than sitting mid-quotation;
+      * the very next span must be UNQUOTED and not whitespace-only (a
+        whitespace-only neighbour is the paragraph break, and a tag on the far
+        side of one introduces the NEXT quotation).
+
+    Parsing the tag itself is speaker_canon's job (attribution_tag_name /
+    contradicts_attribution); this returns raw source text only. Pure.
+    """
+    if source is None:
+        return {}
+    closing = tuple(_CLOSING_QUOTES)
+    texts = {}
+    for index, span in enumerate(spans[:-1]):
+        if span.kind != QUOTED:
+            continue
+        if not span.text(source).rstrip().endswith(closing):
+            continue
+        following = spans[index + 1]
+        if following.kind != UNQUOTED or is_whitespace_span(following, source):
+            continue
+        texts[span.id] = following.text(source)
+    return texts
 
 
 def _tag_contradictions(spans, speaker_by_id, source, roster_index):
@@ -1257,20 +1319,13 @@ def _tag_contradictions(spans, speaker_by_id, source, roster_index):
         return []
 
     contradictions = []
-    for index, span in enumerate(spans[:-1]):
-        speaker = speaker_by_id.get(span.id)
+    for span_id, following_text in _closing_tag_text_by_id(spans, source).items():
+        speaker = speaker_by_id.get(span_id)
         if not speaker or speaker == NARRATOR:
             continue
-        if span.kind != QUOTED:
-            continue
-        if not span.text(source).rstrip().endswith(tuple(_CLOSING_QUOTES)):
-            continue
-        following = spans[index + 1]
-        if following.kind != UNQUOTED or is_whitespace_span(following, source):
-            continue
-        tagged = contradicts_attribution(speaker, following.text(source), roster_index)
+        tagged = contradicts_attribution(speaker, following_text, roster_index)
         if tagged:
-            contradictions.append((span.id, speaker, tagged))
+            contradictions.append((span_id, speaker, tagged))
     return contradictions
 
 
@@ -1404,6 +1459,24 @@ def resolve_span_labels(spans, labels, source=None, roster=None,
     over the whole book; without it repair is unavailable and the gate behaves
     exactly as it did before.
 
+    A repair is VETOED by the attribution tag next to the same line whenever
+    that tag names a different established character (see _gate_speaker): the
+    label is then refused like any other unattested one -- NARRATOR, counted in
+    ``unattested_rejected``, itemized in ``refused_repairs`` and degrading the
+    chunk. This veto does not depend on ``check_tags``: it withholds one of THIS
+    pipeline's rewrites rather than judging the model's label, and its fallback
+    is the behaviour the gate already promises.
+
+    MEASURED on one 281-chunk production run replayed from its own logged
+    responses: 89 repairs, 26 of them next to a machine-readable attribution
+    tag, and all 26 tags AGREED with the repaired name -- so the veto refused 0
+    and that run's output is unchanged. The remaining 63 sat next to a pronoun
+    tag ("he said"), an action beat or nothing at all: no adjacent evidence
+    exists, nothing here can adjudicate them, and they are deliberately left
+    alone rather than guessed at. The veto is therefore cheap insurance against
+    a failure class, not a fix for a measured error rate; what makes the
+    unadjudicable majority visible is the repair block in the run summary.
+
     ATTRIBUTION-TAG CHECK (``check_tags``, off by default). After every speaker
     is decided, _tag_contradictions re-reads the result against the attribution
     tag in the span right after each quotation and counts the disagreements in
@@ -1465,6 +1538,8 @@ def resolve_span_labels(spans, labels, source=None, roster=None,
     unverifiable_accepted = 0
     dialogue_without_speaker = 0
     repairs = []
+    repairs_refused = []
+    tag_texts = _closing_tag_text_by_id(spans, source)
 
     for span in spans:
         if source is not None and is_whitespace_span(span, source):
@@ -1516,10 +1591,23 @@ def resolve_span_labels(spans, labels, source=None, roster=None,
                 # disagree, exactly as _incomplete_span_ids' docstring warns.
                 if require_attested and canonical != NARRATOR:
                     name, outcome = _gate_speaker(
-                        canonical, attest_window, roster_index, source_words)
+                        canonical, attest_window, roster_index, source_words,
+                        tag_texts.get(span.id))
                     if outcome == GATE_REJECTED:
                         accept = False
                         unattested_rejected += 1
+                    elif outcome == GATE_REPAIR_REFUSED:
+                        # A spelling repair was available but the tag next to
+                        # this very line names someone else, so the repair was
+                        # withheld and the label falls back to the plain
+                        # rejection. Counted in unattested_rejected too (it IS
+                        # one, and the chunk must degrade for it), and itemized
+                        # separately because "the repair was wrong here" is a
+                        # different thing for an operator to read than "the
+                        # model invented a name".
+                        accept = False
+                        unattested_rejected += 1
+                        repairs_refused.append(canonical)
                     elif outcome == GATE_UNVERIFIABLE:
                         unverifiable_accepted += 1
                     elif outcome == GATE_REPAIRED:
@@ -1578,6 +1666,8 @@ def resolve_span_labels(spans, labels, source=None, roster=None,
         "unverifiable_accepted": unverifiable_accepted,
         "speakers_repaired": len(repairs),
         "repairs": repairs,
+        "repairs_refused": len(repairs_refused),
+        "refused_repairs": repairs_refused,
         "dialogue_without_speaker": dialogue_without_speaker,
         "tag_contradictions": len(contradictions),
         "contradictions": contradictions,
@@ -2214,6 +2304,10 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
     if stats["unattested_rejected"]:
         print(f"  Rejected {stats['unattested_rejected']} speaker label(s) whose name does "
               "not appear in the text near their own lines -- narrated instead")
+    for original in stats.get("refused_repairs") or []:
+        print(f"  REFUSED to repair speaker label \"{original}\": a spelling repair was "
+              "available, but the narration right after this line attributes it to "
+              "another established character -- narrated instead")
     if stats.get("tag_contradictions"):
         for span_id, speaker, tagged in stats["contradictions"]:
             print(f"  CONTRADICTED speaker label on span {span_id}: labelled "
@@ -2435,6 +2529,7 @@ def main():
     total_unattested = 0
     total_unverifiable = 0
     total_repaired = 0
+    total_repairs_refused = 0
     total_contradicted = 0
     contradiction_examples = []
     repair_mappings = {}
@@ -2487,6 +2582,7 @@ def main():
         total_unattested += stats.get("unattested_rejected", 0)
         total_unverifiable += stats.get("unverifiable_accepted", 0)
         total_repaired += stats.get("speakers_repaired", 0)
+        total_repairs_refused += stats.get("repairs_refused", 0)
         total_contradicted += stats.get("tag_contradictions", 0)
         contradiction_examples.extend(
             (i, speaker, tagged) for _, speaker, tagged in stats.get("contradictions") or [])
@@ -2528,6 +2624,24 @@ def main():
               "(refuted spelling folded onto an established name)")
         for (original, repaired), count in sorted(repair_mappings.items()):
             print(f"    - \"{original}\" -> \"{repaired}\" ({count} span(s))")
+        print(f"  Speaker repairs refused:  {total_repairs_refused} "
+              "(the adjacent attribution tag named someone else; span narrated "
+              "and counted above as an unattested rejection)")
+        if total_repaired:
+            # Repairs are NOT folded into the degradation signal and do NOT
+            # change the exit code. Contract 7's exit 3 means "spans fell back
+            # to NARRATOR"; a repair keeps a character voice, and on a normal
+            # book there are dozens of them, so making them exit 3 would make
+            # exit 3 permanent and destroy the signal instead of sharpening it.
+            # What the wrong ones cost is a rejection -- which IS a fallback and
+            # DOES exit 3 -- via the tag veto above. The rest are visible here.
+            print(f"  {'!' * 58}")
+            print(f"  {total_repaired} speaker label(s) in this book say a name the model "
+                  "never emitted.")
+            print("  Each survived the spelling guards AND the attribution tag next to its")
+            print("  own line, but neither is proof of WHO speaks a line with no tag at all.")
+            print("  Audit the mappings above before rendering audio.")
+            print(f"  {'!' * 58}")
     else:
         print("  Attestation gate:        off "
               "(generation.require_attested_speakers)")

--- a/app/generate_script.py
+++ b/app/generate_script.py
@@ -23,7 +23,7 @@ import argparse
 from openai import OpenAI
 from default_prompts import DEFAULT_SYSTEM_PROMPT, DEFAULT_USER_PROMPT
 from span_tokenizer import tokenize, validate_spans
-from speaker_canon import canonicalize
+from speaker_canon import canonicalize, remember_in_roster, resolve_against_roster
 
 # Cap for single-speaker mode: entries at this size pass through
 # group_into_chunks (MAX_CHUNK_CHARS=500) as-is without further splitting.
@@ -50,6 +50,137 @@ PROMPT_SCHEMA_MARKER = "span-labels-v1"
 # How much of a previous entry's text to show as continuity context. Context is
 # input, not output -- a snippet is enough and keeps the prompt cheap.
 CONTEXT_SNIPPET_CHARS = 120
+
+# Cap on how many character names build_context()'s roster block may list.
+# Previously uncapped: a real 976-chunk run reached 577 names, a ~7,400-char
+# block (~2,000 tokens) growing monotonically for the whole book and crowding
+# out the span payload it exists to support.
+#
+# This is PROMPT HYGIENE, not a fix for speaker-name drift -- verified: the
+# drift observed in that run happened at chunks 379/380/430/442, while the
+# roster block was still well under any cap, so a smaller roster would not
+# have prevented it (speaker_canon's roster resolution is what handles that).
+# The justification is simply that an unbounded, monotonically growing block
+# is a defect on any long book on any server.
+#
+# Policy: keep the MOST RECENTLY SPOKEN names (a backwards pass over the
+# previous entries that stops at the cap), then present them alphabetically.
+# Recency, not frequency: the roster's job is spelling continuity for the
+# current scene's cast, and a character who last spoke 400 chunks ago is not
+# the one about to be misspelled here; frequency would instead favour
+# book-wide protagonists, the names least at risk of drift. Deterministic
+# given the same entries. Default 50: larger than any realistic single-scene
+# cast, ~650 chars. Override via generation.max_context_roster_names.
+MAX_CONTEXT_ROSTER_NAMES = 50
+
+# --- Silent prompt-truncation tripwire -------------------------------------
+#
+# A local server whose serving context window is smaller than the prompt does
+# not error: it silently drops the overflow and answers from what is left. A
+# real 976-chunk run spent its entire second half in this state (prompt_tokens
+# pinned at exactly 2050 for 640 of 1,294 records -- Ollama's default
+# num_ctx=2048), and the run summary was green throughout: the retry path
+# quietly papered over it, firing 318 extra calls. Nothing detected it.
+#
+# Detection compares the reported prompt_tokens against a chars/4 estimate of
+# the prompt actually sent. Warning only -- never a hard failure, never a
+# change in control flow -- because the estimate is a heuristic.
+PROMPT_CHARS_PER_TOKEN = 4
+
+# Warn when the estimate exceeds reported prompt_tokens by more than this
+# factor. The false-alarm direction is one-sided and understood: text with a
+# HIGH token density (CJK source text tokenizes to far more than one token per
+# 4 chars) pushes prompt_tokens UP relative to the estimate and therefore can
+# never trip this. Only unusually LOW-density text could, so the factor leaves
+# a 60% margin below the English baseline before saying anything.
+SILENT_TRUNCATION_RATIO = 1.6
+
+# Flatline detector thresholds (see detect_flatlined_prompt_tokens). The
+# per-call ratio check above only fires once the prompt is far past the cap;
+# a prompt sitting just above the window is truncated just as silently but
+# looks unremarkable per call. Across a run it does not: prompt_tokens stops
+# tracking prompt size and pins to one value. That is the production
+# signature, and it is nearly free to check.
+_FLATLINE_MIN_SAMPLES = 20
+_FLATLINE_SHARE = 0.25
+_FLATLINE_CHAR_SPREAD = 0.25
+
+
+def estimate_prompt_tokens(text):
+    """Rough token count for an assembled prompt. Deliberately crude."""
+    return len(text or "") // PROMPT_CHARS_PER_TOKEN
+
+
+def looks_silently_truncated(prompt_chars, prompt_tokens):
+    """True when reported ``prompt_tokens`` is implausibly low for a prompt of
+    ``prompt_chars`` characters, i.e. the server likely truncated it."""
+    if not prompt_tokens or prompt_tokens <= 0 or not prompt_chars:
+        return False
+    return prompt_chars // PROMPT_CHARS_PER_TOKEN > SILENT_TRUNCATION_RATIO * prompt_tokens
+
+
+def detect_flatlined_prompt_tokens(samples):
+    """Spot a prompt_tokens flatline across a run. Returns ``(value, count,
+    total)`` when one dominant value covers a large share of calls despite the
+    prompts themselves varying substantially in size, else ``None``.
+
+    ``samples`` is an iterable of ``(prompt_chars, prompt_tokens)`` pairs.
+    """
+    pairs = [(c, t) for c, t in samples if t and c]
+    if len(pairs) < _FLATLINE_MIN_SAMPLES:
+        return None
+
+    counts = {}
+    for _, tokens in pairs:
+        counts[tokens] = counts.get(tokens, 0) + 1
+    value, count = max(counts.items(), key=lambda kv: (kv[1], -kv[0]))
+    if count < _FLATLINE_SHARE * len(pairs):
+        return None
+
+    # If the prompts that produced that value were all the same size, a
+    # repeated token count is simply correct, not evidence of a cap.
+    sizes = [c for c, t in pairs if t == value]
+    if max(sizes) - min(sizes) < _FLATLINE_CHAR_SPREAD * max(sizes):
+        return None
+
+    return value, count, len(pairs)
+
+
+def _print_silent_truncation_warning(chunk_num, total_chunks, prompt_chars, prompt_tokens):
+    """Loud, actionable warning. Diagnostic only; control flow is unchanged."""
+    print(f"  {'!' * 60}")
+    print(f"  PROMPT LIKELY TRUNCATED BY THE SERVER on chunk {chunk_num}/{total_chunks}: "
+          f"sent {prompt_chars} chars (~{prompt_chars // PROMPT_CHARS_PER_TOKEN} "
+          f"est. tokens) but the server reported prompt_tokens={prompt_tokens}.")
+    print("  The model is being asked to classify spans it was never shown, so labels")
+    print("  degrade and retries fire needlessly. Raise the SERVER's context window:")
+    print("    - Ollama: OLLAMA_CONTEXT_LENGTH=8192 (env), or set generation.num_ctx")
+    print("      in config.json, or bake num_ctx into the model's Modelfile")
+    print("    - llama.cpp / vLLM: raise -c / --max-model-len")
+    print("  Alternatively lower generation.chunk_size or "
+          "generation.max_context_roster_names.")
+    print(f"  {'!' * 60}")
+
+
+# Placeholder speaker labels the model invents when it cannot identify a
+# speaker, despite the prompt telling it to use NARRATOR. A production run
+# produced 307 such entries ("SPEAKER 1", "SPEAKER 2", "VOICE 3", ...).
+#
+# The pattern is deliberately NARROW and language-neutral: one token followed
+# by a bare number, which is what an enumerated placeholder always looks like
+# in any language. It carries no word list, because this pipeline processes
+# translated text and an English stoplist would be both wrong and unbounded --
+# the lexical cases (SOMEONE, UNKNOWN, bare pronouns) are handled prompt-side
+# in default_prompts.txt instead. A real character name ending in a bare
+# number is vanishingly rare; such a label falls back to NARRATOR, which
+# preserves the prose and costs only a voice assignment.
+_PLACEHOLDER_LABEL_RE = re.compile(r'^\S+\s*\d+$')
+
+
+def is_placeholder_speaker(name):
+    """True for enumerated placeholder labels such as "SPEAKER 1"/"VOICE3"."""
+    return bool(name) and bool(_PLACEHOLDER_LABEL_RE.match(name.strip()))
+
 
 # Where raw LLM responses are logged. Production default; the test suite points
 # ALEXANDRIA_LLM_LOG_DIR at a tempdir so fixture responses never pollute the
@@ -723,7 +854,7 @@ def _label_completeness(label):
     return score
 
 
-def resolve_span_labels(spans, labels, source=None):
+def resolve_span_labels(spans, labels, source=None, roster=None):
     """Resolve each span to (span, speaker, instruct) using the LLM's labels.
 
     A span is NARRATOR unless a label exists for its id AND that label says
@@ -736,8 +867,20 @@ def resolve_span_labels(spans, labels, source=None):
     ``fallback``: the model was never shown them, so a missing label is not a
     failure. ``labelled`` stays inclusive of them so callers may continue to
     rely on ``labelled + fallback == spans``.
+
+    ``roster`` is an optional roster index (see speaker_canon.remember_in_roster)
+    of speaker names already established EARLIER in this book. When given, an
+    accepted speaker whose roster key matches an established name is normalized
+    onto that established spelling -- so the observed "ABBE MARIGNAN" ->
+    "ABBEMARIGNAN" drift cannot fork one character into two roster entries.
+    Exact-key only (spellings differing solely in whitespace/hyphens/
+    apostrophes); similar-but-distinct names (JON/JOHN) are never merged. The caller's dict is NOT mutated: a local copy is extended as
+    the chunk resolves, so a spelling first seen mid-chunk participates in the
+    same selection rule as the rest of the book.
     """
     valid_ids = {span.id for span in spans}
+    # Local copy: never mutate the caller's roster index (see docstring).
+    roster_index = dict(roster) if roster else None
     by_id = {}
     discarded = 0
 
@@ -758,6 +901,7 @@ def resolve_span_labels(spans, labels, source=None):
     labelled = 0
     role_missing = 0
     whitespace = 0
+    placeholder_rejected = 0
 
     for span in spans:
         if source is not None and is_whitespace_span(span, source):
@@ -779,7 +923,17 @@ def resolve_span_labels(spans, labels, source=None):
             raw_speaker = label.get("speaker")
             canonical = canonicalize(raw_speaker) if isinstance(raw_speaker, str) else ""
 
-            if role == "dialogue" and canonical:
+            if role == "dialogue" and canonical and is_placeholder_speaker(canonical):
+                # An invented enumerated placeholder ("SPEAKER 1") is not a
+                # character; it would fragment the roster and claim its own
+                # voice. NARRATOR is the safe direction -- prose is untouched.
+                placeholder_rejected += 1
+            elif role == "dialogue" and canonical:
+                # Roster-aware acceptance point: resolve the spelling against
+                # names already established in this book, then establish this
+                # one for the rest of the chunk.
+                if roster_index is not None:
+                    canonical = remember_in_roster(roster_index, canonical)
                 speaker = canonical
             elif role not in ("dialogue", "narration") and canonical and canonical != NARRATOR:
                 # Contract says role decides. Honour it (NARRATOR is the safe
@@ -802,6 +956,7 @@ def resolve_span_labels(spans, labels, source=None):
         "whitespace": whitespace,
         "discarded": discarded,
         "role_missing": role_missing,
+        "placeholder_rejected": placeholder_rejected,
     }
 
 
@@ -943,13 +1098,20 @@ def split_into_chunks(text, max_size=3000):
 
     return chunks
 
-def build_context(chunk_num, total_chunks, previous_entries=None):
+def build_context(chunk_num, total_chunks, previous_entries=None,
+                  max_roster_names=None):
     """Positional note + speaker roster + a short tail of previous entries.
 
     Context is INPUT, not output: a truncated snippet of each recent entry is
     enough for tone/roster continuity and keeps the prompt cheap now that
     narration entries can be long.
+
+    The roster block is capped at ``max_roster_names`` (default
+    MAX_CONTEXT_ROSTER_NAMES) most-recently-spoken names, and says so when it
+    truncates, so the model never infers the list is the book's full cast.
     """
+    if max_roster_names is None:
+        max_roster_names = MAX_CONTEXT_ROSTER_NAMES
     context_parts = []
 
     if chunk_num == 1:
@@ -960,13 +1122,35 @@ def build_context(chunk_num, total_chunks, previous_entries=None):
         context_parts.append(f"(Part {chunk_num} of {total_chunks})")
 
     if previous_entries and len(previous_entries) > 0:
-        # Build character roster for name consistency across chunks
-        characters_seen = sorted(set(
-            entry.get("speaker", "") for entry in previous_entries
-            if entry.get("speaker", "") and entry.get("speaker", "") != "NARRATOR"
-        ))
+        # Build character roster for name consistency across chunks. Walk
+        # backwards and STOP at the cap, so this stays O(cap) rather than
+        # rescanning the whole book every chunk; the names kept are therefore
+        # the most recently spoken ones (see MAX_CONTEXT_ROSTER_NAMES).
+        limit = max_roster_names if max_roster_names is not None else MAX_CONTEXT_ROSTER_NAMES
+        recent = []
+        seen = set()
+        truncated_roster = False
+        for entry in reversed(previous_entries):
+            speaker = entry.get("speaker", "")
+            if not speaker or speaker == NARRATOR or speaker in seen:
+                continue
+            if limit is not None and limit >= 0 and len(recent) >= limit:
+                # There is at least one older name we are not showing. Stopping
+                # here is why the header says "most recent N" and not
+                # "N of M" -- the total is deliberately not computed.
+                truncated_roster = True
+                break
+            seen.add(speaker)
+            recent.append(speaker)
+
+        characters_seen = sorted(recent)
+
         if characters_seen:
-            context_parts.append(f"Characters in this book: {', '.join(characters_seen)}")
+            # Say when the list is partial, so the model does not infer it is
+            # the book's complete cast.
+            header = (f"Characters in this book (most recent {len(characters_seen)})"
+                      if truncated_roster else "Characters in this book")
+            context_parts.append(f"{header}: {', '.join(characters_seen)}")
 
         # Include last few entries so the model can maintain style and tone continuity
         tail = previous_entries[-3:]
@@ -983,12 +1167,22 @@ def build_context(chunk_num, total_chunks, previous_entries=None):
     return "\n".join(context_parts)
 
 
-def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_entries=None, max_retries=2, system_prompt=None, user_prompt_template=None, max_tokens=4096, temperature=0.6, top_p=0.8, top_k=0, min_p=0, presence_penalty=0.0, banned_tokens=None):
+def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_entries=None, max_retries=2, system_prompt=None, user_prompt_template=None, max_tokens=4096, temperature=0.6, top_p=0.8, top_k=0, min_p=0, presence_penalty=0.0, banned_tokens=None, roster=None, max_context_roster_names=None, num_ctx=None):
     """Classify one chunk's spans and rebuild its script entries verbatim.
 
     Returns ``(entries, stats)``. ``stats`` reports span counts and whether the
     chunk degraded; ``entries`` ALWAYS reproduces the chunk byte-for-byte, even
     when the LLM failed outright (the whole chunk then becomes NARRATOR).
+
+    ``roster`` (optional, trailing keyword so existing callers/tests are
+    unaffected) is a roster index of speaker names established by previous
+    chunks; see resolve_span_labels.
+
+    ``num_ctx``, when set, asks the server for that serving context window via
+    ``extra_body={"options": {...}}`` (Ollama's documented option bag). It is
+    BEST EFFORT: a server that does not understand the key ignores it, which
+    is why the silent-truncation detection below is the part that is actually
+    guaranteed to work.
     """
     # Use provided prompts or fall back to defaults
     sys_prompt = system_prompt or DEFAULT_SYSTEM_PROMPT
@@ -999,8 +1193,10 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
 
     if not spans:
         return [], {"spans": 0, "labelled": 0, "fallback": 0, "whitespace": 0,
-                    "discarded": 0, "role_missing": 0, "degraded": False,
-                    "reason": None, "recovery": None}
+                    "discarded": 0, "role_missing": 0, "placeholder_rejected": 0,
+                    "degraded": False, "reason": None, "recovery": None,
+                    "prompt_chars": 0, "prompt_tokens": None,
+                    "prompt_truncation_events": 0}
 
     if not visible_spans(spans, chunk):
         # Nothing audible to classify (a chunk of pure whitespace). Resolve
@@ -1009,10 +1205,13 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
         entries = build_entries(resolved, chunk)
         _assert_chunk_verbatim(entries, chunk, chunk_num)
         stats.update({"spans": len(spans), "degraded": False,
-                      "reason": None, "recovery": None})
+                      "reason": None, "recovery": None,
+                      "prompt_chars": 0, "prompt_tokens": None,
+                      "prompt_truncation_events": 0})
         return entries, stats
 
-    context = build_context(chunk_num, total_chunks, previous_entries)
+    context = build_context(chunk_num, total_chunks, previous_entries,
+                            max_roster_names=max_context_roster_names)
     base_prompt = usr_template.format(context=context, chunk=build_span_payload(spans, chunk))
 
     # Labels accumulate ACROSS attempts, filling blanks only (see _merge_label),
@@ -1025,6 +1224,9 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
     truncated = False
     reason = None
     retry_nudge = ""
+    prompt_chars = 0
+    prompt_tokens = None
+    prompt_truncation_events = 0
 
     for attempt in range(max_retries + 1):
         try:
@@ -1043,6 +1245,10 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
                         "top_k": top_k if top_k else None,
                         "min_p": min_p if min_p else None,
                         "banned_tokens": banned_tokens if banned_tokens else None,
+                        # Best-effort context-window request. Omitted entirely
+                        # when unconfigured, so a request is byte-identical to
+                        # before for anyone who does not set generation.num_ctx.
+                        "options": {"num_ctx": num_ctx} if num_ctx else None,
                     }.items() if v is not None
                 }
             )
@@ -1051,6 +1257,11 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
             text = choice.message.content.strip()
             finish_reason = choice.finish_reason
             usage = getattr(response, 'usage', None)
+
+            # Size of what we actually sent, for the silent-truncation
+            # tripwire and for the forensic log.
+            prompt_chars = len(sys_prompt) + len(base_prompt) + len(retry_nudge)
+            prompt_tokens = getattr(usage, 'prompt_tokens', None) if usage else None
 
             # Log raw response for debugging
             log_dir = llm_log_dir()
@@ -1069,6 +1280,11 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
             if usage:
                 print(f" | tokens: prompt={getattr(usage, 'prompt_tokens', '?')} completion={getattr(usage, 'completion_tokens', '?')}", end="")
             print()
+
+            if looks_silently_truncated(prompt_chars, prompt_tokens):
+                prompt_truncation_events += 1
+                _print_silent_truncation_warning(
+                    chunk_num, total_chunks, prompt_chars, prompt_tokens)
 
             truncated = finish_reason == "length"
             if truncated:
@@ -1141,7 +1357,8 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
     # Reassemble regardless of what came back. Unlabelled spans -> NARRATOR,
     # so a failure costs labels, never prose. Phantom ids stay in the merged map
     # on purpose: resolve_span_labels discards and counts them (once each).
-    resolved, stats = resolve_span_labels(spans, list(merged_labels.values()), source=chunk)
+    resolved, stats = resolve_span_labels(
+        spans, list(merged_labels.values()), source=chunk, roster=roster)
     entries = build_entries(resolved, chunk)
     _assert_chunk_verbatim(entries, chunk, chunk_num)
 
@@ -1161,6 +1378,9 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
                   "role=dialogue")
 
     stats["spans"] = len(spans)
+    stats["prompt_chars"] = prompt_chars
+    stats["prompt_tokens"] = prompt_tokens
+    stats["prompt_truncation_events"] = prompt_truncation_events
     stats["recovery"] = recovery
     stats["degraded"] = reason is not None
     stats["reason"] = reason
@@ -1170,6 +1390,9 @@ def process_chunk(client, model_name, chunk, chunk_num, total_chunks, previous_e
     if stats["role_missing"]:
         print(f"  {stats['role_missing']} label(s) named a speaker without role=\"dialogue\" "
               "-- narrated instead (schema violation by the model)")
+    if stats["placeholder_rejected"]:
+        print(f"  Rejected {stats['placeholder_rejected']} invented placeholder speaker "
+              "label(s) (e.g. \"SPEAKER 1\") -- narrated instead")
 
     if stats["degraded"]:
         print(f"  {'!' * 60}")
@@ -1290,10 +1513,18 @@ def main():
     min_p = generation_config.get("min_p", 0)
     presence_penalty = generation_config.get("presence_penalty", 0.0)
     banned_tokens = generation_config.get("banned_tokens", [])
+    max_context_roster_names = generation_config.get(
+        "max_context_roster_names", MAX_CONTEXT_ROSTER_NAMES)
+    # Optional, best-effort serving-context-window request. Left as None when
+    # unset so the outgoing request is unchanged for existing users.
+    num_ctx = generation_config.get("num_ctx")
 
     print(f"Connecting to: {base_url}")
     print(f"Using model: {model_name}")
     print(f"Chunk size: {chunk_size} chars, Max tokens: {max_tokens}")
+    if num_ctx:
+        print(f"Requesting server context window (num_ctx): {num_ctx} "
+              "(best effort -- ignored by servers that do not support it)")
     if banned_tokens:
         print(f"Banned tokens: {banned_tokens}")
 
@@ -1310,9 +1541,17 @@ def main():
     print(f"Split into {total_chunks} chunks at paragraph/sentence boundaries")
 
     all_entries = []
+    # Roster index of speaker spellings established so far, threaded into every
+    # chunk so a later spelling variant is snapped onto the established name
+    # (speaker_canon.remember_in_roster): of two spellings that differ only in
+    # their boundary marks, the more-punctuated one wins, order-independently.
+    roster_index = {}
     degraded_chunks = []
     total_spans = 0
     total_fallback = 0
+    total_placeholders = 0
+    truncation_events = 0
+    prompt_samples = []
 
     for i, chunk in enumerate(chunks, 1):
         print(f"Processing chunk {i}/{total_chunks} ({len(chunk)} chars)...")
@@ -1329,11 +1568,22 @@ def main():
             top_k=top_k,
             min_p=min_p,
             presence_penalty=presence_penalty,
-            banned_tokens=banned_tokens
+            banned_tokens=banned_tokens,
+            roster=roster_index,
+            max_context_roster_names=max_context_roster_names,
+            num_ctx=num_ctx,
         )
         all_entries.extend(entries)
+        for entry in entries:
+            speaker = entry.get("speaker")
+            if speaker and speaker != NARRATOR:
+                remember_in_roster(roster_index, speaker)
         total_spans += stats["spans"]
         total_fallback += stats["fallback"]
+        total_placeholders += stats.get("placeholder_rejected", 0)
+        truncation_events += stats.get("prompt_truncation_events", 0)
+        if stats.get("prompt_tokens"):
+            prompt_samples.append((stats.get("prompt_chars", 0), stats["prompt_tokens"]))
         if stats["degraded"]:
             degraded_chunks.append((i, stats["reason"]))
 
@@ -1353,6 +1603,20 @@ def main():
     print(f"  Chunks degraded:         {len(degraded_chunks)}")
     print(f"  Spans total:             {total_spans}")
     print(f"  Spans fallback-labelled: {total_fallback} (read by NARRATOR)")
+    print(f"  Placeholder labels rejected: {total_placeholders}")
+    print(f"  Prompt-truncation warnings: {truncation_events}")
+    flatline = detect_flatlined_prompt_tokens(prompt_samples)
+    if flatline:
+        value, count, total = flatline
+        print(f"  {'!' * 58}")
+        print(f"  SERVER CONTEXT WINDOW SUSPECT: prompt_tokens was exactly {value} on "
+              f"{count} of {total} calls,")
+        print("  despite the prompts varying substantially in size -- the hallmark of a")
+        print("  server silently truncating prompts to a fixed window. The book was")
+        print("  classified from partial prompts. Raise the server's context length")
+        print("  (e.g. OLLAMA_CONTEXT_LENGTH, or generation.num_ctx in config.json)")
+        print("  and re-run for materially better speaker attribution.")
+        print(f"  {'!' * 58}")
     if degraded_chunks:
         print("  Degradation events:")
         for chunk_num, reason in degraded_chunks:

--- a/app/project.py
+++ b/app/project.py
@@ -22,6 +22,124 @@ from pydub import AudioSegment
 
 MAX_CHUNK_CHARS = 500
 
+# Sentence-ending punctuation, used ONLY to choose WHERE to cut an over-long
+# entry -- never to rewrite, expand or normalize text. A data table of
+# punctuation conventions, in the same spirit as span_tokenizer.PAIRED_QUOTES:
+# adding a script is a data change here, not a logic change. This is not a
+# word list and carries no language knowledge beyond "this glyph ends a
+# sentence".
+_SENTENCE_ENDERS = (
+    ".!?"            # Latin and most European scripts
+    "。！？"  # 。！？  CJK ideographic full stop / full-width ! ?
+    "؟"         # ؟  Arabic question mark
+    "۔"         # ۔  Urdu full stop
+    "।॥"   # ।॥ Devanagari danda / double danda
+    "…"         # …  ellipsis
+)
+
+
+def split_long_text(text, max_chars=MAX_CHUNK_CHARS):
+    """Split `text` into pieces of at most `max_chars` characters, cutting at
+    the most natural boundary available.
+
+    WHY THIS EXISTS: group_into_chunks() caps how much it will MERGE, but a
+    single script entry longer than the cap was previously passed through
+    whole -- nothing between annotated_script.json and the TTS call bounded
+    entry length, and tts.py has no splitter. On a real book this sent
+    entries of up to 2934 characters (measured; 271 of 7862 chunks, 3.4%,
+    exceeded the 500-char cap) to an engine the pipeline itself considers safe
+    only to 500. Long inputs are where TTS silently truncates or degrades, and
+    neither _assert_chunk_verbatim (which compares entries to their source
+    chunk, upstream of here) nor the word-coverage invariant (which reads the
+    script, not the audio) can see it.
+
+    VERBATIM: ``"".join(split_long_text(t)) == t`` for every input. This
+    function only chooses cut POINTS; it never inserts, deletes or rewrites a
+    character, so the audiobook still reads the author's text exactly.
+
+    Boundary preference, most natural first:
+      1. paragraph break (blank line)
+      2. single line break
+      3. sentence-ending punctuation followed by whitespace
+      4. any whitespace
+      5. a hard cut at max_chars -- the unavoidable fallback for scripts that
+         do not delimit words with spaces (Chinese, Japanese, Thai), where
+         there is no whitespace to find and a hard cut is the only option.
+
+    Whitespace at a cut point stays with the LEFT piece, which is what keeps
+    the join byte-exact.
+    """
+    if not text or max_chars <= 0 or len(text) <= max_chars:
+        return [text] if text else []
+
+    pieces = []
+    remaining = text
+    while len(remaining) > max_chars:
+        window = remaining[:max_chars]
+        cut = -1
+
+        # 1/2. Line structure. Search the window for the rightmost break and
+        # keep the newline(s) with the left piece.
+        for marker in ("\n\n", "\n"):
+            found = window.rfind(marker)
+            if found > 0:
+                cut = found + len(marker)
+                break
+
+        # 3. Sentence end followed by whitespace.
+        if cut <= 0:
+            for index in range(len(window) - 1, 0, -1):
+                if window[index].isspace() and window[index - 1] in _SENTENCE_ENDERS:
+                    cut = index + 1
+                    break
+
+        # 4. Any whitespace.
+        if cut <= 0:
+            for index in range(len(window) - 1, 0, -1):
+                if window[index].isspace():
+                    cut = index + 1
+                    break
+
+        # 5. Hard cut. No boundary exists inside the window.
+        if cut <= 0:
+            cut = max_chars
+
+        pieces.append(remaining[:cut])
+        remaining = remaining[cut:]
+
+    if remaining:
+        pieces.append(remaining)
+    return pieces
+
+
+def _split_oversize_chunks(chunks, max_chars=MAX_CHUNK_CHARS):
+    """Return `chunks` with any over-long chunk replaced by several pieces.
+
+    Applied AFTER grouping so the merge logic above is untouched. Each piece
+    keeps the chunk's speaker and instruct; only the LAST piece keeps the
+    original ``pause_after``, and the earlier pieces are pinned to 0 ms so
+    splitting a paragraph does not introduce a same-speaker pause in the
+    middle of a sentence (combine_audio_with_pauses treats an override of 0
+    as "no gap", so this is silence-neutral).
+    """
+    result = []
+    for chunk in chunks:
+        text = chunk.get("text") or ""
+        if len(text) <= max_chars:
+            result.append(chunk)
+            continue
+
+        pieces = split_long_text(text, max_chars)
+        last = len(pieces) - 1
+        for index, piece in enumerate(pieces):
+            result.append(_make_chunk(
+                chunk.get("speaker"),
+                piece,
+                chunk.get("instruct"),
+                chunk.get("pause_after") if index == last else 0,
+            ))
+    return result
+
 def get_speaker(entry):
     """Get speaker from entry, checking both 'speaker' and 'type' fields."""
     return entry.get("speaker") or entry.get("type") or ""
@@ -47,7 +165,14 @@ def _make_chunk(speaker, text, instruct, pause_after=None):
 
 
 def group_into_chunks(script_entries, max_chars=MAX_CHUNK_CHARS):
-    """Group consecutive entries by same speaker into chunks up to max_chars"""
+    """Group consecutive entries by same speaker into chunks up to max_chars.
+
+    `max_chars` bounds the result in BOTH directions: it caps how much this
+    merges, and (via _split_oversize_chunks) it also caps a single entry that
+    arrives longer than the limit on its own. Before that split existed, an
+    entry of any length passed straight through to the TTS engine -- see
+    split_long_text for the measured impact.
+    """
     if not script_entries:
         return []
 
@@ -94,7 +219,7 @@ def group_into_chunks(script_entries, max_chars=MAX_CHUNK_CHARS):
     # Don't forget the last chunk
     chunks.append(_make_chunk(current_speaker, current_text, current_instruct, current_pause_after))
 
-    return chunks
+    return _split_oversize_chunks(chunks, max_chars)
 
 logger = logging.getLogger(__name__)
 
@@ -184,8 +309,11 @@ class ProjectManager:
         `tts.resolve_voice`, the single shared resolver used by every
         voice_config lookup that feeds synthesis (project.py and tts.py
         alike), which tries an exact-key match, then a canonicalized-key
-        match, then a scan of voice_config keys by canonical form, then
-        follows the alias_of/alias chain (cycle-safe, max 8 hops).
+        match, then a scan of voice_config keys by canonical form, then the
+        gendered-title migration shim (so a voice_config.json written before
+        canonicalize() preserved Mr/Mrs/Mme/... still voices today's
+        "MISTER SMITH"), then follows the alias_of/alias chain (cycle-safe,
+        max 8 hops).
 
         Returns the resolved key, or `speaker` unchanged if it is falsy or
         no resolution strategy finds a match (preserves this method's

--- a/app/project.py
+++ b/app/project.py
@@ -554,7 +554,28 @@ class ProjectManager:
         )
 
     def _load_chunks_with_audio(self):
-        """Load chunks and pair each with its AudioSegment. Returns list of (chunk, segment)."""
+        """Load chunks and pair each with its AudioSegment. Returns list of (chunk, segment).
+
+        The format is passed explicitly instead of letting pydub probe for it.
+        A bare ``from_file()`` calls ``mediainfo_json()``, which spawns an
+        ffprobe subprocess PER FILE -- on a book-length script that is one
+        subprocess per line, ~8,700 of them, purely to re-discover that a file
+        this pipeline wrote itself is the format its own extension says.
+
+        That probe is also where a merge hung. Observed on Windows: the reader
+        thread inside ``subprocess.communicate()`` waited forever on an ffprobe
+        that had already exited but whose pipe handles were never released --
+        the process showed as a zombie, unkillable, so the whole merge stalled
+        with no timeout and no log line after every chunk had been synthesized.
+        The same file parsed in milliseconds from a shell and had merged
+        successfully in an earlier run, so the fault is the subprocess churn,
+        not the audio.
+
+        pydub skips the probe entirely when a codec is given (``if codec: info
+        = None`` in AudioSegment.from_file), so naming both removes the whole
+        class of failure and halves the subprocesses a merge spawns. Falls back
+        to the probing path for an unrecognized extension rather than guessing.
+        """
         chunks = self.load_chunks()
         result = []
         for chunk in chunks:
@@ -564,8 +585,12 @@ class ProjectManager:
             full_path = os.path.join(self.root_dir, path)
             if not os.path.exists(full_path):
                 continue
+            extension = os.path.splitext(full_path)[1].lstrip(".").lower()
+            load_kwargs = {}
+            if extension in ("mp3", "wav", "flac", "ogg"):
+                load_kwargs = {"format": extension, "codec": extension}
             try:
-                segment = AudioSegment.from_file(full_path)
+                segment = AudioSegment.from_file(full_path, **load_kwargs)
                 result.append((chunk, segment))
             except Exception as e:
                 print(f"Error loading audio segment {path}: {e}")

--- a/app/project.py
+++ b/app/project.py
@@ -15,7 +15,8 @@ from tts import (
     compute_timeline,
     sanitize_filename,
     DEFAULT_PAUSE_MS,
-    SAME_SPEAKER_PAUSE_MS
+    SAME_SPEAKER_PAUSE_MS,
+    resolve_voice,
 )
 from pydub import AudioSegment
 
@@ -65,7 +66,15 @@ def group_into_chunks(script_entries, max_chars=MAX_CHUNK_CHARS):
         if (speaker == current_speaker and instruct == current_instruct
                 and not _is_structural_text(current_text)
                 and not _is_structural_text(text)):
-            combined = current_text + " " + text
+            # Entries now carry their own boundary whitespace verbatim (the
+            # pipeline is byte-verbatim end to end). Only inject a joining
+            # space when NEITHER adjacent side already has boundary
+            # whitespace -- legacy/stripped entries still get a readable
+            # join, but verbatim entries that already touch a space/newline
+            # at their boundary are joined byte-exact, with no space added
+            # that was never in the source.
+            needs_space = bool(current_text) and bool(text) and not current_text[-1].isspace() and not text[0].isspace()
+            combined = current_text + (" " if needs_space else "") + text
             if len(combined) <= max_chars:
                 current_text = combined
                 # Last merged entry's pause_after wins
@@ -165,30 +174,26 @@ class ProjectManager:
         return []
 
     def _resolve_alias(self, speaker, voice_config):
-        """Resolve speaker aliases by following `alias_of` chain in voice_config.
+        """Resolve a raw speaker label to the voice_config key used for TTS.
 
-        Prevent infinite loops by limiting chain length.
-        Returns the canonical speaker name (string).
+        Canonical-aware: voice_config is keyed by canonical UPPERCASE
+        speaker names (per app.py's build_voice_roster / speaker_canon),
+        but `speaker` here may be a raw, non-canonical label straight out
+        of chunks.json / annotated_script.json (e.g. mixed-case "Narrator",
+        or a pre-refactor project's "Mr. Mark"). Delegates to
+        `tts.resolve_voice`, the single shared resolver used by every
+        voice_config lookup that feeds synthesis (project.py and tts.py
+        alike), which tries an exact-key match, then a canonicalized-key
+        match, then a scan of voice_config keys by canonical form, then
+        follows the alias_of/alias chain (cycle-safe, max 8 hops).
+
+        Returns the resolved key, or `speaker` unchanged if it is falsy or
+        no resolution strategy finds a match (preserves this method's
+        original "never returns None" contract for existing callers).
         """
         if not speaker:
             return speaker
-        name = speaker
-        seen = set()
-        for _ in range(8):
-            if name in seen:
-                logger.warning(f"Alias cycle detected for speaker '{speaker}': chain visited {seen}")
-                break
-            seen.add(name)
-            entry = voice_config.get(name, {})
-            alias = entry.get('alias_of') or entry.get('alias')
-            if not alias:
-                break
-            # If alias is empty or same, stop
-            if not isinstance(alias, str) or alias.strip() == '' or alias == name:
-                break
-            # Continue resolution
-            name = alias
-        return name
+        return resolve_voice(voice_config, speaker) or speaker
 
     def save_chunks(self, chunks):
         with self._chunks_lock:

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -12,3 +12,5 @@ transformers==4.57.3
 peft==0.18.1
 python-multipart==0.0.27
 aiofiles==24.1.0
+rapidfuzz==3.14.5
+wetext==0.1.6

--- a/app/review_script.py
+++ b/app/review_script.py
@@ -325,7 +325,8 @@ def review_batch(client, model_name, batch_entries, batch_num, total_batches,
                  previous_tail=None, source_context=None, max_retries=2,
                  system_prompt=None, user_prompt_template=None,
                  max_tokens=8000, temperature=0.4, top_p=0.8, top_k=20,
-                 min_p=0, presence_penalty=0.0, banned_tokens=None):
+                 min_p=0, presence_penalty=0.0, banned_tokens=None,
+                 reasoning_effort=None):
     """Send a batch of script entries through the LLM for review and correction."""
     sys_prompt = system_prompt or REVIEW_SYSTEM_PROMPT
     usr_template = user_prompt_template or REVIEW_USER_PROMPT
@@ -366,12 +367,17 @@ def review_batch(client, model_name, batch_entries, batch_num, total_batches,
                         "top_k": top_k,
                         "min_p": min_p,
                         "banned_tokens": banned_tokens if banned_tokens else None,
+                        # See generate_script.process_chunk: omitted when unset,
+                        # so the request is unchanged for existing users.
+                        "reasoning_effort": reasoning_effort or None,
                     }.items() if v is not None
                 }
             )
 
             choice = response.choices[0]
-            text = choice.message.content.strip()
+            # `or ""`: a reasoning model returns content=None when it never
+            # leaves the reasoning phase, which would crash .strip().
+            text = (choice.message.content or "").strip()
             finish_reason = choice.finish_reason
             usage = getattr(response, 'usage', None)
 
@@ -610,6 +616,10 @@ def main():
     if _timeout:
         _client_kwargs["timeout"] = _timeout
     client = OpenAI(**_client_kwargs)
+    # llm.reasoning_effort: see generate_script.process_chunk. Review is the
+    # same shape of call against the same model, so it has the same exposure to
+    # a thinking model burning its budget and returning nothing.
+    reasoning_effort = llm_config.get("reasoning_effort")
 
     all_corrected = []
     # "text_changed"/"entries_added"/"entries_removed" are intentionally
@@ -669,7 +679,8 @@ def main():
                 top_k=top_k,
                 min_p=min_p,
                 presence_penalty=presence_penalty,
-                banned_tokens=banned_tokens
+                banned_tokens=banned_tokens,
+                reasoning_effort=reasoning_effort
             )
 
             if corrected is None:
@@ -740,7 +751,8 @@ def main():
                 top_k=top_k,
                 min_p=min_p,
                 presence_penalty=presence_penalty,
-                banned_tokens=banned_tokens
+                banned_tokens=banned_tokens,
+                reasoning_effort=reasoning_effort
             )
 
             if corrected is None:

--- a/app/review_script.py
+++ b/app/review_script.py
@@ -306,9 +306,24 @@ def review_batch(client, model_name, batch_entries, batch_num, total_batches,
 
 
 def normalize_text(text):
-    """Normalize text for comparison: lowercase, collapse whitespace, strip punctuation."""
+    """Normalize text for comparison: lowercase, collapse whitespace, strip punctuation.
+
+    Punctuation is replaced with a SPACE (not deleted outright) before the
+    whitespace collapse. Deleting it outright used to fuse words across a
+    punctuation boundary that abuts two words with no space of its own
+    (e.g. `he said:--"Sicut` -> `saidsicut`). That fusion happens
+    differently depending on whether the text was normalized as one long
+    string (whole source) or as separately-normalized, then word-joined,
+    entries (per span) -- because entry/span boundaries often fall exactly
+    at a quote mark. The mismatch is a false alarm: no characters are
+    actually gained or lost, only whether two words end up glued together
+    by this normalization. Replacing with a space first means both sides of
+    every comparison tokenize identically regardless of where the
+    normalization boundary falls, since a punctuation mark that used to
+    silently disappear now always leaves a token separator behind.
+    """
     text = text.lower()
-    text = re.sub(r'[^\w\s]', '', text)
+    text = re.sub(r'[^\w\s]', ' ', text)
     text = re.sub(r'\s+', ' ', text).strip()
     return text
 

--- a/app/review_script.py
+++ b/app/review_script.py
@@ -6,7 +6,7 @@ import argparse
 from openai import OpenAI
 from review_prompts import REVIEW_SYSTEM_PROMPT, REVIEW_USER_PROMPT
 from generate_script import clean_json_string, repair_json_array, salvage_json_entries
-from speaker_canon import canonicalize
+from speaker_canon import canonicalize, remember_in_roster, resolve_against_roster
 
 # Marker embedded in both halves of review_prompts.txt (see the file itself)
 # identifying prompts written for the current positional-overlay review
@@ -64,7 +64,25 @@ def _canonicalize_speakers(entries):
     return result
 
 
-def apply_positional_overlay(batch, corrected):
+def build_script_roster(entries):
+    """Roster index of the speaker spellings already present in a script.
+
+    Spelling collisions are settled by remember_in_roster's rule (most
+    boundary marks wins, ties to the incumbent), which is
+    order-independent -- so this roster and generation's agree even though
+    they are built in different orders. Pass the result to
+    apply_positional_overlay so a reviewer's spelling variant is snapped back
+    onto the established name instead of forking the roster.
+    """
+    index = {}
+    for entry in entries or ():
+        speaker = entry.get("speaker") if isinstance(entry, dict) else None
+        if speaker:
+            remember_in_roster(index, speaker)
+    return index
+
+
+def apply_positional_overlay(batch, corrected, roster=None):
     """Overlay LLM speaker/instruct corrections onto the ORIGINAL batch text.
 
     This is the hard, structural guarantee against text damage: "text" is
@@ -95,8 +113,16 @@ def apply_positional_overlay(batch, corrected):
         # the voices roster and mute it at render time. Fall back to the
         # original (canonicalized) speaker whenever the correction is empty,
         # not only when the "speaker" key is absent entirely.
-        corrected_speaker = canonicalize(corr.get("speaker") or "")
-        new_entry["speaker"] = corrected_speaker or canonicalize(orig.get("speaker", ""))
+        #
+        # `roster` (optional, see build_script_roster) additionally snaps a
+        # correction onto an established spelling from the same script when
+        # the two differ only in their boundary marks -- whitespace, hyphens,
+        # apostrophes ("ABBEMARIGNAN" -> "ABBE MARIGNAN", "OBRIEN" ->
+        # "O'BRIEN"). Exact roster-key equality only -- similar-but-distinct
+        # names (JON/JOHN, ELLA/BELLA) are never merged.
+        corrected_speaker = resolve_against_roster(corr.get("speaker") or "", roster or {})
+        new_entry["speaker"] = corrected_speaker or resolve_against_roster(
+            orig.get("speaker", ""), roster or {})
 
         # Instruct: only accept a non-empty string from the LLM. None, a
         # list/dict, or a whitespace-only string is rejected in favor of the
@@ -512,6 +538,11 @@ def main():
 
     print(f"Loaded {len(entries)} script entries for review")
 
+    # Established speaker spellings for this script, built once. Threaded
+    # into every apply_positional_overlay() call so a reviewer's spelling
+    # variant is snapped back onto the name the script already uses.
+    script_roster = build_script_roster(entries)
+
     # Load source text if provided (mode 2 prep)
     source_text = None
     if args.source:
@@ -649,7 +680,7 @@ def main():
                 previous_tail = batch[-2:] if len(batch) >= 2 else batch
                 continue
 
-            accepted = apply_positional_overlay(batch, corrected)
+            accepted = apply_positional_overlay(batch, corrected, roster=script_roster)
 
             # Safety net only: the positional overlay always takes "text"
             # from the original batch, so this can never actually fail. If
@@ -720,7 +751,7 @@ def main():
                 previous_tail = batch[-2:] if len(batch) >= 2 else batch
                 continue
 
-            accepted = apply_positional_overlay(batch, corrected)
+            accepted = apply_positional_overlay(batch, corrected, roster=script_roster)
 
             # Safety net only: the positional overlay always takes "text"
             # from the original batch, so this can never actually fail. If

--- a/app/review_script.py
+++ b/app/review_script.py
@@ -194,6 +194,107 @@ def merge_consecutive_narrators(entries, max_merged_length=800):
     return merged, merges
 
 
+def _rendered_len(entries_list):
+    """Length (chars) of the JSON that would actually be sent to the LLM for
+    this list of entries -- i.e. exactly what review_batch() renders via
+    `json.dumps(entries_list, indent=2, ensure_ascii=False)`."""
+    return len(json.dumps(entries_list, indent=2, ensure_ascii=False))
+
+
+def build_review_batches(entries, batch_size, char_budget):
+    """Split entries into review batches bounded by BOTH entry count and
+    rendered JSON size.
+
+    A fixed entry-count batch (the old behavior) can silently overflow a
+    small LLM serving context window when individual entries are unusually
+    large (e.g. huge Gutenberg front-matter blocks) -- the server then
+    truncates the prompt instead of erroring, the model never sees its
+    instructions or most of its entries, and review silently becomes a
+    no-op on exactly the batches with the longest entries.
+
+    Entries accumulate into the current batch until EITHER:
+      - the batch already has `batch_size` entries, or
+      - adding the next entry would push the batch's rendered
+        `json.dumps(batch, indent=2, ensure_ascii=False)` length past
+        `char_budget`,
+    whichever comes first. A single entry never gets split across batches
+    -- if one entry's own rendered size alone exceeds `char_budget`, it
+    becomes a singleton batch by itself (the positional-overlay review
+    contract requires each entry to survive review as one unit; splitting
+    an entry is not an option).
+    """
+    if not entries:
+        return []
+
+    batches = []
+    current = []
+    for entry in entries:
+        candidate = current + [entry]
+        if current and (len(candidate) > batch_size or _rendered_len(candidate) > char_budget):
+            batches.append(current)
+            current = [entry]
+        else:
+            current = candidate
+    if current:
+        batches.append(current)
+    return batches
+
+
+def _truncate_context_entry(entry, max_text_chars=300):
+    """Return a copy of `entry` for CONTEXT-ONLY display, with "text" capped
+    to `max_text_chars` (plus an ellipsis) so a single giant neighbor entry
+    (e.g. a huge front-matter block sitting just outside the target batch)
+    can't blow the prompt's char budget from the context side.
+
+    NEVER apply this to the target batch itself -- only to the +/-N
+    neighbor entries shown for context in contextual review mode. The
+    reviewer never edits context entries anyway (only the TARGET BATCH is
+    returned), so truncating their display text has no effect on output
+    correctness, only on prompt size.
+    """
+    text = entry.get("text", "")
+    if isinstance(text, str) and len(text) > max_text_chars:
+        truncated = dict(entry)
+        truncated["text"] = text[:max_text_chars] + "..."
+        return truncated
+    return entry
+
+
+# Best-effort truncation-tripwire heuristic (see _maybe_print_truncation_hint):
+# English text averages roughly this many characters per token. If the
+# actual rendered prompt is more than _TRUNCATION_HINT_MULTIPLIER times this
+# baseline ratio away from what the reported prompt_tokens would imply, the
+# server is probably silently truncating its context window rather than
+# processing the whole prompt.
+_CHARS_PER_TOKEN_BASELINE = 4.0
+_TRUNCATION_HINT_MULTIPLIER = 3.5
+
+
+def _maybe_print_truncation_hint(prompt_chars, prompt_tokens):
+    """Print a one-line, best-effort hint when a response looks unusable
+    because the LLM server silently truncated its context window.
+
+    Symptom (observed in production on a 494k-word script): a locally
+    served model (e.g. Ollama) with a serving context window smaller than
+    the actual prompt truncates the prompt instead of erroring. The model
+    never sees its instructions/entries and returns garbage (wrong format,
+    wrong entry count) -- the overlay keeps annotated_script.json safe
+    either way, but review silently becomes a no-op on exactly the batches
+    containing the longest entries. The signature: reported prompt_tokens
+    stays roughly flat across wildly different batch sizes, because the
+    server only counts what it kept after truncating.
+
+    This is purely a diagnostic print -- it never changes control flow or
+    what gets returned/written.
+    """
+    if not prompt_tokens:
+        return
+    if prompt_chars > _TRUNCATION_HINT_MULTIPLIER * _CHARS_PER_TOKEN_BASELINE * prompt_tokens:
+        print(f"  HINT: response unusable and prompt_tokens ({prompt_tokens}) far below prompt "
+              f"size ({prompt_chars} chars) -- the LLM server may be truncating its context "
+              f"window; reduce review_batch_char_budget or raise the server's context length.")
+
+
 def review_batch(client, model_name, batch_entries, batch_num, total_batches,
                  previous_tail=None, source_context=None, max_retries=2,
                  system_prompt=None, user_prompt_template=None,
@@ -219,7 +320,9 @@ def review_batch(client, model_name, batch_entries, batch_num, total_batches,
     context = "\n".join(context_parts)
     batch_json = json.dumps(batch_entries, indent=2, ensure_ascii=False)
     user_prompt = usr_template.format(context=context, batch=batch_json)
+    prompt_chars = len(sys_prompt) + len(user_prompt)
 
+    usage = None
     for attempt in range(max_retries + 1):
         try:
             response = client.chat.completions.create(
@@ -276,17 +379,22 @@ def review_batch(client, model_name, batch_entries, batch_num, total_batches,
         # Clean and parse JSON response
         json_text = clean_json_string(text)
 
+        prompt_tokens = getattr(usage, 'prompt_tokens', None) if usage else None
+
         if not json_text:
             print(f"Warning: Could not find JSON array in batch {batch_num} response (attempt {attempt + 1})")
             if attempt < max_retries:
                 print("Retrying...")
                 continue
             print(f"Response preview: {text[:300]}...")
+            _maybe_print_truncation_hint(prompt_chars, prompt_tokens)
             return None
 
         entries = repair_json_array(json_text)
 
         if entries and len(entries) > 0:
+            if len(entries) != len(batch_entries):
+                _maybe_print_truncation_hint(prompt_chars, prompt_tokens)
             if attempt > 0:
                 print(f"  Succeeded on retry {attempt + 1}")
             return entries
@@ -300,8 +408,11 @@ def review_batch(client, model_name, batch_entries, batch_num, total_batches,
         salvaged = salvage_json_entries(json_text)
         if salvaged:
             print(f"Regex-salvaged {len(salvaged)} entries from malformed response")
+            if len(salvaged) != len(batch_entries):
+                _maybe_print_truncation_hint(prompt_chars, prompt_tokens)
             return salvaged
 
+    _maybe_print_truncation_hint(prompt_chars, getattr(usage, 'prompt_tokens', None) if usage else None)
     return None
 
 
@@ -439,6 +550,13 @@ def main():
 
     generation_config = config.get("generation", {})
     batch_size = generation_config.get("review_batch_size", 25)
+    # Dual-budget batching: a fixed entry count alone can silently overflow
+    # a small LLM serving context window when individual entries are huge
+    # (e.g. Gutenberg front-matter). 12000 chars (~3k tokens) is
+    # conservative -- it leaves room for the system prompt plus contextual
+    # neighbor windows even inside a 4096-token serving window. See
+    # build_review_batches().
+    batch_char_budget = generation_config.get("review_batch_char_budget", 12000)
     max_tokens = generation_config.get("max_tokens", 8000)
     temperature = generation_config.get("temperature", 0.4)
     top_p = generation_config.get("top_p", 0.8)
@@ -449,7 +567,7 @@ def main():
 
     print(f"Connecting to: {base_url}")
     print(f"Using model: {model_name}")
-    print(f"Batch size: {batch_size} entries, Max tokens: {max_tokens}")
+    print(f"Batch size: up to {batch_size} entries or {batch_char_budget:,} chars per batch, Max tokens: {max_tokens}")
     if banned_tokens:
         print(f"Banned tokens: {banned_tokens}")
 
@@ -470,29 +588,36 @@ def main():
 
     if args.context_window and args.context_window > 0:
         window = max(1, args.context_window)
-        total_batches = max(1, (len(entries) + batch_size - 1) // batch_size)
-        print(f"Contextual review mode enabled: batching ~{batch_size} entries per LLM call with +/-{window} neighbors")
+        batches = build_review_batches(entries, batch_size, batch_char_budget)
+        total_batches = len(batches)
+        print(f"Contextual review mode enabled: batching up to {batch_size} entries or "
+              f"{batch_char_budget:,} chars per LLM call, with +/-{window} neighbors "
+              f"({total_batches} batches)")
 
         previous_tail = None
-        for batch_index, start in enumerate(range(0, len(entries), batch_size), 1):
-            end = min(len(entries), start + batch_size)
-            batch = entries[start:end]
+        pos = 0
+        for batch_index, batch in enumerate(batches, 1):
+            start = pos
+            end = start + len(batch)
+            pos = end
             before = entries[max(0, start - window):start]
             after = entries[end:min(len(entries), end + window)]
 
-            print(f"\nReviewing batch {batch_index}/{total_batches} ({len(batch)} entries)...")
+            batch_chars = _rendered_len(batch)
+            print(f"\nReviewing batch {batch_index}/{total_batches} ({len(batch)} entries, {batch_chars:,} chars)...")
 
             contextual_lines = [
                 "Contextual batch review mode.",
                 "The 'SCRIPT ENTRIES TO REVIEW' below is your TARGET BATCH.",
                 "Use the following PREVIOUS and NEXT entries for context, but DO NOT include them in your output. Only return the corrected TARGET BATCH.",
+                "Context entries' \"text\" may be truncated with '...' for brevity -- that truncation applies ONLY to this context section, never to your TARGET BATCH.",
             ]
             if before:
                 contextual_lines.append("\n--- PREVIOUS ENTRIES (Context Only) ---")
-                contextual_lines.extend(json.dumps(e, ensure_ascii=False) for e in before)
+                contextual_lines.extend(json.dumps(_truncate_context_entry(e), ensure_ascii=False) for e in before)
             if after:
                 contextual_lines.append("\n--- NEXT ENTRIES (Context Only) ---")
-                contextual_lines.extend(json.dumps(e, ensure_ascii=False) for e in after)
+                contextual_lines.extend(json.dumps(_truncate_context_entry(e), ensure_ascii=False) for e in after)
 
             corrected = review_batch(
                 client, model_name, batch, batch_index, total_batches,
@@ -552,18 +677,18 @@ def main():
             all_corrected.extend(accepted)
             previous_tail = accepted[-2:] if len(accepted) >= 2 else accepted
     else:
-        # Split entries into batches
-        batches = []
-        for i in range(0, len(entries), batch_size):
-            batches.append(entries[i:i + batch_size])
+        # Split entries into batches, bounded by both count and rendered
+        # JSON size (see build_review_batches).
+        batches = build_review_batches(entries, batch_size, batch_char_budget)
 
         total_batches = len(batches)
-        print(f"Split into {total_batches} batches of ~{batch_size} entries")
+        print(f"Split into {total_batches} batches (up to {batch_size} entries or {batch_char_budget:,} chars each)")
 
         previous_tail = None
 
         for i, batch in enumerate(batches, 1):
-            print(f"\nReviewing batch {i}/{total_batches} ({len(batch)} entries)...")
+            batch_chars = _rendered_len(batch)
+            print(f"\nReviewing batch {i}/{total_batches} ({len(batch)} entries, {batch_chars:,} chars)...")
 
             corrected = review_batch(
                 client, model_name, batch, i, total_batches,

--- a/app/review_script.py
+++ b/app/review_script.py
@@ -97,9 +97,45 @@ def apply_positional_overlay(batch, corrected, roster=None):
     remove entries -- a count mismatch means its response can't be aligned
     positionally, so the caller must treat this as a failed batch (keep the
     original entries) rather than guessing an alignment.
+
+    Returns None ALSO when any slot's echoed "text" does not match the
+    original entry's text (whitespace-normalized). Count alone is not
+    alignment: a response that duplicates one entry and drops another has
+    the right length but shifts every later label one slot left, filing
+    correct labels against the wrong entries. Measured on a real review run:
+    34 misaligned slots, 13 of them one contiguous off-by-one run inside a
+    single batch, silently demoting a whole conversation to NARRATOR. Text
+    stayed verbatim (that guarantee is structural), so nothing else could
+    detect it -- check_text_loss compares the accepted entries against the
+    batch they were built FROM, which is a tautology.
+
+    Whole-batch rejection rather than per-slot skipping: a shift means every
+    slot after the drop point is wrong, and the slots whose text happens to
+    coincide again are exactly the ones that would silently take a
+    neighbour's label. Rejecting only the provably-mismatched slots would
+    still apply garbage to the coincidences. A failed batch keeps its
+    original labels, which is the safe direction.
+
+    Comparison is whitespace-normalized, not exact: models routinely echo
+    the text with a leading/collapsed space (41 correctly-aligned slots in
+    that same run, against 7097 exact echoes), and an exact compare would
+    reject all of them.
+    A missing/blank/non-string "text" is NOT treated as a mismatch -- the
+    reviewer is asked for labels only, and a response that omits the echo
+    entirely carries no alignment evidence either way; those responses have
+    always been accepted positionally and stay accepted.
     """
     if len(corrected) != len(batch):
         return None
+
+    for orig, corr in zip(batch, corrected):
+        if not isinstance(corr, dict):
+            continue
+        echoed = corr.get("text")
+        if not isinstance(echoed, str) or not echoed.strip():
+            continue
+        if " ".join(echoed.split()) != " ".join(str(orig.get("text", "")).split()):
+            return None
 
     accepted = []
     for orig, corr in zip(batch, corrected):
@@ -426,7 +462,26 @@ def review_batch(client, model_name, batch_entries, batch_num, total_batches,
 
         if entries and len(entries) > 0:
             if len(entries) != len(batch_entries):
+                # Valid JSON, wrong length -- measured as the ONLY failure
+                # mode that actually happens (33 of 34 failed batches in a
+                # full run; all finish_reason=stop, max completion 2966 of
+                # 4096 tokens, so not truncation). It used to return here,
+                # which made the two paid-for retries unreachable for it and
+                # left ~10% of the book unreviewed; the drops are
+                # temperature noise and do not repeat across attempts, so a
+                # retry is the cheap fix. The truncation hint is kept (it is
+                # a pure diagnostic and still the right message when a
+                # server silently truncates its context) but is now known to
+                # be a red herring for this particular symptom.
+                print(f"Warning: batch {batch_num} returned {len(entries)} entries for a "
+                      f"{len(batch_entries)}-entry batch (attempt {attempt + 1})")
                 _maybe_print_truncation_hint(prompt_chars, prompt_tokens)
+                if attempt < max_retries:
+                    print("Retrying...")
+                    continue
+                # Retries exhausted: return the mismatched array unchanged so
+                # the caller's own count check reports and discards the batch
+                # exactly as it did before.
             if attempt > 0:
                 print(f"  Succeeded on retry {attempt + 1}")
             return entries
@@ -700,6 +755,14 @@ def main():
 
             accepted = apply_positional_overlay(batch, corrected, roster=script_roster)
 
+            if accepted is None:
+                print(f"  FAILED — reviewer's echoed text does not align with the batch "
+                      f"(dropped/duplicated entry); keeping original entries for batch {batch_index}")
+                all_corrected.extend(_canonicalize_speakers(batch))
+                total_stats["batches_failed"] += 1
+                previous_tail = batch[-2:] if len(batch) >= 2 else batch
+                continue
+
             # Safety net only: the positional overlay always takes "text"
             # from the original batch, so this can never actually fail. If
             # it does, that's a structural bug -- surface it loudly instead
@@ -771,6 +834,14 @@ def main():
                 continue
 
             accepted = apply_positional_overlay(batch, corrected, roster=script_roster)
+
+            if accepted is None:
+                print(f"  FAILED — reviewer's echoed text does not align with the batch "
+                      f"(dropped/duplicated entry); keeping original entries for batch {i}")
+                all_corrected.extend(_canonicalize_speakers(batch))
+                total_stats["batches_failed"] += 1
+                previous_tail = batch[-2:] if len(batch) >= 2 else batch
+                continue
 
             # Safety net only: the positional overlay always takes "text"
             # from the original batch, so this can never actually fail. If

--- a/app/review_script.py
+++ b/app/review_script.py
@@ -6,6 +6,71 @@ import argparse
 from openai import OpenAI
 from review_prompts import REVIEW_SYSTEM_PROMPT, REVIEW_USER_PROMPT
 from generate_script import clean_json_string, repair_json_array, salvage_json_entries
+from speaker_canon import canonicalize
+
+
+def _canonicalize_speakers(entries):
+    """Return a copy of `entries` with each "speaker" field canonicalized.
+
+    Never touches "text" -- only the speaker label. Safety net against
+    casing/formatting drift introduced by the review LLM (or older,
+    pre-canonicalization scripts) so the `!= "NARRATOR"` checks in
+    merge_consecutive_narrators stay reliable.
+    """
+    result = []
+    for entry in entries:
+        new_entry = dict(entry)
+        if "speaker" in new_entry:
+            new_entry["speaker"] = canonicalize(new_entry["speaker"])
+        result.append(new_entry)
+    return result
+
+
+def apply_positional_overlay(batch, corrected):
+    """Overlay LLM speaker/instruct corrections onto the ORIGINAL batch text.
+
+    This is the hard, structural guarantee against text damage: "text" is
+    ALWAYS taken from the original entry, never from the LLM's output, so no
+    amount of accidental rewording/splitting/merging/attribution-stripping in
+    a model response can touch the verbatim script. Only "speaker"
+    (canonicalized) and "instruct" are taken from the LLM's corresponding
+    entry, matched positionally (same index in `batch` and `corrected`).
+
+    Returns None if `corrected` has a different number of entries than
+    `batch`. The reviewer is no longer allowed to split, merge, add, or
+    remove entries -- a count mismatch means its response can't be aligned
+    positionally, so the caller must treat this as a failed batch (keep the
+    original entries) rather than guessing an alignment.
+    """
+    if len(corrected) != len(batch):
+        return None
+
+    accepted = []
+    for orig, corr in zip(batch, corrected):
+        new_entry = dict(orig)
+        corr = corr if isinstance(corr, dict) else {}
+
+        # Speaker: prefer the LLM's correction, but only if it canonicalizes
+        # to something non-empty. An empty string, None, or a value that
+        # canonicalizes to "" (e.g. a stray "(shouting)") must NOT blank out
+        # a good original label -- that would silently drop the entry from
+        # the voices roster and mute it at render time. Fall back to the
+        # original (canonicalized) speaker whenever the correction is empty,
+        # not only when the "speaker" key is absent entirely.
+        corrected_speaker = canonicalize(corr.get("speaker") or "")
+        new_entry["speaker"] = corrected_speaker or canonicalize(orig.get("speaker", ""))
+
+        # Instruct: only accept a non-empty string from the LLM. None, a
+        # list/dict, or a whitespace-only string is rejected in favor of the
+        # original instruct (already present via dict(orig) above) rather
+        # than writing a malformed value into annotated_script.json.
+        corrected_instruct = corr.get("instruct")
+        if isinstance(corrected_instruct, str) and corrected_instruct.strip():
+            new_entry["instruct"] = corrected_instruct
+
+        new_entry["text"] = orig.get("text", "")
+        accepted.append(new_entry)
+    return accepted
 
 
 def _is_section_break(text):
@@ -18,6 +83,24 @@ def _is_section_break(text):
     if stripped == stripped.upper() and len(stripped) < 80 and stripped.isascii():
         return True
     return False
+
+
+def _join_narrator_texts(left, right):
+    """Join two narrator texts across a merge boundary.
+
+    Verbatim entries already carry their own boundary whitespace (a
+    trailing/leading space or newline copied straight from the source), so
+    unconditionally inserting an extra " " would introduce a byte that was
+    never in the original text. Only inject a space when NEITHER side
+    already has boundary whitespace -- this keeps legacy scripts (older
+    annotated_script.json files whose entries were .strip()'d) merging
+    readably, while verbatim entries stay byte-exact.
+    """
+    if not left or not right:
+        return left + right
+    if left[-1].isspace() or right[0].isspace():
+        return left + right
+    return left + " " + right
 
 
 def merge_consecutive_narrators(entries, max_merged_length=800):
@@ -54,7 +137,7 @@ def merge_consecutive_narrators(entries, max_merged_length=800):
                 break
             if _is_section_break(next_entry.get("text", "")):
                 break
-            candidate = combined_text + " " + next_entry["text"]
+            candidate = _join_narrator_texts(combined_text, next_entry["text"])
             if len(candidate) > max_merged_length:
                 break
             combined_text = candidate
@@ -316,12 +399,15 @@ def main():
     client = OpenAI(base_url=base_url, api_key=api_key)
 
     all_corrected = []
+    # "text_changed"/"entries_added"/"entries_removed" are intentionally
+    # absent: the positional overlay (apply_positional_overlay) guarantees
+    # every accepted entry keeps its original text and every accepted batch
+    # keeps its original entry count, so those counters could only ever be
+    # 0 on batches that made it through. A batch that would have caused
+    # either is instead rejected outright and counted in batches_failed.
     total_stats = {
-        "text_changed": 0,
         "speaker_changed": 0,
         "instruct_changed": 0,
-        "entries_added": 0,
-        "entries_removed": 0,
         "batches_failed": 0,
     }
 
@@ -368,47 +454,46 @@ def main():
 
             if corrected is None:
                 print(f"  FAILED — keeping original entries for batch {batch_index}")
-                all_corrected.extend(batch)
+                all_corrected.extend(_canonicalize_speakers(batch))
                 total_stats["batches_failed"] += 1
                 previous_tail = batch[-2:] if len(batch) >= 2 else batch
                 continue
 
-            passed, orig_text, corr_text, ratio = check_text_loss(batch, corrected, threshold=0.95, upper_bound=1.15)
+            if len(corrected) != len(batch):
+                print(f"  FAILED — reviewer returned {len(corrected)} entries for a {len(batch)}-entry "
+                      f"batch (splitting/merging is not permitted); keeping original entries for batch {batch_index}")
+                all_corrected.extend(_canonicalize_speakers(batch))
+                total_stats["batches_failed"] += 1
+                previous_tail = batch[-2:] if len(batch) >= 2 else batch
+                continue
+
+            accepted = apply_positional_overlay(batch, corrected)
+
+            # Safety net only: the positional overlay always takes "text"
+            # from the original batch, so this can never actually fail. If
+            # it does, that's a structural bug -- surface it loudly instead
+            # of silently keeping originals.
+            passed, orig_text, corr_text, ratio = check_text_loss(batch, accepted, threshold=1.0, upper_bound=1.0)
             if not passed:
-                print(f"  WARNING: Text length mismatch (loss or gain)! Word ratio: {ratio:.2f} (acceptable range: 0.95-1.15)")
-                print(f"  Original words: {len(orig_text.split())}, Corrected words: {len(corr_text.split())}")
-                print(f"  Keeping original entries for batch {batch_index} to prevent data corruption.")
-                all_corrected.extend(batch)
+                print(f"  BUG: text-loss safety net tripped despite positional overlay (ratio {ratio:.4f})! "
+                      f"Keeping original entries for batch {batch_index}.")
+                all_corrected.extend(_canonicalize_speakers(batch))
                 total_stats["batches_failed"] += 1
                 previous_tail = batch[-2:] if len(batch) >= 2 else batch
                 continue
 
-            stats = diff_entries(batch, corrected)
-            entry_diff = len(corrected) - len(batch)
-
-            if entry_diff > 0:
-                total_stats["entries_added"] += entry_diff
-            elif entry_diff < 0:
-                total_stats["entries_removed"] += abs(entry_diff)
-
-            total_stats["text_changed"] += stats["text_changed"]
+            stats = diff_entries(batch, accepted)
             total_stats["speaker_changed"] += stats["speaker_changed"]
             total_stats["instruct_changed"] += stats["instruct_changed"]
 
-            changes = stats["text_changed"] + stats["speaker_changed"] + stats["instruct_changed"]
-            if changes > 0 or entry_diff != 0:
-                print(f"  Changes: {stats['text_changed']} text, {stats['speaker_changed']} speaker, {stats['instruct_changed']} instruct", end="")
-                if entry_diff > 0:
-                    print(f", +{entry_diff} entries (split)")
-                elif entry_diff < 0:
-                    print(f", {entry_diff} entries (merge)")
-                else:
-                    print()
+            changes = stats["speaker_changed"] + stats["instruct_changed"]
+            if changes > 0:
+                print(f"  Changes: {stats['speaker_changed']} speaker, {stats['instruct_changed']} instruct")
             else:
                 print("  No changes")
 
-            all_corrected.extend(corrected)
-            previous_tail = corrected[-2:] if len(corrected) >= 2 else corrected
+            all_corrected.extend(accepted)
+            previous_tail = accepted[-2:] if len(accepted) >= 2 else accepted
     else:
         # Split entries into batches
         batches = []
@@ -440,49 +525,47 @@ def main():
 
             if corrected is None:
                 print(f"  FAILED — keeping original entries for batch {i}")
-                all_corrected.extend(batch)
+                all_corrected.extend(_canonicalize_speakers(batch))
                 total_stats["batches_failed"] += 1
                 previous_tail = batch[-2:] if len(batch) >= 2 else batch
                 continue
 
-            # Text-loss safety check
-            passed, orig_text, corr_text, ratio = check_text_loss(batch, corrected)
+            if len(corrected) != len(batch):
+                print(f"  FAILED — reviewer returned {len(corrected)} entries for a {len(batch)}-entry "
+                      f"batch (splitting/merging is not permitted); keeping original entries for batch {i}")
+                all_corrected.extend(_canonicalize_speakers(batch))
+                total_stats["batches_failed"] += 1
+                previous_tail = batch[-2:] if len(batch) >= 2 else batch
+                continue
+
+            accepted = apply_positional_overlay(batch, corrected)
+
+            # Safety net only: the positional overlay always takes "text"
+            # from the original batch, so this can never actually fail. If
+            # it does, that's a structural bug -- surface it loudly instead
+            # of silently keeping originals.
+            passed, orig_text, corr_text, ratio = check_text_loss(batch, accepted, threshold=1.0, upper_bound=1.0)
             if not passed:
-                print(f"  WARNING: Text length mismatch (loss or gain)! Word ratio: {ratio:.2f} (acceptable range: 0.95-1.05)")
-                print(f"  Original words: {len(orig_text.split())}, Corrected words: {len(corr_text.split())}")
-                print(f"  Keeping original entries for batch {i} to prevent data corruption.")
-                all_corrected.extend(batch)
+                print(f"  BUG: text-loss safety net tripped despite positional overlay (ratio {ratio:.4f})! "
+                      f"Keeping original entries for batch {i}.")
+                all_corrected.extend(_canonicalize_speakers(batch))
                 total_stats["batches_failed"] += 1
                 previous_tail = batch[-2:] if len(batch) >= 2 else batch
                 continue
 
             # Diff stats
-            stats = diff_entries(batch, corrected)
-            entry_diff = len(corrected) - len(batch)
-
-            if entry_diff > 0:
-                total_stats["entries_added"] += entry_diff
-            elif entry_diff < 0:
-                total_stats["entries_removed"] += abs(entry_diff)
-
-            total_stats["text_changed"] += stats["text_changed"]
+            stats = diff_entries(batch, accepted)
             total_stats["speaker_changed"] += stats["speaker_changed"]
             total_stats["instruct_changed"] += stats["instruct_changed"]
 
-            changes = stats["text_changed"] + stats["speaker_changed"] + stats["instruct_changed"]
-            if changes > 0 or entry_diff != 0:
-                print(f"  Changes: {stats['text_changed']} text, {stats['speaker_changed']} speaker, {stats['instruct_changed']} instruct", end="")
-                if entry_diff > 0:
-                    print(f", +{entry_diff} entries (splits)")
-                elif entry_diff < 0:
-                    print(f", {entry_diff} entries (merges)")
-                else:
-                    print()
+            changes = stats["speaker_changed"] + stats["instruct_changed"]
+            if changes > 0:
+                print(f"  Changes: {stats['speaker_changed']} speaker, {stats['instruct_changed']} instruct")
             else:
                 print(f"  No changes")
 
-            all_corrected.extend(corrected)
-            previous_tail = corrected[-2:] if len(corrected) >= 2 else corrected
+            all_corrected.extend(accepted)
+            previous_tail = accepted[-2:] if len(accepted) >= 2 else accepted
 
     # Post-processing: merge consecutive NARRATOR entries with same instruct
     merge_narrators_enabled = generation_config.get("merge_narrators", False)
@@ -507,17 +590,17 @@ def main():
         print("Cleared old chunks.json")
 
     # Final summary
-    total_changes = (total_stats["text_changed"] + total_stats["speaker_changed"] +
-                     total_stats["instruct_changed"] + total_stats["entries_added"] +
-                     total_stats["entries_removed"] + narrator_merges)
+    # Text-loss and entry-count changes are structurally impossible on
+    # accepted batches (see apply_positional_overlay / total_stats comment
+    # above), so they're not tracked here -- only speaker/instruct edits and
+    # narrator merges count as "changes".
+    total_changes = (total_stats["speaker_changed"] +
+                     total_stats["instruct_changed"] + narrator_merges)
 
     print(f"\n{'='*60}")
     print(f"Review complete: {len(entries)} -> {len(all_corrected)} entries")
-    print(f"  Text changed:    {total_stats['text_changed']}")
     print(f"  Speaker changed: {total_stats['speaker_changed']}")
     print(f"  Instruct changed:{total_stats['instruct_changed']}")
-    print(f"  Entries added:   {total_stats['entries_added']}")
-    print(f"  Entries removed: {total_stats['entries_removed']}")
     print(f"  Narrators merged:{narrator_merges}")
     if total_stats["batches_failed"] > 0:
         print(f"  Batches failed:  {total_stats['batches_failed']}")

--- a/app/review_script.py
+++ b/app/review_script.py
@@ -8,6 +8,44 @@ from review_prompts import REVIEW_SYSTEM_PROMPT, REVIEW_USER_PROMPT
 from generate_script import clean_json_string, repair_json_array, salvage_json_entries
 from speaker_canon import canonicalize
 
+# Marker embedded in both halves of review_prompts.txt (see the file itself)
+# identifying prompts written for the current positional-overlay review
+# schema: the reviewer only ever corrects "speaker"/"instruct" and must
+# return exactly as many entries as it was given. This is review_script.py's
+# own equivalent of generate_script.py's PROMPT_SCHEMA_MARKER
+# ("span-labels-v1") for the classifier stage -- kept separate (rather than
+# sharing generate_script.select_prompt) because that marker is specific to
+# the span-classifier schema, not the review schema, and generate_script.py
+# is out of scope for this fix.
+REVIEW_PROMPT_SCHEMA_MARKER = "verbatim-review-v1"
+
+
+def select_review_prompt(custom_prompt, default_prompt, config_key):
+    """Choose between a saved custom review prompt and the built-in default.
+
+    A custom prompt is honoured only when it carries
+    REVIEW_PROMPT_SCHEMA_MARKER, i.e. when it was written for the current
+    verbatim/positional-overlay review schema (speaker/instruct-only
+    corrections, same entry count out as in). A prompt saved before that
+    refactor still instructs the old "strip attribution tags, rephrase,
+    split/merge, rewrite front-matter" methodology -- the overlay makes that
+    incapable of damaging annotated_script.json's text, but it still causes
+    entry-count mismatches (failed batches) and degrades speaker/instruct
+    fixes, so a stale prompt is rejected loudly rather than used silently.
+    """
+    if not custom_prompt or not custom_prompt.strip():
+        return default_prompt
+
+    if REVIEW_PROMPT_SCHEMA_MARKER in custom_prompt:
+        return custom_prompt
+
+    print(f"  {'!' * 60}")
+    print(f"  WARNING: saved custom prompt '{config_key}' predates the verbatim-review")
+    print(f"  pipeline (missing '{REVIEW_PROMPT_SCHEMA_MARKER}' marker) -- using the built-in")
+    print("  default instead. Re-customize starting from the new default if needed.")
+    print(f"  {'!' * 60}")
+    return default_prompt
+
 
 def _canonicalize_speakers(entries):
     """Return a copy of `entries` with each "speaker" field canonicalized.
@@ -377,8 +415,12 @@ def main():
 
     # Load custom review prompts or use defaults from review_prompts.txt
     prompts_config = config.get("prompts", {})
-    review_sys = prompts_config.get("review_system_prompt") or REVIEW_SYSTEM_PROMPT
-    review_usr = prompts_config.get("review_user_prompt") or REVIEW_USER_PROMPT
+    review_sys = select_review_prompt(
+        prompts_config.get("review_system_prompt"), REVIEW_SYSTEM_PROMPT, "review_system_prompt"
+    )
+    review_usr = select_review_prompt(
+        prompts_config.get("review_user_prompt"), REVIEW_USER_PROMPT, "review_user_prompt"
+    )
 
     generation_config = config.get("generation", {})
     batch_size = generation_config.get("review_batch_size", 25)

--- a/app/review_script.py
+++ b/app/review_script.py
@@ -602,7 +602,14 @@ def main():
     if banned_tokens:
         print(f"Banned tokens: {banned_tokens}")
 
-    client = OpenAI(base_url=base_url, api_key=api_key)
+    # llm.timeout: same override as generate_script.main, for the same reason
+    # (slow local inference vs the SDK's fixed 600s ceiling). Omitted from the
+    # call when unset so the client is unchanged for existing installs.
+    _client_kwargs = {"base_url": base_url, "api_key": api_key}
+    _timeout = llm_config.get("timeout")
+    if _timeout:
+        _client_kwargs["timeout"] = _timeout
+    client = OpenAI(**_client_kwargs)
 
     all_corrected = []
     # "text_changed"/"entries_added"/"entries_removed" are intentionally

--- a/app/span_tokenizer.py
+++ b/app/span_tokenizer.py
@@ -90,12 +90,16 @@ quote non-dialogue, which is the unsafe direction. They stay narration.
 
 SINGLE-QUOTE DISAMBIGUATION RULE (the ambiguous case, documented exactly)
 ------------------------------------------------------------------------
-``‘`` (left single curly) is unambiguous and ALWAYS opens a span.
-
 ``'`` (U+0027) and ``’`` (right single curly) are ambiguous -- they are
-also the apostrophe character. Such a character opens a quoted span only when
-ALL FIVE of the following hold; otherwise it is treated as an apostrophe and
-stays inside the surrounding UNQUOTED span:
+also the apostrophe character. ``‘`` (left single curly) is *direction*-
+unambiguous but, measured against real ebooks, is NOT guaranteed to be a
+correctly paired opener (see "‘ is not exempt" below).
+
+A single-quote character opens a quoted span only when ALL FIVE of the
+following hold; otherwise it is treated as an apostrophe and stays inside the
+surrounding UNQUOTED span. Rules 2-4 ask what FOLLOWS the mark in order to
+tell an apostrophe from a quote, so they apply to the ambiguous glyphs only;
+rules 1 and 5 apply to ``‘`` as well:
 
 1. It is at start-of-text, or the preceding character is whitespace, or the
    preceding character is opening punctuation (one of ``([{<"“”«—–-*_~``).
@@ -131,8 +135,47 @@ stays inside the surrounding UNQUOTED span:
    runaway. Single-quoted dialogue longer than that, or spanning a paragraph
    break, is rare enough that narrator fallback is the right trade.
 
-   Rule 5 applies ONLY to the ambiguous glyphs. ``‘`` is unambiguous and is
-   not subject to it -- neither bound constrains ``‘`` dialogue.
+``‘`` IS NOT EXEMPT (rules 1 and 5) -- superseded rationale, with evidence
+--------------------------------------------------------------------------
+This module used to state that ``‘`` "is unambiguous and ALWAYS opens a span"
+and exempted it from all five rules. Measurement disproves the premise. In a
+794K-character trade ebook (281 chunks at the configured ``chunk_size`` 3000)
+``‘`` opened 8 quoted spans with a median length of 906 characters and a max
+of 2289; 6 exceeded 500. Against 4552 ``“`` spans of median length 33, every
+one of those 8 is a false quotation: 2.58% of the book was typed ``kind=
+"quoted"`` -- offered to the classifier as dialogue -- while being plain
+third-person narration, with attribution tags and paragraph breaks dragged
+inside one span where ``build_entries`` cannot separate them.
+
+Two causes, both real and neither book-specific:
+
+* **Wrong-direction smart apostrophe.** Word processors and EPUB converters
+  emit ``‘`` where an apostrophe was meant (``mochteroof‘s``, ``cousins‘?``).
+  6 of the book's 163 ``‘`` were preceded by a letter. Rule 1 exists exactly
+  to reject ``O'Brien`` / ``Jones'`` and was simply never applied here.
+  Applying it is language-neutral and needs no lexicon: a single quote
+  directly after a letter is never an opening quote in any convention.
+* **Leading-elision proper noun.** An elided name (``'Mela`` for Carmela) is
+  whitespace-preceded, so it passes rule 1, and with no bound it ran to the
+  next stray apostrophe -- 945, 977 and 844 characters in three chunks. No
+  lexicon can fix this: adding the name would be corpus-fitting. Rule 5's
+  bounds are the general answer, and the argument that once justified the
+  exemption ("``‘`` is unambiguous") is the thing measurement falsified. What
+  ``‘`` guarantees is *direction*, not correct pairing; a mark whose partner
+  never arrives inside a paragraph or 500 characters is not behaving as a
+  quote regardless of which glyph it is.
+
+Rules 2-4 still do NOT apply to ``‘``: they discriminate apostrophe from
+quote by the following character, a question ``‘`` does not raise, and
+imposing them would narrate legitimate ``‘'Tis...’`` or ``‘1984 was...’``.
+
+Cost to a legitimately single-quoted (British / Commonwealth) book, where
+``‘ ... ’`` is the primary dialogue convention: none for ordinary dialogue,
+which is whitespace- or open-punctuation-preceded and closes well inside one
+paragraph. The two losses are the same ones already accepted for ``'``: a
+single-quoted speech longer than ``MAX_AMBIGUOUS_SINGLE_SPAN``, and one
+continued across a paragraph break without an intervening closer. Both become
+narration -- no text is lost, and NARRATOR is the safe fallback.
 
 A ``'`` or ``’`` closes an open single-quoted span only when the preceding
 character is a non-space AND the following character is end-of-input,
@@ -149,9 +192,9 @@ KNOWN, ACCEPTED LIMITATIONS
 * A plural possessive inside single-quoted dialogue (``'the dogs' tails,' he
   said``) closes the quotation early at ``dogs'``. The remaining text becomes
   narration -- again the safe direction, and no text is lost.
-* Straight-single-quoted dialogue that continues across a paragraph break, or
-  that runs longer than ``MAX_AMBIGUOUS_SINGLE_SPAN``, is read as narration
-  (rule 5's two bounds). ``‘`` dialogue is unaffected by both.
+* Single-quoted dialogue that continues across a paragraph break, or that runs
+  longer than ``MAX_AMBIGUOUS_SINGLE_SPAN``, is read as narration (rule 5's
+  two bounds). This now includes ``‘`` dialogue.
 """
 
 from bisect import bisect_left, bisect_right
@@ -199,11 +242,11 @@ SINGLE_CLOSERS = "'’"            # '  and  ’
 # Characters that may legitimately sit immediately before an opening quote.
 OPEN_CONTEXT_CHARS = "([{<\"“”«—–-*_~" + "".join(PAIRED_QUOTES)
 
-# Longest span an AMBIGUOUS single quote (' or ’) may open. Matches
-# MAX_CHUNK_CHARS in project.py: a quotation longer than the pipeline's own
-# chunk cap is split downstream anyway, so accepting one buys nothing and
-# risks a stray apostrophe swallowing a page of narration. Does not apply to
-# the unambiguous ‘.
+# Longest span ANY single quote (' ’ ‘) may open. Matches MAX_CHUNK_CHARS in
+# project.py: a quotation longer than the pipeline's own chunk cap is split
+# downstream anyway, so accepting one buys nothing and risks a stray
+# apostrophe swallowing a page of narration. Name kept for compatibility; ‘
+# is subject to it too since measurement showed ‘ runaways in real ebooks.
 MAX_AMBIGUOUS_SINGLE_SPAN = 500
 
 # Alphabetic runs that follow a leading apostrophe in an elision. A quote
@@ -329,23 +372,30 @@ def _find_single_closer(source, open_index, closers=None):
     return -1
 
 
-def _is_single_opener(source, index, closers=None, breaks=None):
-    """Apply the five-part ambiguous-single-quote rule (see module docstring)."""
+def _is_single_opener(source, index, closers=None, breaks=None, unambiguous=False):
+    """Apply the single-quote opener rules (see module docstring).
+
+    ``unambiguous=True`` is the ``‘`` case: rules 2-4 exist only to tell an
+    apostrophe from a quote mark by what FOLLOWS it, and ``‘`` needs no such
+    test. Rules 1 and 5 still apply -- ``‘`` is direction-unambiguous, not
+    guaranteed to be a correctly paired opener.
+    """
     # 1. preceded by start-of-text, whitespace or opening punctuation
     if index > 0:
         prev = source[index - 1]
         if not (prev.isspace() or prev in OPEN_CONTEXT_CHARS):
             return False
-    # 2. not the final character
-    nxt_index = index + 1
-    if nxt_index >= len(source):
-        return False
-    # 3. followed by a letter (digits rejected: '90s is an elision)
-    if not source[nxt_index].isalpha():
-        return False
-    # 4. not a known elision ('tis, 'twas, 'em ...)
-    if _alpha_run(source, nxt_index) in ELISIONS:
-        return False
+    if not unambiguous:
+        # 2. not the final character
+        nxt_index = index + 1
+        if nxt_index >= len(source):
+            return False
+        # 3. followed by a letter (digits rejected: '90s is an elision)
+        if not source[nxt_index].isalpha():
+            return False
+        # 4. not a known elision ('tis, 'twas, 'em ...)
+        if _alpha_run(source, nxt_index) in ELISIONS:
+            return False
     # 5. a valid closer must exist, and must land before BOTH the next
     #    paragraph break and the span-length cap -- otherwise a stray opener
     #    plus a distant possessive swallows a page of narration
@@ -399,9 +449,12 @@ def tokenize(source):
                 state = _IN_PAIRED
                 pending_closers = PAIRED_QUOTES[ch]
                 quote_start = i
-            elif ch == SINGLE_UNAMBIGUOUS_OPENER or (
-                ch in SINGLE_AMBIGUOUS
-                and _is_single_opener(source, i, closers, breaks)
+            elif (
+                ch == SINGLE_UNAMBIGUOUS_OPENER
+                or ch in SINGLE_AMBIGUOUS
+            ) and _is_single_opener(
+                source, i, closers, breaks,
+                unambiguous=(ch == SINGLE_UNAMBIGUOUS_OPENER),
             ):
                 emit(segment_start, i, UNQUOTED)
                 state = _IN_SINGLE

--- a/app/span_tokenizer.py
+++ b/app/span_tokenizer.py
@@ -1,0 +1,411 @@
+"""Character-by-character FSM that splits book text into quoted / unquoted spans.
+
+WHY THIS EXISTS
+---------------
+Audiobooks are verbatim: the spoken word must match the printed word exactly.
+The downstream pipeline sends only span *ids* to an LLM and receives only
+*labels* back (``{"id", "speaker", "role", "instruct"}``) -- never book text.
+Code then reassembles the audiobook script verbatim from the source string by
+``(start, end)`` offsets. That makes this tokenizer the correctness keystone:
+if the spans do not tile the source exactly, the reassembled text is wrong.
+
+The one invariant every caller may rely on::
+
+    "".join(source[s.start:s.end] for s in tokenize(source)) == source
+
+Spans are contiguous (``spans[i].end == spans[i + 1].start``), the first starts
+at 0, the last ends at ``len(source)``, ids are ``1..N`` in document order, and
+no span is empty. Whitespace between a quotation and its attribution tag lives
+in exactly one span, so concatenation is lossless.
+
+Sentence segmentation libraries (pysbd, spaCy) are deliberately NOT used: they
+group a quotation and its attribution tag into a single sentence, which is
+precisely the failure mode this module fixes.
+
+WHAT IT DOES *NOT* DO
+---------------------
+* It does not drop attribution tags. ``"Go," he said.`` yields a quoted span
+  ``"Go,"`` and an unquoted span ``` he said.``` -- the narrator reads the tag.
+* It does not classify speakers, does not detect em-dash or unquoted dialogue,
+  and does not split narration into sentences. Those are the LLM's job.
+* It does not normalize, strip or rewrite a single character of the source.
+
+STATE MACHINE
+-------------
+Three states: ``NARRATION``, ``IN_DOUBLE``, ``IN_SINGLE``. Only the *outer*
+quote level delimits, so nested quotes stay inside their enclosing span
+(``"She told me 'go away' yesterday," he said.`` is ONE quoted span plus one
+unquoted span). A quotation left open at end of input becomes a quoted span
+running to ``len(source)`` -- no crash, no lost text.
+
+DOUBLE QUOTES
+-------------
+``"`` (U+0022) opens and closes; ``“`` opens; ``”`` closes. A ``"``
+seen in NARRATION always opens -- double quotes are effectively never
+apostrophes in prose.
+
+SINGLE-QUOTE DISAMBIGUATION RULE (the ambiguous case, documented exactly)
+------------------------------------------------------------------------
+``‘`` (left single curly) is unambiguous and ALWAYS opens a span.
+
+``'`` (U+0027) and ``’`` (right single curly) are ambiguous -- they are
+also the apostrophe character. Such a character opens a quoted span only when
+ALL FIVE of the following hold; otherwise it is treated as an apostrophe and
+stays inside the surrounding UNQUOTED span:
+
+1. It is at start-of-text, or the preceding character is whitespace, or the
+   preceding character is opening punctuation (one of ``([{<"“”«—–-*_~``).
+   This rejects ``don't``, ``O'Brien`` and possessive ``Jones'``.
+2. It is not the last character of the input.
+3. The following character is an ASCII/Unicode *letter*. Requiring a letter
+   (not a digit) rejects decade elisions such as ``'90s``.
+4. The alphabetic run that follows is not a known elision (``'tis``, ``'twas``,
+   ``'em``, ``'round``, ``'til`` ... see ``ELISIONS``). ``'tis`` therefore never
+   opens a span.
+5. A syntactically valid CLOSER (see below) exists later in the input, and it
+   falls within BOTH of these bounds:
+
+   a. Before the next paragraph break -- a blank-line boundary, i.e. a newline
+      separated from a following newline by at most horizontal whitespace.
+      When no break follows, end of input is the bound.
+   b. Within ``MAX_AMBIGUOUS_SINGLE_SPAN`` characters of the opener.
+
+   All three parts earn their keep. Without "a closer exists", an unterminated
+   single quote swallows the rest of the chunk on what is far more likely an
+   apostrophe. Without (a), an opener plus a possessive in a later paragraph
+   closes across the paragraph boundary. Without (b), the same thing happens
+   *inside* one long paragraph, which is the case that actually bites:
+   ``He said 'no more.`` followed by 40 sentences of narration and ``The dogs'
+   tails wagged.`` -- one paragraph, no newline anywhere -- produced a single
+   1139-character *quoted* span. No text is lost either way, but handing the
+   LLM a page-long quotation invites it to give plain narration a character
+   voice, which is fidelity-adverse.
+
+   ``MAX_AMBIGUOUS_SINGLE_SPAN`` is 500 to match ``MAX_CHUNK_CHARS`` in
+   ``project.py``: a quotation longer than the pipeline's own chunk cap gets
+   split downstream regardless, so accepting one buys nothing and risks a
+   runaway. Single-quoted dialogue longer than that, or spanning a paragraph
+   break, is rare enough that narrator fallback is the right trade.
+
+   Rule 5 applies ONLY to the ambiguous glyphs. ``‘`` is unambiguous and is
+   not subject to it -- neither bound constrains ``‘`` dialogue.
+
+A ``'`` or ``’`` closes an open single-quoted span only when the preceding
+character is a non-space AND the following character is end-of-input,
+whitespace, or any non-alphanumeric character. That keeps ``doesn't`` /
+``doesn’t`` inside the quotation instead of closing it early.
+
+Ambiguity that these rules cannot resolve resolves toward UNQUOTED, because an
+unlabelled span falls back to NARRATOR downstream -- the safe failure mode.
+
+KNOWN, ACCEPTED LIMITATIONS
+---------------------------
+* A single-quoted line that opens on an elision (``'Course you can,' he said.``)
+  is read as narration. Rule 4 wins; narrator fallback is safe.
+* A plural possessive inside single-quoted dialogue (``'the dogs' tails,' he
+  said``) closes the quotation early at ``dogs'``. The remaining text becomes
+  narration -- again the safe direction, and no text is lost.
+* Straight-single-quoted dialogue that continues across a paragraph break, or
+  that runs longer than ``MAX_AMBIGUOUS_SINGLE_SPAN``, is read as narration
+  (rule 5's two bounds). ``‘`` dialogue is unaffected by both.
+"""
+
+from bisect import bisect_left, bisect_right
+from dataclasses import dataclass
+
+__all__ = [
+    "Span",
+    "tokenize",
+    "reassemble",
+    "validate_spans",
+    "QUOTED",
+    "UNQUOTED",
+    "MAX_AMBIGUOUS_SINGLE_SPAN",
+]
+
+QUOTED = "quoted"
+UNQUOTED = "unquoted"
+
+# --- quote character classes -------------------------------------------------
+
+DOUBLE_OPENERS = '"“'            # "  and  “
+DOUBLE_CLOSERS = '"”'            # "  and  ”
+
+SINGLE_UNAMBIGUOUS_OPENER = "‘"  # ‘  (never an apostrophe)
+SINGLE_AMBIGUOUS = "'’"          # '  and  ’  (also the apostrophe glyph)
+SINGLE_CLOSERS = "'’"            # '  and  ’
+
+# Characters that may legitimately sit immediately before an opening quote.
+OPEN_CONTEXT_CHARS = "([{<\"“”«—–-*_~"
+
+# Longest span an AMBIGUOUS single quote (' or ’) may open. Matches
+# MAX_CHUNK_CHARS in project.py: a quotation longer than the pipeline's own
+# chunk cap is split downstream anyway, so accepting one buys nothing and
+# risks a stray apostrophe swallowing a page of narration. Does not apply to
+# the unambiguous ‘.
+MAX_AMBIGUOUS_SINGLE_SPAN = 500
+
+# Alphabetic runs that follow a leading apostrophe in an elision. A quote
+# followed by one of these is an apostrophe, not an opening quote.
+ELISIONS = frozenset(
+    [
+        "tis", "twas", "twere", "twill", "twould", "twixt", "tween",
+        "em", "im", "er", "n", "un", "uns",
+        "til", "till", "bout", "cause", "cept", "course",
+        "gainst", "neath", "nother", "fore", "fraid",
+        "round", "stead", "scuse", "specially",
+        "way", "nuff", "ol", "ere", "kay", "lo", "pon", "gain", "bove",
+        "bye", "sblood", "struth", "twarn", "tain",
+    ]
+)
+
+
+@dataclass(frozen=True)
+class Span:
+    """A contiguous slice of the source string.
+
+    ``id``    -- 1-based, contiguous, document order.
+    ``start`` / ``end`` -- offsets such that ``source[start:end]`` is the text.
+    ``kind``  -- ``"quoted"`` (a quotation *including* its quote marks) or
+                 ``"unquoted"`` (everything else, attribution tags included).
+    """
+
+    id: int
+    start: int
+    end: int
+    kind: str
+
+    def text(self, source):
+        """Return this span's verbatim text from the source string."""
+        return source[self.start:self.end]
+
+    def as_dict(self):
+        return {"id": self.id, "start": self.start, "end": self.end, "kind": self.kind}
+
+
+# --- single-quote heuristics -------------------------------------------------
+
+def _alpha_run(source, index):
+    """Return the lowercased alphabetic run starting at ``index``."""
+    end = index
+    n = len(source)
+    while end < n and source[end].isalpha():
+        end += 1
+    return source[index:end].lower()
+
+
+def _is_single_closer(source, index):
+    """True when ``source[index]`` can close an open single-quoted span.
+
+    Requires a non-space before it and end-of-input, whitespace or any
+    non-alphanumeric character after it (so ``doesn't`` never closes).
+    """
+    if index <= 0:
+        return False
+    prev = source[index - 1]
+    if prev.isspace():
+        return False
+    nxt_index = index + 1
+    if nxt_index >= len(source):
+        return True
+    return not source[nxt_index].isalnum()
+
+
+def _closer_index(source):
+    """Every position in ``source`` that could close a single-quoted span.
+
+    Precomputed once per tokenize() call so the opener rule's "does a closer
+    exist?" test is a binary search rather than a rescan of the tail. Without
+    it, a chunk full of failing opener candidates costs O(n^2) -- ~60s on
+    200KB of adversarial text. The result is identical either way.
+    """
+    return [
+        j
+        for j, ch in enumerate(source)
+        if ch in SINGLE_CLOSERS and _is_single_closer(source, j)
+    ]
+
+
+def _paragraph_break_index(source):
+    """Start offsets of every blank-line boundary in ``source``.
+
+    A paragraph break is a newline separated from a following newline by at
+    most horizontal whitespace, so ``\\n\\n``, ``\\n   \\n`` and ``\\r\\n\\r\\n``
+    all qualify. Precomputed once per tokenize() call and binary-searched, for
+    the same reason as the closer index.
+    """
+    breaks = []
+    n = len(source)
+    for j, ch in enumerate(source):
+        if ch != "\n":
+            continue
+        k = j + 1
+        while k < n and source[k] in " \t\r":
+            k += 1
+        if k < n and source[k] == "\n":
+            breaks.append(j)
+    return breaks
+
+
+def _paragraph_limit(source, index, breaks=None):
+    """Offset of the next paragraph break after ``index``, else ``len(source)``."""
+    if breaks is None:
+        breaks = _paragraph_break_index(source)
+    position = bisect_right(breaks, index)
+    if position < len(breaks):
+        return breaks[position]
+    return len(source)
+
+
+def _find_single_closer(source, open_index, closers=None):
+    """Index of the first valid closer after ``open_index``, or -1."""
+    # open_index + 1 is guaranteed to be a letter by the caller, so start after.
+    if closers is None:
+        closers = _closer_index(source)
+    position = bisect_left(closers, open_index + 2)
+    if position < len(closers):
+        return closers[position]
+    return -1
+
+
+def _is_single_opener(source, index, closers=None, breaks=None):
+    """Apply the five-part ambiguous-single-quote rule (see module docstring)."""
+    # 1. preceded by start-of-text, whitespace or opening punctuation
+    if index > 0:
+        prev = source[index - 1]
+        if not (prev.isspace() or prev in OPEN_CONTEXT_CHARS):
+            return False
+    # 2. not the final character
+    nxt_index = index + 1
+    if nxt_index >= len(source):
+        return False
+    # 3. followed by a letter (digits rejected: '90s is an elision)
+    if not source[nxt_index].isalpha():
+        return False
+    # 4. not a known elision ('tis, 'twas, 'em ...)
+    if _alpha_run(source, nxt_index) in ELISIONS:
+        return False
+    # 5. a valid closer must exist, and must land before BOTH the next
+    #    paragraph break and the span-length cap -- otherwise a stray opener
+    #    plus a distant possessive swallows a page of narration
+    closer = _find_single_closer(source, index, closers)
+    if closer == -1:
+        return False
+    limit = _paragraph_limit(source, index, breaks)
+    if index + MAX_AMBIGUOUS_SINGLE_SPAN < limit:
+        limit = index + MAX_AMBIGUOUS_SINGLE_SPAN
+    if closer >= limit:
+        return False
+    return True
+
+
+# --- the finite state machine ------------------------------------------------
+
+_NARRATION = 0
+_IN_DOUBLE = 1
+_IN_SINGLE = 2
+
+
+def tokenize(source):
+    """Split ``source`` into contiguous quoted / unquoted :class:`Span` records.
+
+    Returns ``[]`` for empty input. Never raises on malformed quoting.
+    """
+    if not source:
+        return []
+
+    spans = []
+    n = len(source)
+    closers = _closer_index(source)
+    breaks = _paragraph_break_index(source)
+
+    def emit(start, end, kind):
+        if end > start:
+            spans.append(Span(id=len(spans) + 1, start=start, end=end, kind=kind))
+
+    state = _NARRATION
+    segment_start = 0   # start of the current unquoted run
+    quote_start = -1    # start of the currently open quotation
+    i = 0
+
+    while i < n:
+        ch = source[i]
+
+        if state == _NARRATION:
+            if ch in DOUBLE_OPENERS:
+                emit(segment_start, i, UNQUOTED)
+                state = _IN_DOUBLE
+                quote_start = i
+            elif ch == SINGLE_UNAMBIGUOUS_OPENER or (
+                ch in SINGLE_AMBIGUOUS
+                and _is_single_opener(source, i, closers, breaks)
+            ):
+                emit(segment_start, i, UNQUOTED)
+                state = _IN_SINGLE
+                quote_start = i
+
+        elif state == _IN_DOUBLE:
+            if ch in DOUBLE_CLOSERS:
+                emit(quote_start, i + 1, QUOTED)
+                segment_start = i + 1
+                state = _NARRATION
+
+        else:  # _IN_SINGLE -- nested double quotes are ignored on purpose
+            if ch in SINGLE_CLOSERS and _is_single_closer(source, i):
+                emit(quote_start, i + 1, QUOTED)
+                segment_start = i + 1
+                state = _NARRATION
+
+        i += 1
+
+    # Tail: an unterminated quotation runs to end of input rather than losing text.
+    if state == _NARRATION:
+        emit(segment_start, n, UNQUOTED)
+    else:
+        emit(quote_start, n, QUOTED)
+
+    return spans
+
+
+def reassemble(spans, source):
+    """Rebuild the source text from spans by offset. Must equal ``source``."""
+    return "".join(source[s.start:s.end] for s in spans)
+
+
+def validate_spans(spans, source):
+    """Raise ``ValueError`` unless the spans tile ``source`` exactly.
+
+    Checks the full contract: 1..N ids in order, contiguity, no empty spans,
+    full coverage, known kinds, and byte-exact reassembly.
+    """
+    if not source:
+        if spans:
+            raise ValueError("empty source must produce no spans")
+        return True
+
+    if not spans:
+        raise ValueError("non-empty source produced no spans")
+
+    if spans[0].start != 0:
+        raise ValueError("first span does not start at 0: %d" % spans[0].start)
+    if spans[-1].end != len(source):
+        raise ValueError(
+            "last span ends at %d, expected %d" % (spans[-1].end, len(source))
+        )
+
+    for index, span in enumerate(spans):
+        if span.id != index + 1:
+            raise ValueError("span id %d out of order at position %d" % (span.id, index))
+        if span.end <= span.start:
+            raise ValueError("empty or inverted span id %d" % span.id)
+        if span.kind not in (QUOTED, UNQUOTED):
+            raise ValueError("unknown span kind %r on id %d" % (span.kind, span.id))
+        if index + 1 < len(spans) and span.end != spans[index + 1].start:
+            raise ValueError(
+                "gap or overlap between span %d and %d" % (span.id, spans[index + 1].id)
+            )
+
+    if reassemble(spans, source) != source:
+        raise ValueError("reassembly does not reproduce the source verbatim")
+
+    return True

--- a/app/span_tokenizer.py
+++ b/app/span_tokenizer.py
@@ -32,17 +32,61 @@ WHAT IT DOES *NOT* DO
 
 STATE MACHINE
 -------------
-Three states: ``NARRATION``, ``IN_DOUBLE``, ``IN_SINGLE``. Only the *outer*
+Three states: ``NARRATION``, ``IN_PAIRED``, ``IN_SINGLE``. Only the *outer*
 quote level delimits, so nested quotes stay inside their enclosing span
 (``"She told me 'go away' yesterday," he said.`` is ONE quoted span plus one
 unquoted span). A quotation left open at end of input becomes a quoted span
 running to ``len(source)`` -- no crash, no lost text.
 
-DOUBLE QUOTES
--------------
-``"`` (U+0022) opens and closes; ``“`` opens; ``”`` closes. A ``"``
-seen in NARRATION always opens -- double quotes are effectively never
-apostrophes in prose.
+PAIRED (UNAMBIGUOUS) QUOTE DELIMITERS
+-------------------------------------
+``PAIRED_QUOTES`` maps every unambiguous OPENER character to the set of
+characters that may close *that* opener. Adding a language's convention is a
+one-line data change; the FSM never grows a branch for it. In ``IN_PAIRED``
+only the closers of the opener that started the span end it, so a quotation
+opened with one convention cannot be closed by another convention's mark and
+inner quotes of a different convention stay inside the outer span.
+
+Supported today:
+
+===========  ================  =========================================
+Opener       Closers           Convention
+===========  ================  =========================================
+``"``        ``"`` ``”``       English straight (also closes on curly)
+``“``        ``"`` ``”``       English curly
+``„``        ``“`` ``”``       German / Polish / Czech low-high
+``«``        ``»``             French / Russian / Spanish guillemets
+``‹``        ``›``             single guillemets
+``「``       ``」``            CJK corner brackets
+``『``       ``』``            CJK white corner brackets
+``＂``       ``＂``            full-width straight (U+FF02)
+===========  ================  =========================================
+
+A ``"`` seen in NARRATION always opens -- double quotes are effectively never
+apostrophes in prose. The same holds for every other character in the table:
+none of them is ever an apostrophe, so none is routed through the ambiguous
+single-quote machinery below, and none is subject to its length or paragraph
+bounds.
+
+``“`` IS BOTH AN OPENER AND A CLOSER -- how that is disambiguated
+-----------------------------------------------------------------
+``“`` opens an English curly quotation but closes a German ``„`` one. State,
+not the character, decides: in NARRATION ``“`` opens (unchanged English
+behaviour); inside a span opened by ``„`` it closes, because ``„``'s closer
+set is the only one consulted there. An English document never contains ``„``
+and so can never reach that state -- adding German cannot regress English.
+The mirror case ``‚ ... ‘`` works the same way, and leaves ``‘``'s role as the
+unambiguous single opener in NARRATION untouched.
+
+Whitespace *inside* the marks is part of the quoted span and is never touched,
+so French typography's inner spaces -- U+0020, U+00A0 or U+202F, as in
+``« bonjour »`` -- survive byte-exactly.
+
+WHAT IS DELIBERATELY NOT A DELIMITER
+------------------------------------
+``《 》`` and ``〈 〉`` mark work titles rather than speech in Chinese, and
+``〝 〞`` is vanishingly rare in book text; treating them as dialogue would
+quote non-dialogue, which is the unsafe direction. They stay narration.
 
 SINGLE-QUOTE DISAMBIGUATION RULE (the ambiguous case, documented exactly)
 ------------------------------------------------------------------------
@@ -121,6 +165,7 @@ __all__ = [
     "QUOTED",
     "UNQUOTED",
     "MAX_AMBIGUOUS_SINGLE_SPAN",
+    "PAIRED_QUOTES",
 ]
 
 QUOTED = "quoted"
@@ -128,15 +173,31 @@ UNQUOTED = "unquoted"
 
 # --- quote character classes -------------------------------------------------
 
-DOUBLE_OPENERS = '"“'            # "  and  “
+DOUBLE_OPENERS = '"“'            # "  and  “   (English; kept for reference)
 DOUBLE_CLOSERS = '"”'            # "  and  ”
+
+# Every unambiguous paired delimiter: OPENER -> the closers valid for IT.
+# Adding a language's convention is a data change here, not a logic change.
+# See the table in the module docstring for the rationale of each row, and in
+# particular for why “ may appear as both a key and a value without ambiguity.
+PAIRED_QUOTES = {
+    '"': '"”',      # English straight double
+    "“": '"”',      # English curly double
+    "„": "“”",      # German / Polish / Czech low-high double
+    "«": "»",       # French / Russian / Spanish guillemets
+    "‹": "›",       # single guillemets
+    "「": "」",     # CJK corner brackets
+    "『": "』",     # CJK white corner brackets
+    "＂": "＂",     # full-width straight double (U+FF02)
+    "‚": "‘’",      # German / Polish low-high single
+}
 
 SINGLE_UNAMBIGUOUS_OPENER = "‘"  # ‘  (never an apostrophe)
 SINGLE_AMBIGUOUS = "'’"          # '  and  ’  (also the apostrophe glyph)
 SINGLE_CLOSERS = "'’"            # '  and  ’
 
 # Characters that may legitimately sit immediately before an opening quote.
-OPEN_CONTEXT_CHARS = "([{<\"“”«—–-*_~"
+OPEN_CONTEXT_CHARS = "([{<\"“”«—–-*_~" + "".join(PAIRED_QUOTES)
 
 # Longest span an AMBIGUOUS single quote (' or ’) may open. Matches
 # MAX_CHUNK_CHARS in project.py: a quotation longer than the pipeline's own
@@ -302,7 +363,7 @@ def _is_single_opener(source, index, closers=None, breaks=None):
 # --- the finite state machine ------------------------------------------------
 
 _NARRATION = 0
-_IN_DOUBLE = 1
+_IN_PAIRED = 1
 _IN_SINGLE = 2
 
 
@@ -324,17 +385,19 @@ def tokenize(source):
             spans.append(Span(id=len(spans) + 1, start=start, end=end, kind=kind))
 
     state = _NARRATION
-    segment_start = 0   # start of the current unquoted run
-    quote_start = -1    # start of the currently open quotation
+    segment_start = 0     # start of the current unquoted run
+    quote_start = -1      # start of the currently open quotation
+    pending_closers = ""  # closers valid for the currently open paired quote
     i = 0
 
     while i < n:
         ch = source[i]
 
         if state == _NARRATION:
-            if ch in DOUBLE_OPENERS:
+            if ch in PAIRED_QUOTES:
                 emit(segment_start, i, UNQUOTED)
-                state = _IN_DOUBLE
+                state = _IN_PAIRED
+                pending_closers = PAIRED_QUOTES[ch]
                 quote_start = i
             elif ch == SINGLE_UNAMBIGUOUS_OPENER or (
                 ch in SINGLE_AMBIGUOUS
@@ -344,8 +407,10 @@ def tokenize(source):
                 state = _IN_SINGLE
                 quote_start = i
 
-        elif state == _IN_DOUBLE:
-            if ch in DOUBLE_CLOSERS:
+        elif state == _IN_PAIRED:
+            # Only THIS opener's closers end the span, so a differently
+            # punctuated inner quotation stays inside it.
+            if ch in pending_closers:
                 emit(quote_start, i + 1, QUOTED)
                 segment_start = i + 1
                 state = _NARRATION

--- a/app/speaker_canon.py
+++ b/app/speaker_canon.py
@@ -8,7 +8,11 @@ Two tiers:
 
   Tier 1 (canonicalize): fully automatic, deterministic normalization of a
   single raw speaker label into a canonical UPPERCASE form. Safe to apply
-  everywhere a speaker label is produced or compared.
+  everywhere a speaker label is produced or compared. Rank titles are
+  dropped ("Dr. Millman" -> "MILLMAN"); gender-marking titles are PRESERVED
+  and normalized ("Mr. Smith" -> "MISTER SMITH", "Mme Tellier" -> "MADAME
+  TELLIER"), because they are often the only thing telling two characters
+  apart -- see _RANK_TITLES / _GENDERED_TITLES.
 
   Tier 1b (roster_key / remember_in_roster / resolve_against_roster):
   roster-AWARE spelling resolution, kept strictly separate from canonicalize()
@@ -24,6 +28,41 @@ Two tiers:
   reject. JON/JOHN and ELLA/BELLA are deliberately treated as *distinct*
   people in the roster even though they are similar strings -- this module
   will surface a suggestion for a human to review, but will not merge them.
+
+  Tier 3 (attest_label / attest_speaker): advisory local-window attestation
+  -- flags labels whose core name tokens don't appear near the label's own
+  entries in the source, catching drift/invention the LLM produces (e.g.
+  transposed letters, invented names). READ-ONLY / advisory: never mutates
+  anything. attest_label() returns the boolean detail record the Voices UI
+  badge consumes; attest_speaker() returns the three-way ATTESTED /
+  UNATTESTED / UNVERIFIABLE verdict a would-be *gate* needs, because a
+  caller that rejects labels must distinguish "refuted" from "our check does
+  not apply here".
+
+EVERY CHARACTER TEST IN THIS MODULE IS UNICODE, NOT ASCII, AND MUST STAY THAT
+WAY. The pipeline processes non-English books (French honorifics are listed
+below; span_tokenizer.PAIRED_QUOTES carries German, Russian and CJK quote
+conventions), and an ASCII character class silently DELETES non-Latin text
+rather than failing. Three ASCII classes lived here, each failing differently,
+and all three are now category predicates (_is_name_char and the helpers built
+on it -- _strip_disallowed, _strip_boundary_marks, _scan_tokens):
+
+  * canonicalize()'s punctuation strip erased non-Latin names to "", and
+    resolve_span_labels only accepts a truthy canonical form -- so EVERY
+    dialogue line in a Cyrillic/Hebrew/Arabic/Greek/CJK book was narrated and
+    the book got no character voices at all.
+  * the roster key dropped non-Latin letters, so every such name would have
+    keyed to "" -- one roster entry and one voice for an entire cast,
+    irreversibly. Widening the canonical form WITHOUT widening the key turns
+    "no voices" into "one voice for everybody", which is strictly worse; see
+    the note at _strip_boundary_marks.
+  * the attestation tokenizer extracted zero core tokens, so the Voices UI's
+    attestation badge was wrong for every speaker in every non-Latin book.
+
+Predicates, not regex classes: `re` cannot express "any Unicode mark" without
+the third-party `regex` module, and the spacing combining marks that carry
+vowels in Indic scripts are category Mc, which `\w` does not match -- "सीता"
+came out as two bare consonants under a `\w`-based class.
 
 IMPORTANT: canonicalization applies to speaker LABELS only. Audiobook body
 text must remain byte-for-byte verbatim; nothing in this module should ever
@@ -41,29 +80,85 @@ from rapidfuzz import fuzz
 # Tier 1: canonicalize()
 # ---------------------------------------------------------------------------
 
-# Honorifics stripped from the front of a name, longest-first so multi-word
-# honorifics (e.g. "Professor") aren't shadowed by a shorter prefix match.
-# Matched case-insensitively, with an optional trailing period, followed by
-# whitespace (so "Drake" is never mistaken for "Dr" + "ake").
+# Leading titles are handled in TWO classes, because they carry two very
+# different amounts of information about WHO is speaking.
 #
-# INCLUSION CRITERION: strip a word only when it is a TITLE whose abbreviation
-# varies between mentions of the same person -- "Dr." / "Doctor", "Capt." /
-# "Captain" -- which is exactly the drift that fragments a roster. Never strip
-# a word that can be part of the name itself.
+# INCLUSION CRITERION (both classes): treat a word as a title only when its
+# spelling varies between mentions of the same person -- "Dr." / "Doctor",
+# "Capt." / "Captain", "Mme" / "Madame" -- which is exactly the drift that
+# fragments a roster. Never list a word that can be part of the name itself.
 #
-# "ST" was removed under that criterion: it is a name constituent, not a title
-# (St. Clair, St. John, St. Laurent), and saint-derived surnames are common in
-# the French literature this pipeline processes. While it was listed,
-# "ST JOHN RIVERS" canonicalized to "JOHN RIVERS" -- a different character.
-_HONORIFICS = [
-    "professor", "captain", "prof", "capt", "mrs", "miss", "lady", "lord",
-    "dame", "col", "rev", "sgt", "mr", "ms", "mx", "dr", "sir", "lt", "fr",
+# "ST" is deliberately absent under that criterion: it is a name constituent,
+# not a title (St. Clair, St. John, St. Laurent), and saint-derived surnames
+# are common in the French literature this pipeline processes. While it was
+# listed, "ST JOHN RIVERS" canonicalized to "JOHN RIVERS" -- a different
+# character.
+#
+# CLASS 1 -- RANK titles are DROPPED. Rank says nothing about identity that the
+# surname doesn't already say, and the same person is freely "Dr. Millman",
+# "Doctor Millman" and "Millman" within one book. Dropping them merges those
+# three mentions into one voice, which is the desired outcome.
+_RANK_TITLES = [
+    "professor", "captain", "prof", "capt", "col", "rev", "sgt", "dr", "lt",
 ]
 
-_HONORIFIC_RE = re.compile(
-    r"^(?:" + "|".join(_HONORIFICS) + r")\.?\s+",
-    re.IGNORECASE,
-)
+# CLASS 2 -- GENDER-MARKING titles are PRESERVED, normalized to one spelled-out
+# form per title. Dropping them was a silent data-loss bug: "Mr. Smith" and
+# "Mrs. Smith" both canonicalized to "SMITH", so a husband and wife were merged
+# into a single roster entry and a single voice, at annotation time and
+# irreversibly -- the Voices UI's alias mechanism can merge two entries but can
+# never split one. The title is the ONLY thing distinguishing them, so it has
+# to survive canonicalization.
+#
+# Normalization is language-PRESERVING: "Mme Tellier" and "Madame Tellier"
+# unify on MADAME (they are one character), while "Monsieur Dufour" and
+# "Madame Dufour" stay apart. Folding French onto English (MME -> MISSUS) would
+# be a translation of the author's text into the roster, and the abbreviated
+# and spelled-out French forms drift against each other in real books -- on the
+# 578-label production roster, MADAME/MME split five characters in two.
+#
+# Judgment calls, recorded so they are not silently re-litigated:
+#   * SIR / LADY / LORD / DAME / MX are gendered, not rank, and are preserved.
+#     "Sir John" and "Lady John" are two people.
+#   * FR moved here rather than being dropped. It was flagged as a
+#     name-constituent risk of the same class as ST (a surname beginning
+#     "Fr ..."); preserving it contains that risk -- the worst case is now a
+#     harmless "FR" prefix on one roster entry, not a silently different
+#     character. FR is NOT folded onto FATHER: "Father Milon" reads as part of
+#     the name in this corpus and has never been in the title list.
+#   * M -> MONSIEUR only as a standalone leading token (same position and
+#     tokenization as every other title), so "M. Marambot" unifies with
+#     "Monsieur Marambot". A single-letter initial in that position -- "M.
+#     Night" -- is therefore read as a title. Accepted: consistency with the
+#     other titles beats a special case, and the failure is a visible wrong
+#     prefix rather than two characters merged.
+#   * The normalized forms are themselves recognized titles mapping to
+#     themselves (MISTER -> MISTER), which is what keeps canonicalize()
+#     idempotent once its own output is fed back in.
+_GENDERED_TITLES = {
+    "mr": "MISTER", "mister": "MISTER",
+    "mrs": "MISSUS", "missus": "MISSUS",
+    "ms": "MS",
+    "miss": "MISS",
+    "mx": "MX",
+    "m": "MONSIEUR", "monsieur": "MONSIEUR",
+    "mme": "MADAME", "madame": "MADAME",
+    "mlle": "MADEMOISELLE", "mademoiselle": "MADEMOISELLE",
+    "sir": "SIR",
+    "lady": "LADY",
+    "lord": "LORD",
+    "dame": "DAME",
+    "fr": "FR",
+}
+
+# The normalized gender-marking prefixes, exported for consumers that need to
+# reason about "same surname, different title" -- notably tts.resolve_voice's
+# migration shim for voice_config.json files written before titles were
+# preserved. Consumers MUST import this rather than re-listing the titles.
+GENDERED_TITLES = frozenset(_GENDERED_TITLES.values())
+
+# Every leading token treated as a title, in lowercase.
+_ALL_TITLES = frozenset(_RANK_TITLES) | frozenset(_GENDERED_TITLES)
 
 # A parenthetical (and any surrounding whitespace) anywhere in the string,
 # e.g. "MARK (shouting)" -> "MARK", "MARK (angrily) enters" -> "MARK enters".
@@ -73,18 +168,58 @@ _PARENS_RE = re.compile(r"\s*\([^)]*\)\s*")
 # whitespace, apostrophes (O'Brien), and hyphens (Jean-Luc). Everything else
 # is considered "stray punctuation" and stripped. This intentionally runs
 # AFTER accent normalization (NFKD + combining-mark strip), so accented
-# letters have already been folded down to plain ASCII letters by this point.
-_ALLOWED_CHARS_RE = re.compile(r"[^A-Za-z0-9'\-\s]")
+# letters have already been folded down to their base letters by this point.
+#
+# UNICODE, not ASCII. This class was `[^A-Za-z0-9'\-\s]` and therefore treated
+# every non-Latin letter as stray punctuation, which was a total-loss bug for
+# any book not written in a Latin script: "Ирина" canonicalized to "" (every
+# character stripped, then the empty-string bail-out at the top of
+# canonicalize), and resolve_span_labels only accepts a speaker when
+# `canonical` is truthy -- so EVERY dialogue line in a Cyrillic, Hebrew,
+# Arabic, Greek or CJK book fell back to NARRATOR and the book got no
+# character voices at all. `[^\W_]` is "any word character except
+# underscore", i.e. letters and digits in ANY script; it encodes
+# word-character-ness, not knowledge of any particular language.
+# Implemented as a CATEGORY PREDICATE, not a regex character class, because a
+# class cannot express "any Unicode mark" without the third-party `regex`
+# module. `\w` matches str.isalnum() characters, and the spacing combining
+# marks that carry vowels in Indic scripts are category Mc, which is NOT
+# alphanumeric: "सीता" lost its vowel signs under a `\w`-based class and came
+# out as two bare consonants. Marks are part of the letter, so they are kept.
+_QUOTE_CHARS = "\"'‘’“”"
+_NAME_PUNCT = "'‘’"
 
-# Same as _ALLOWED_CHARS_RE, but additionally keeps straight/curly quote
-# characters alive through the first punctuation pass, so a name like
-# '"BLACK SCOUT"' still has both of its wrapping quote characters present
-# when _strip_wrapping_quotes() runs. Anything it lets through that isn't
-# consumed as part of a matched wrapping pair is cleaned up afterward by a
-# second pass through the strict _ALLOWED_CHARS_RE above.
-_ALLOWED_CHARS_WITH_QUOTES_RE = re.compile(
-    "[^A-Za-z0-9'\\-\\s\"‘’“”]"
-)
+
+def _is_name_char(ch, allow_quotes=False):
+    """True for a character that may appear inside a canonical name: any
+    alphanumeric in any script, any Unicode mark (Mn/Mc/Me -- Indic vowel
+    signs, Hebrew points, combining diacritics), and the apostrophe glyphs.
+    Language-agnostic by construction: it asks the Unicode database what kind
+    of character this is, and knows nothing about any particular script.
+    """
+    if ch.isalnum() or ch in _NAME_PUNCT:
+        return True
+    if allow_quotes and ch in _QUOTE_CHARS:
+        return True
+    return unicodedata.category(ch).startswith("M")
+
+
+def _strip_disallowed(text, allow_quotes=False):
+    """Replace every character that cannot appear in a canonical name with a
+    space, keeping hyphens and whitespace. Replacement (not deletion) matches
+    the previous regex behaviour, so "MARK(shouting)" still separates into
+    words rather than fusing.
+    """
+    return "".join(
+        ch if (ch in "-" or ch.isspace() or _is_name_char(ch, allow_quotes)) else " "
+        for ch in text
+    )
+
+# _strip_disallowed(..., allow_quotes=True) additionally keeps straight/curly
+# quote characters alive through the first punctuation pass, so a name like
+# '"BLACK SCOUT"' still has both of its wrapping quote characters present when
+# _strip_wrapping_quotes() runs. Anything it lets through that isn't consumed
+# as part of a matched wrapping pair is cleaned up by the second, strict pass.
 
 # Collapse any run of whitespace to a single space.
 _WHITESPACE_RE = re.compile(r"\s+")
@@ -166,10 +301,15 @@ def canonicalize(raw: str) -> str:
       7. Strip any remaining stray punctuation (incl. leftover unmatched
          quote characters), keeping apostrophes and hyphens, then re-collapse
          whitespace.
-      8. Strip a single leading honorific (Mr, Mrs, Dr, Professor, ...) --
-         but never let this reduce a non-empty input to emptiness; if
-         stripping the honorific would leave nothing, keep the honorific
-         itself as the name (e.g. "Dr." alone -> "DR").
+      8. Resolve the run of leading titles (see _RANK_TITLES /
+         _GENDERED_TITLES): rank titles are dropped ("Dr. Millman" ->
+         "MILLMAN"), while the FIRST gender-marking title becomes a
+         normalized preserved prefix ("Mr. Smith" -> "MISTER SMITH",
+         "Mme Bovary" -> "MADAME BOVARY"). Stacked titles are all consumed,
+         so "Mrs. Dr. Watson" -> "MISSUS WATSON" and "Sir Lt. Col. Blimp"
+         -> "SIR BLIMP". Never lets this reduce a non-empty input to
+         emptiness: a label that is nothing but titles keeps its last title
+         as the name ("Dr." -> "DR", "Mrs." -> "MRS", "Mr. Mrs." -> "MRS").
       9. Uppercase the result.
       10. Map any casing of "narrator" to exactly "NARRATOR".
 
@@ -185,39 +325,50 @@ def canonicalize(raw: str) -> str:
 
     text = _strip_accents(text)
     text = _PARENS_RE.sub(" ", text)
-    text = _ALLOWED_CHARS_WITH_QUOTES_RE.sub(" ", text)
+    text = _strip_disallowed(text, allow_quotes=True)
     text = _WHITESPACE_RE.sub(" ", text).strip()
 
     if not text:
         return ""
 
     text = _strip_wrapping_quotes(text)
-    text = _ALLOWED_CHARS_RE.sub(" ", text)
+    text = _strip_disallowed(text)
     text = _WHITESPACE_RE.sub(" ", text).strip()
 
     if not text:
         return ""
 
-    # Strip honorifics to a FIXPOINT. A single pass is not idempotent, and the
-    # damage was silent: "Mr. St. Clair" canonicalized to "ST CLAIR", which
-    # canonicalized AGAIN (as it does -- generate_script.py canonicalizes for
-    # the entry and remember_in_roster canonicalizes for the roster) to
-    # "CLAIR". The script said one name, the roster and voice_config another,
-    # and the character was split across two voices. Stacked honorifics are
-    # real: "Sir Lt. Col. Blimp", "Mrs. Dr. Watson".
-    while True:
-        honorific_match = _HONORIFIC_RE.match(text)
-        if not honorific_match:
-            break
-        remainder = text[honorific_match.end():].strip()
-        if not remainder:
-            # Stripping would empty the name out -- keep what we have (the
-            # honorific itself becomes the canonical name, so a bare "Dr."
-            # stays "DR" rather than vanishing).
-            break
-        text = remainder
+    # Consume the WHOLE run of leading titles in one pass, not one title per
+    # pass. Stacked titles are real ("Sir Lt. Col. Blimp", "Mrs. Dr. Watson"),
+    # and a single-title pass was not idempotent -- the damage was silent:
+    # "Mr. St. Clair" canonicalized to "ST CLAIR", which canonicalized AGAIN
+    # (as it does -- generate_script.py canonicalizes for the entry and
+    # remember_in_roster canonicalizes for the roster) to "CLAIR". The script
+    # said one name, the roster and voice_config another, and the character was
+    # split across two voices.
+    #
+    # Tokenizing on whitespace is safe here: step 4/7 already replaced every
+    # period with a space, so "Dr. Smith" is "Dr Smith" by now and no title can
+    # be matched inside a word ("Drake" is one token, and "drake" is not a
+    # title).
+    tokens = text.split(" ")
+    prefix = None
+    index = 0
+    while index < len(tokens) and tokens[index].lower() in _ALL_TITLES:
+        if prefix is None:
+            prefix = _GENDERED_TITLES.get(tokens[index].lower())
+        index += 1
 
-    text = _WHITESPACE_RE.sub(" ", text).strip()
+    if index >= len(tokens):
+        # The label is nothing but titles. Consuming them all would empty the
+        # name out, so the LAST title becomes the name itself and no prefix is
+        # emitted: a bare "Dr." stays "DR" rather than vanishing, and
+        # "Mr. Mrs." stays "MRS" rather than becoming "MISTER MRS".
+        tokens = tokens[-1:]
+    else:
+        tokens = ([prefix] if prefix else []) + tokens[index:]
+
+    text = _WHITESPACE_RE.sub(" ", " ".join(tokens)).strip()
     canonical = text.upper()
 
     if canonical == "NARRATOR":
@@ -297,7 +448,31 @@ def canonicalize(raw: str) -> str:
 
 # Everything that is not a letter or a digit. Applied to an ALREADY canonical
 # name, where the only survivors are spaces, hyphens and apostrophes.
-_KEY_STRIP_RE = re.compile(r"[^A-Z0-9]")
+#
+# UNICODE, and this one is load-bearing for safety, not just coverage. While
+# this class was `[^A-Z0-9]` it stripped every non-Latin letter too, so once
+# canonicalize() (correctly) began preserving them, roster_key("ИРИНА") and
+# roster_key("ПЕТР") would both have been "" -- an empty key that EVERY
+# non-Latin name collides on. remember_in_roster would then have merged the
+# entire cast of a Russian novel into one speaker with one voice, and a wrong
+# merge is unsplittable (see the SELECTION RULE note above). Widening
+# canonicalize() without widening this key would have turned "no character
+# voices" into "one character voice for everybody", which is strictly worse.
+# Implemented with the same category predicate as canonicalize() (see
+# _is_name_char) so the two agree on what a letter is in every script,
+# including Indic vowel signs. Keeps alphanumerics and marks; removes exactly
+# the boundary marks the key is meant to ignore -- spaces, hyphens,
+# apostrophes.
+
+
+def _strip_boundary_marks(canonical):
+    """Derive the lossy comparison key: keep letters/digits/marks of any
+    script, drop every boundary mark. Pure.
+    """
+    return "".join(
+        ch for ch in canonical
+        if ch not in _NAME_PUNCT and (ch.isalnum() or unicodedata.category(ch).startswith("M"))
+    )
 
 
 def roster_key(name: str) -> str:
@@ -308,7 +483,7 @@ def roster_key(name: str) -> str:
     stored as a speaker label. Two names share a key iff they differ solely in
     where their boundary marks fall.
     """
-    return _KEY_STRIP_RE.sub("", canonicalize(name))
+    return _strip_boundary_marks(canonicalize(name))
 
 
 def remember_in_roster(index: dict, name: str) -> str:
@@ -328,7 +503,7 @@ def remember_in_roster(index: dict, name: str) -> str:
     if not canonical:
         return ""
 
-    key = _KEY_STRIP_RE.sub("", canonical)
+    key = _strip_boundary_marks(canonical)
     established = index.get(key)
     if established is None:
         index[key] = canonical
@@ -351,7 +526,7 @@ def resolve_against_roster(raw: str, index: dict) -> str:
     canonical = canonicalize(raw)
     if not canonical:
         return ""
-    return (index or {}).get(_KEY_STRIP_RE.sub("", canonical)) or canonical
+    return (index or {}).get(_strip_boundary_marks(canonical)) or canonical
 
 
 # ---------------------------------------------------------------------------
@@ -443,3 +618,291 @@ def suggest_aliases(roster: list) -> list:
 
     suggestions.sort(key=lambda s: s["score"], reverse=True)
     return suggestions
+
+
+# ---------------------------------------------------------------------------
+# Tier 3: attest_label()
+#
+# Purely advisory, local-window text attestation. The LLM occasionally
+# invents or drifts a speaker name (transposed letters, an outright
+# hallucinated name) that is NOT the byte-verbatim text of the book -- since
+# labels are metadata, not book text, nothing else in the pipeline checks
+# them against the source. This tier gives a human reviewer a signal:
+# "this label's name doesn't appear anywhere near its own lines" -- without
+# ever touching a speaker value, roster entry, or voice_config.
+#
+# Deliberately NOT a general search across the whole book: a name appearing
+# ANYWHERE in a 300-page novel is a near-useless signal (most names appear
+# many times, far from any particular character's own lines). Attestation is
+# scoped to windows drawn from the label's OWN entries, which is exactly the
+# text this label is describing.
+# ---------------------------------------------------------------------------
+
+# A small, deliberately conservative list of generic connector words that
+# never carry identifying information on their own and therefore should not
+# be required to appear near a label's lines. Extensible -- add another
+# lowercase connector here if a real roster surfaces one, but keep the list
+# short: anything that could plausibly BE a surname (e.g. "DE" as part of
+# "DE LA CRUZ" combos is still excluded on purpose, mirroring how titles are
+# handled) should stay out unless it is purely a function word.
+_CORE_TOKEN_STOPWORDS = frozenset({
+    "THE", "A", "AN", "OF", "AND", "OR", "DE", "DU", "LA", "LE", "VON", "VAN",
+})
+
+# Uppercase forms of every recognized title token (both classes), derived
+# from the existing module constants rather than re-listed, so this stays in
+# sync with _RANK_TITLES / _GENDERED_TITLES automatically.
+_CORE_TOKEN_TITLES = frozenset(t.upper() for t in _ALL_TITLES) | GENDERED_TITLES
+
+# A bare word-boundary token: letters/digits/apostrophes (straight or curly)
+# and internal hyphens, used both to pull core tokens out of a label and to
+# scan a source window for whole-word occurrences of those tokens. Hyphens
+# are included so a hyphenated label token ("ARCH-VOTARY") matches a
+# hyphenated source occurrence ("Arch-votary") as a single unit rather than
+# splitting into two words that individually pass but the label as a whole
+# never does.
+#
+# UNICODE, for the same reason as canonicalize()'s character handling: as
+# `[A-Za-z0-9'‘’]+` this extracted ZERO tokens from a Hebrew, Arabic, Greek or
+# CJK name (measured), and a label with no core tokens is reported unattested
+# -- so the Voices UI's attestation badge was wrong for every speaker in every
+# non-Latin book. Scanners rather than regexes, for the same reason as
+# _strip_disallowed: a character class cannot say "any Unicode mark", and
+# Indic vowel signs (category Mc) are part of the letter.
+
+
+def _scan_tokens(text, join_hyphens):
+    """Split `text` into name tokens: maximal runs of name characters (see
+    _is_name_char), optionally joining runs separated by a single hyphen so a
+    hyphenated name is one token. Pure; returns a list in source order.
+    """
+    tokens = []
+    current = []
+    index = 0
+    length = len(text)
+    while index < length:
+        ch = text[index]
+        if _is_name_char(ch):
+            current.append(ch)
+        elif (
+            join_hyphens and ch == "-" and current
+            and index + 1 < length and _is_name_char(text[index + 1])
+        ):
+            current.append("-")
+        elif current:
+            tokens.append("".join(current))
+            current = []
+        index += 1
+    if current:
+        tokens.append("".join(current))
+    return tokens
+
+# Curly ("smart") apostrophe variants, folded to the straight ASCII
+# apostrophe before comparison. The LLM and the book's own prose disagree on
+# which glyph they use for the same character's name -- "SKER'RET" (label,
+# straight) vs "Sker'ret" (source, curly U+2019) -- and that disagreement
+# carries no identifying information, so it must not affect attestation.
+_CURLY_APOSTROPHE_RE = re.compile("[‘’]")
+
+
+def _fold_word(word: str) -> str:
+    """Fold a single word for attestation comparison: accent-strip, curly
+    apostrophes to straight, uppercase, then drop one trailing possessive
+    "'S" (so "Dairine's" matches core token "DAIRINE"). Does NOT strip other
+    apostrophes, so "O'BRIEN" stays "O'BRIEN" on both sides of the
+    comparison -- only the glyph is normalized, not the character's presence.
+    """
+    folded = _strip_accents(word)
+    folded = _CURLY_APOSTROPHE_RE.sub("'", folded).upper()
+    if folded.endswith("'S") and len(folded) > 2:
+        folded = folded[:-2]
+    return folded
+
+
+def _window_words(window: str) -> set:
+    """Extract the set of folded whole-word tokens present in a source
+    window, for attestation lookup.
+
+    Includes hyphenated tokens as single folded units (via _scan_tokens) so a
+    hyphenated label token matches a hyphenated source occurrence. Also adds
+    hyphen-joined bigrams of adjacent plain words (e.g. source "Arch votary"
+    contributes "ARCH-VOTARY") so a hyphenated label token still matches when
+    the source spells the same name with a space instead of a hyphen. This is
+    exact whole-word/whole-token matching, not fuzzy: a name must appear as
+    an unbroken hyphenated form, or as two adjacent plain words joined the
+    same way the label joins them.
+    """
+    words = set()
+    for match in _scan_tokens(window, join_hyphens=True):
+        folded = _fold_word(match)
+        if folded:
+            words.add(folded)
+
+    simple = [_fold_word(w) for w in _scan_tokens(window, join_hyphens=False)]
+    for first, second in zip(simple, simple[1:]):
+        if first and second:
+            words.add(f"{first}-{second}")
+
+    return words
+
+
+def _core_tokens(label: str) -> list:
+    """Extract the "core" identifying tokens from a canonical speaker label.
+
+    A core token is any whitespace-separated token of the label that is
+    NOT a generic stopword (_CORE_TOKEN_STOPWORDS) and NOT a recognized
+    title token (_CORE_TOKEN_TITLES, derived from the Tier 1 title lists).
+    Tokens are accent-folded and possessive-stripped the same way source
+    words are, so "MISTER SMITH" -> ["SMITH"] and a label containing an
+    accented or possessive-looking token still compares consistently.
+
+    Pure function of `label`; does no I/O and touches no roster state.
+    """
+    if not label:
+        return []
+    tokens = []
+    for raw_token in label.split():
+        folded = _fold_word(raw_token)
+        if not folded:
+            continue
+        if folded in _CORE_TOKEN_STOPWORDS or folded in _CORE_TOKEN_TITLES:
+            continue
+        tokens.append(folded)
+    return tokens
+
+
+def attest_label(label: str, windows: list) -> dict:
+    """Advisory, read-only check that a label's core name tokens appear as
+    whole words somewhere in its own local source `windows`.
+
+    Args:
+        label: a (canonical) speaker label, e.g. "MISTER SMITH".
+        windows: a list of source-text substrings (strings) drawn from
+            around this label's own entries in the book. Not mutated.
+
+    Returns:
+        {"attested": bool, "missing_tokens": [str, ...], "core_tokens": [str, ...]}
+
+        A label is attested=True iff EVERY core token extracted from it
+        appears (accent-folded, case-insensitive, possessive-stripped) as a
+        whole word in at least one window.
+
+        If the label has ZERO core tokens (e.g. it is only a title, or only
+        stopwords -- "MISTER", "NARRATOR"-like edge cases), this is treated
+        conservatively as attested=False with missing_tokens=[] and a note
+        that this is a trivial/unknown case: there is nothing to check, so
+        there is nothing to positively confirm either. Callers that want to
+        suppress trivial cases from a UI can do so by checking
+        `core_tokens == []`.
+
+    Pure function of (label, windows): no file I/O, no globals mutated, no
+    roster access. `windows` is read-only -- neither the list nor its
+    string elements are modified.
+    """
+    core_tokens = _core_tokens(label)
+
+    if not core_tokens:
+        return {
+            "attested": False,
+            "missing_tokens": [],
+            "core_tokens": [],
+            "note": "trivial_or_unknown_label",
+        }
+
+    # Build the set of whole words present across all windows, folded the
+    # same way as the core tokens, once, rather than re-scanning per token.
+    words_seen = set()
+    for window in windows or []:
+        if not window:
+            continue
+        words_seen |= _window_words(window)
+
+    missing = [token for token in core_tokens if token not in words_seen]
+
+    return {
+        "attested": len(missing) == 0,
+        "missing_tokens": missing,
+        "core_tokens": core_tokens,
+    }
+
+
+# Verdicts returned by attest_speaker(). Exported as constants so callers
+# compare against these rather than re-spelling the strings.
+ATTESTED = "attested"
+UNATTESTED = "unattested"
+UNVERIFIABLE = "unverifiable"
+
+
+def attest_speaker(label, windows):
+    """Three-way attestation verdict for a speaker label: ATTESTED,
+    UNATTESTED, or UNVERIFIABLE.
+
+    Wraps attest_label() rather than replacing it: attest_label's boolean
+    contract is depended on by GET /api/voices/label_flags and by
+    test_speaker_canon.py, and stays exactly as it was. This function adds
+    the third outcome that a *gate* needs and a badge does not.
+
+    Why a third verdict exists. A boolean forces every label that cannot be
+    positively confirmed into the same bucket as a label that was positively
+    refuted, and those two must not share a fate: refuted means the LLM
+    invented or misspelled a name, while merely-unconfirmed means our own
+    check does not apply to this text. Any caller that rejects labels must
+    reject only the first kind, or it silently destroys books written in
+    scripts this module cannot tokenize.
+
+    Verdicts:
+      ATTESTED      every core token appears as a whole word in some window.
+      UNVERIFIABLE  the label yields no core tokens at all (it is only
+                    titles/stopwords), or every otherwise-missing token IS
+                    present in a window but not at a word boundary. The
+                    second case is what unsegmented scripts look like:
+                    Chinese, Japanese and Thai do not delimit words with
+                    spaces, so a correct name is a substring of a longer run
+                    and no amount of whole-word matching will confirm it.
+                    It is ALSO what a too-short Latin token looks like
+                    ("AL" inside "ALICE"), which is exactly why this is
+                    UNVERIFIABLE and not ATTESTED -- it is the honest
+                    "cannot tell" answer, and callers must treat it as
+                    accept-and-count, never as grounds for rejection.
+      UNATTESTED    at least one core token appears nowhere in the windows,
+                    in any form. This is the only verdict that constitutes
+                    positive evidence the label is wrong.
+
+    Deliberately NOT language detection. No script table, no language
+    parameter, no per-language branch: the substring probe is a property of
+    the text in front of it, so a book in an unsegmented script degrades to
+    UNVERIFIABLE by the same rule that any other ambiguous match does.
+
+    Args:
+        label: a (canonical) speaker label, e.g. "MISTER SMITH".
+        windows: list of source-text substrings drawn from around this
+            label's own entries. Not mutated.
+
+    Returns:
+        One of the ATTESTED / UNATTESTED / UNVERIFIABLE string constants.
+
+    Pure function of (label, windows): no I/O, no globals mutated, no roster
+    access, and neither argument is modified. Idempotent -- repeated calls on
+    equal inputs return equal verdicts.
+    """
+    result = attest_label(label, windows)
+
+    if not result["core_tokens"]:
+        return UNVERIFIABLE
+    if result["attested"]:
+        return ATTESTED
+
+    # Fold each window once, the same way _fold_word folds a token, so the
+    # substring probe compares like with like (accents stripped, curly
+    # apostrophes straightened, uppercased) instead of comparing a folded
+    # token against raw source bytes.
+    folded_windows = [
+        _CURLY_APOSTROPHE_RE.sub("'", _strip_accents(window)).upper()
+        for window in (windows or []) if window
+    ]
+
+    for token in result["missing_tokens"]:
+        if not any(token in window for window in folded_windows):
+            return UNATTESTED
+
+    return UNVERIFIABLE

--- a/app/speaker_canon.py
+++ b/app/speaker_canon.py
@@ -45,10 +45,19 @@ from rapidfuzz import fuzz
 # honorifics (e.g. "Professor") aren't shadowed by a shorter prefix match.
 # Matched case-insensitively, with an optional trailing period, followed by
 # whitespace (so "Drake" is never mistaken for "Dr" + "ake").
+#
+# INCLUSION CRITERION: strip a word only when it is a TITLE whose abbreviation
+# varies between mentions of the same person -- "Dr." / "Doctor", "Capt." /
+# "Captain" -- which is exactly the drift that fragments a roster. Never strip
+# a word that can be part of the name itself.
+#
+# "ST" was removed under that criterion: it is a name constituent, not a title
+# (St. Clair, St. John, St. Laurent), and saint-derived surnames are common in
+# the French literature this pipeline processes. While it was listed,
+# "ST JOHN RIVERS" canonicalized to "JOHN RIVERS" -- a different character.
 _HONORIFICS = [
     "professor", "captain", "prof", "capt", "mrs", "miss", "lady", "lord",
     "dame", "col", "rev", "sgt", "mr", "ms", "mx", "dr", "sir", "lt", "fr",
-    "st",
 ]
 
 _HONORIFIC_RE = re.compile(
@@ -189,13 +198,24 @@ def canonicalize(raw: str) -> str:
     if not text:
         return ""
 
-    honorific_match = _HONORIFIC_RE.match(text)
-    if honorific_match:
+    # Strip honorifics to a FIXPOINT. A single pass is not idempotent, and the
+    # damage was silent: "Mr. St. Clair" canonicalized to "ST CLAIR", which
+    # canonicalized AGAIN (as it does -- generate_script.py canonicalizes for
+    # the entry and remember_in_roster canonicalizes for the roster) to
+    # "CLAIR". The script said one name, the roster and voice_config another,
+    # and the character was split across two voices. Stacked honorifics are
+    # real: "Sir Lt. Col. Blimp", "Mrs. Dr. Watson".
+    while True:
+        honorific_match = _HONORIFIC_RE.match(text)
+        if not honorific_match:
+            break
         remainder = text[honorific_match.end():].strip()
-        if remainder:
-            text = remainder
-        # else: stripping would empty the name out -- keep original text
-        # (the honorific itself becomes the canonical name).
+        if not remainder:
+            # Stripping would empty the name out -- keep what we have (the
+            # honorific itself becomes the canonical name, so a bare "Dr."
+            # stays "DR" rather than vanishing).
+            break
+        text = remainder
 
     text = _WHITESPACE_RE.sub(" ", text).strip()
     canonical = text.upper()

--- a/app/speaker_canon.py
+++ b/app/speaker_canon.py
@@ -1225,6 +1225,21 @@ def repair_speaker(canonical, windows, roster_index, source_words):
       7. The rebuilt name must fully ATTEST against the same windows, or it is
          refused. A repair that still would not pass the gate is not a repair.
 
+    WHAT THESE GUARDS DO NOT COVER -- and who covers it. Every condition above
+    is about SPELLING: is this spelling in the book, is exactly one roster name
+    one edit away, does that name appear in this window. None of them is
+    evidence about who speaks THIS span, and guard 4 is weakest exactly where it
+    matters: in a two-character scene both candidates appear in the window, so
+    the wrong one satisfies it as easily as the right one. Measured across
+    production runs of one book, repairs were POSITIVELY correlated with
+    attribution error -- the model misspells names in the same chunks where it
+    is unsure who is talking. The caller therefore applies an eighth condition
+    this function cannot: generate_script._gate_speaker vetoes the repair when
+    contradicts_attribution() finds the attribution tag beside that very line
+    naming a different established character, and the label falls back to the
+    plain rejection it would have had if repair did not exist. Keep that veto at
+    the call site: it needs span adjacency, and this function stays pure.
+
     WHY NO LENGTH FLOOR. A minimum token length ("only repair tokens of 4+
     characters") is a constant with no general justification: it is only ever
     chosen by measuring collisions on one book's roster, and it neither

--- a/app/speaker_canon.py
+++ b/app/speaker_canon.py
@@ -59,8 +59,30 @@ _PARENS_RE = re.compile(r"\s*\([^)]*\)\s*")
 # letters have already been folded down to plain ASCII letters by this point.
 _ALLOWED_CHARS_RE = re.compile(r"[^A-Za-z0-9'\-\s]")
 
+# Same as _ALLOWED_CHARS_RE, but additionally keeps straight/curly quote
+# characters alive through the first punctuation pass, so a name like
+# '"BLACK SCOUT"' still has both of its wrapping quote characters present
+# when _strip_wrapping_quotes() runs. Anything it lets through that isn't
+# consumed as part of a matched wrapping pair is cleaned up afterward by a
+# second pass through the strict _ALLOWED_CHARS_RE above.
+_ALLOWED_CHARS_WITH_QUOTES_RE = re.compile(
+    "[^A-Za-z0-9'\\-\\s\"‘’“”]"
+)
+
 # Collapse any run of whitespace to a single space.
 _WHITESPACE_RE = re.compile(r"\s+")
+
+# Wrapping quote pairs recognized by _strip_wrapping_quotes(): straight
+# single quote/apostrophe, straight double quote, and the curly ("smart")
+# single and double quote pairs. The straight apostrophe intentionally maps
+# to itself (') since ASCII text uses the same glyph for both open and
+# close; the curly variants use their proper distinct open/close characters.
+_QUOTE_PAIRS = {
+    "'": "'",
+    '"': '"',
+    "‘": "’",  # ‘ ... ’
+    "“": "”",  # “ ... ”
+}
 
 
 def _strip_accents(text: str) -> str:
@@ -72,6 +94,42 @@ def _strip_accents(text: str) -> str:
     return "".join(ch for ch in normalized if not unicodedata.combining(ch))
 
 
+def _strip_wrapping_quotes(text: str) -> str:
+    """Iteratively strip MATCHED wrapping quote pairs from `text`.
+
+    Handles the case where an LLM emits a speaker label wrapped in quotes,
+    e.g. 'MOTHER OF MONSTERS' or "BLACK SCOUT" or nested combinations like
+    '"BLACK SCOUT"' or curly ‘Mother of Monsters’ / “Black Scout”. Each pass
+    strips one matched outer pair (straight/curly single or double quote,
+    per _QUOTE_PAIRS) and re-trims whitespace, so nested wraps ("''X''")
+    unwind one layer at a time.
+
+    Deliberately conservative: only strips when the FIRST and LAST character
+    of the (whitespace-trimmed) string form a matching open/close pair AND
+    the string is longer than 2 characters (so a bare "'" or a 2-char
+    wrapper isn't hollowed out to nothing). This means an UNMATCHED leading
+    or trailing apostrophe -- possessive "JONES'" or elision "'TIS" -- is
+    left untouched, since in both cases only one end is a quote character
+    and the other is a letter, so first/last never form a pair.
+
+    Bounded by len(text) iterations, which is far more than any realistic
+    nesting depth, to guarantee termination on pathological input.
+    """
+    for _ in range(len(text)):
+        stripped = text.strip()
+        if len(stripped) <= 2:
+            break
+        first, last = stripped[0], stripped[-1]
+        if _QUOTE_PAIRS.get(first) == last:
+            candidate = stripped[1:-1].strip()
+            if not candidate:
+                break
+            text = candidate
+        else:
+            break
+    return text.strip()
+
+
 def canonicalize(raw: str) -> str:
     """Canonicalize a raw speaker label into its canonical UPPERCASE form.
 
@@ -79,15 +137,24 @@ def canonicalize(raw: str) -> str:
       1. Bail out to "" for empty/whitespace-only input.
       2. Strip accents (NFKD decompose + drop combining marks).
       3. Remove parenthetical asides, e.g. "MARK (shouting)" -> "MARK".
-      4. Strip stray punctuation, keeping apostrophes and hyphens (so
-         "O'Brien" and "Jean-Luc" survive intact).
+      4. Strip stray punctuation EXCEPT apostrophes/hyphens/quote marks, so
+         "O'Brien" and "Jean-Luc" survive intact and quote characters are
+         still around for the wrapping-quote check in the next step.
       5. Collapse internal whitespace runs and strip leading/trailing space.
-      6. Strip a single leading honorific (Mr, Mrs, Dr, Professor, ...) --
+      6. Strip MATCHED wrapping quote pairs iteratively (straight or curly,
+         single or double), e.g. "'Mother of Monsters'" -> "Mother of
+         Monsters", '"BLACK SCOUT"' -> "BLACK SCOUT". Unmatched leading/
+         trailing apostrophes (possessive "JONES'", elision "'TIS") are left
+         alone -- see _strip_wrapping_quotes for the exact rule.
+      7. Strip any remaining stray punctuation (incl. leftover unmatched
+         quote characters), keeping apostrophes and hyphens, then re-collapse
+         whitespace.
+      8. Strip a single leading honorific (Mr, Mrs, Dr, Professor, ...) --
          but never let this reduce a non-empty input to emptiness; if
          stripping the honorific would leave nothing, keep the honorific
          itself as the name (e.g. "Dr." alone -> "DR").
-      7. Uppercase the result.
-      8. Map any casing of "narrator" to exactly "NARRATOR".
+      9. Uppercase the result.
+      10. Map any casing of "narrator" to exactly "NARRATOR".
 
     Canonicalization is idempotent: canonicalize(canonicalize(x)) ==
     canonicalize(x).
@@ -101,6 +168,13 @@ def canonicalize(raw: str) -> str:
 
     text = _strip_accents(text)
     text = _PARENS_RE.sub(" ", text)
+    text = _ALLOWED_CHARS_WITH_QUOTES_RE.sub(" ", text)
+    text = _WHITESPACE_RE.sub(" ", text).strip()
+
+    if not text:
+        return ""
+
+    text = _strip_wrapping_quotes(text)
     text = _ALLOWED_CHARS_RE.sub(" ", text)
     text = _WHITESPACE_RE.sub(" ", text).strip()
 

--- a/app/speaker_canon.py
+++ b/app/speaker_canon.py
@@ -39,6 +39,14 @@ Two tiers:
   caller that rejects labels must distinguish "refuted" from "our check does
   not apply here".
 
+  Tier 3b (repair_speaker): the ONE place in this module that rewrites a
+  speaker name. It fires only on a label Tier 3 already ruled UNATTESTED, and
+  only when the book's own text refutes that spelling outright and points at
+  exactly one established alternative. It is a policy argument, NOT a proof of
+  immunity to the fuzzy-merge ban -- read its docstring, including its list of
+  accepted limitations, before touching it. Roster-aware, and therefore takes
+  the roster as an explicit argument, exactly like Tier 1b.
+
 EVERY CHARACTER TEST IN THIS MODULE IS UNICODE, NOT ASCII, AND MUST STAY THAT
 WAY. The pipeline processes non-English books (French honorifics are listed
 below; span_tokenizer.PAIRED_QUOTES carries German, Russian and CJK quote
@@ -705,6 +713,21 @@ def _scan_tokens(text, join_hyphens):
 _CURLY_APOSTROPHE_RE = re.compile("[‘’]")
 
 
+def _split_possessive(word: str):
+    """Fold a single word and split off one trailing possessive "'S".
+
+    Returns ``(base, suffix)`` where ``suffix`` is "'S" or "". The suffix is
+    returned rather than discarded so a caller that REBUILDS a label (see
+    repair_speaker) can put it back: "KITT'S" must repair to "KITT'S", not to
+    a bare "KIT".
+    """
+    folded = _strip_accents(word)
+    folded = _CURLY_APOSTROPHE_RE.sub("'", folded).upper()
+    if folded.endswith("'S") and len(folded) > 2:
+        return folded[:-2], "'S"
+    return folded, ""
+
+
 def _fold_word(word: str) -> str:
     """Fold a single word for attestation comparison: accent-strip, curly
     apostrophes to straight, uppercase, then drop one trailing possessive
@@ -712,11 +735,7 @@ def _fold_word(word: str) -> str:
     apostrophes, so "O'BRIEN" stays "O'BRIEN" on both sides of the
     comparison -- only the glyph is normalized, not the character's presence.
     """
-    folded = _strip_accents(word)
-    folded = _CURLY_APOSTROPHE_RE.sub("'", folded).upper()
-    if folded.endswith("'S") and len(folded) > 2:
-        folded = folded[:-2]
-    return folded
+    return _split_possessive(word)[0]
 
 
 def _window_words(window: str) -> set:
@@ -833,7 +852,63 @@ UNATTESTED = "unattested"
 UNVERIFIABLE = "unverifiable"
 
 
-def attest_speaker(label, windows):
+def _roster_core_tokens(roster_index) -> frozenset:
+    """The union of the core tokens of every name established in ``roster_index``.
+
+    Roster-AWARE, and therefore deliberately NOT part of canonicalize(): the
+    roster arrives as an explicit argument, exactly like roster_key /
+    remember_in_roster / resolve_against_roster. Pure; ``roster_index`` is
+    read, never mutated.
+    """
+    tokens = set()
+    for established in (roster_index or {}).values():
+        tokens.update(_core_tokens(established))
+    return frozenset(tokens)
+
+
+def source_word_index(text: str) -> set:
+    """The set of folded whole words the SOURCE TEXT contains, for callers that
+    need book-wide (not window-local) evidence about a spelling.
+
+    Same folding and same tokenization as attestation windows (_window_words),
+    so a token looked up here compares like with like. Built once per book by
+    the caller and passed down; this module never reads a file.
+    """
+    return _window_words(text or "")
+
+
+def _is_distance_one(a: str, b: str) -> bool:
+    """True iff ``a`` and ``b`` differ by exactly one Levenshtein edit
+    (one substitution, one insertion, or one deletion).
+
+    An explicit BOUNDED predicate, not a similarity ratio and not a library
+    call: `difflib` and rapidfuzz both answer "how alike are these?", which is
+    the question the banned-approaches list forbids acting on. This answers
+    "is there exactly one edit between them?", which is decidable, exact, and
+    cheap -- it early-exits on a length gap of 2 and otherwise makes a single
+    linear pass. Compares Unicode code points, so it is script-agnostic.
+    """
+    if a == b:
+        return False
+    len_a, len_b = len(a), len(b)
+    if abs(len_a - len_b) > 1:
+        return False
+    if len_a == len_b:
+        differences = 0
+        for left, right in zip(a, b):
+            if left != right:
+                differences += 1
+                if differences > 1:
+                    return False
+        return differences == 1
+    shorter, longer = (a, b) if len_a < len_b else (b, a)
+    index = 0
+    while index < len(shorter) and shorter[index] == longer[index]:
+        index += 1
+    return shorter[index:] == longer[index + 1:]
+
+
+def attest_speaker(label, windows, roster_index=None):
     """Three-way attestation verdict for a speaker label: ATTESTED,
     UNATTESTED, or UNVERIFIABLE.
 
@@ -868,6 +943,29 @@ def attest_speaker(label, windows):
                     in any form. This is the only verdict that constitutes
                     positive evidence the label is wrong.
 
+    ROSTER-NAME PARTIAL ATTESTATION (only when ``roster_index`` is given). A
+    label with TWO OR MORE core tokens, at least one of which both (a) appears
+    as a whole word in a window and (b) is itself a core token of a name this
+    book has already established, is UNVERIFIABLE rather than UNATTESTED.
+    Rationale: UNATTESTED is defined as positive evidence that the label is
+    WRONG, and a label built around a name the book has established is not
+    positively wrong -- "KIT'S FATHER" describes a real person the text names
+    obliquely, and the honest answer is "cannot tell", not "refuted". The
+    weaker rule "any attested token" was rejected: it is satisfied by any
+    common noun the model copied out of the prose, which would gut the gate.
+    Requiring a ROSTER token is what keeps it narrow.
+
+    Its cost, stated plainly: the roster is not itself guaranteed clean, so a
+    junk name that reached the roster earlier (an UNVERIFIABLE acceptance, say)
+    lends its tokens to later multi-token labels. The failure is bounded --
+    those labels are ACCEPTED-and-counted rather than silently correct, and
+    prose is never involved -- but it is a real widening of the gate on a book
+    whose roster has already been polluted.
+
+    ``roster_index`` is an explicit argument, never module state: this function
+    stays a pure function of its inputs, and canonicalize() stays roster-free
+    (contract 6). Passing no roster reproduces the previous behaviour exactly.
+
     Deliberately NOT language detection. No script table, no language
     parameter, no per-language branch: the substring probe is a property of
     the text in front of it, so a book in an unsegmented script degrades to
@@ -892,6 +990,16 @@ def attest_speaker(label, windows):
     if result["attested"]:
         return ATTESTED
 
+    # Roster-name partial attestation (see docstring). Checked before the
+    # substring probe because it is the cheaper and more specific rule.
+    if roster_index and len(result["core_tokens"]) >= 2:
+        missing = set(result["missing_tokens"])
+        present = [token for token in result["core_tokens"] if token not in missing]
+        if present:
+            roster_tokens = _roster_core_tokens(roster_index)
+            if any(token in roster_tokens for token in present):
+                return UNVERIFIABLE
+
     # Fold each window once, the same way _fold_word folds a token, so the
     # substring probe compares like with like (accents stripped, curly
     # apostrophes straightened, uppercased) instead of comparing a folded
@@ -906,3 +1014,204 @@ def attest_speaker(label, windows):
             return UNATTESTED
 
     return UNVERIFIABLE
+
+
+# ---------------------------------------------------------------------------
+# Tier 3b: repair_speaker()
+#
+# HONEST FRAMING FIRST. This is a single-edit spelling repair, and it is NOT
+# structurally immune to the "no fuzzy auto-merging of speaker names" ban in
+# the same way roster_key() is. roster_key() cannot merge two names the book
+# supports, as a matter of arithmetic: they have different letters, so they
+# have different keys, full stop. Repair has no such proof available. The
+# argument for it is a POLICY argument -- that a spelling which the author's
+# text never uses is not a name the book supports, so folding it onto a
+# spelling the text does use is a correction rather than a merge -- and the
+# guards below are what make that argument hold often enough to be worth
+# shipping. Every one of them can be defeated by a book with the right shape,
+# and the ACCEPTED LIMITATIONS section names the shapes.
+# ---------------------------------------------------------------------------
+
+
+def _repair_candidate_pool(roster_index, window_words, source_words):
+    """Core tokens of established roster names that are ALSO attested as whole
+    words both in the label's own window and in the book at large.
+
+    The book-wide condition is amendment (b): a repair must never target a
+    roster name that was never source-attested, or roster pollution
+    self-propagates -- a junk name accepted once would then start rewriting
+    real names onto itself.
+    """
+    return {
+        token for token in _roster_core_tokens(roster_index)
+        if token in window_words and token in source_words
+    }
+
+
+def repair_speaker(canonical, windows, roster_index, source_words):
+    """Repair a REFUTED speaker label onto an established spelling, or refuse.
+
+    Call this ONLY on a label the attestation gate has already ruled
+    UNATTESTED. Returns the repaired canonical name, or ``None`` to refuse --
+    and refusing is the default: every condition below must hold.
+
+      1. The label is non-empty, is not NARRATOR, and is not itself an
+         established roster name (an established name is never refuted).
+      2. A roster and a book-wide word index are both available. With neither,
+         there is no evidence to repair from, so nothing is repaired.
+      3. THE BOOK NEVER SPELLS IT THAT WAY. Every token being repaired must be
+         absent, as a whole word, from the WHOLE BOOK -- not merely from the
+         label's own window. This is the load-bearing guard and it replaces
+         the minimum-token-length floor an earlier design proposed (see WHY NO
+         LENGTH FLOOR below).
+      4. Candidates are core tokens of names already established in this
+         book's roster that also occur as whole words in this label's own
+         attestation window AND in the book at large (_repair_candidate_pool).
+      5. Exactly ONE candidate lies at Levenshtein distance 1 (_is_distance_one
+         -- an exact bounded predicate, never a similarity ratio), AND no
+         OTHER roster token anywhere in the book's roster lies at distance 1
+         either. Two or more of either kind means the evidence does not pick a
+         winner, so it refuses.
+      6. Tokens that already attest are kept verbatim, in place, with their
+         possessive intact; only refuted tokens are substituted.
+      7. The rebuilt name must fully ATTEST against the same windows, or it is
+         refused. A repair that still would not pass the gate is not a repair.
+
+    WHY NO LENGTH FLOOR. A minimum token length ("only repair tokens of 4+
+    characters") is a constant with no general justification: it is only ever
+    chosen by measuring collisions on one book's roster, and it neither
+    protects a long name (ANDRE/ANDREA are both long) nor is needed by a short
+    one the book never spells (KITT). It was replaced by two guards that are
+    properties of whatever book is loaded, not of any particular one:
+      * condition 3 scales with the book: the shorter and more word-like a
+        token is, the likelier the author's own prose contains it, and the
+        likelier this guard fires. "TWIN" is refused on any book that uses the
+        word "twin"; a 12-letter invented misspelling is refused on any book
+        that happens to contain it. Nothing is tuned -- the book decides.
+      * condition 5 scales with the cast: ambiguity is measured against the
+        ENTIRE roster, not just the tokens visible in this window, so the
+        denser a book's name-space is, the more often repair declines. A book
+        with ANDREA and ANDRES in the cast repairs neither.
+    DEGRADATION ON UNLIKE BOOKS: on a book with a very small vocabulary
+    (short texts) guard 3 is weak because absence proves less; on a book whose
+    cast names are near-anagrams of ordinary words, repair simply stops firing
+    (a lost voice, never wrong prose). On a non-segmenting script (Chinese,
+    Japanese, Thai) whole-word evidence is unavailable, so the gate returns
+    UNVERIFIABLE and repair is never reached at all.
+
+    ACCEPTED LIMITATIONS (adversarial cases; not papered over):
+      * ANDRE -> ANDREA, where ANDRE is a real character who is never named in
+        his own window (pronoun-only attribution) but IS named elsewhere in the
+        book: PREVENTED by guard 3. If ANDRE is a real character whose name
+        appears NOWHERE in the entire book, the repair still fires and is
+        wrong. Accepted: the model cannot have read a name the book never
+        contains, so such a label is far likelier invention than knowledge --
+        but it can come from the model's memory of a famous text, and then this
+        is a genuine mis-attribution.
+      * MARIA -> MARIE with MARIE polluted into the roster by an earlier bad
+        label: PREVENTED by guard 4's book-wide condition whenever the junk
+        name is not a whole word of the book (which is how such names get in --
+        via UNVERIFIABLE substring-only matches). NOT prevented when the junk
+        target happens to be a genuine word of the book.
+      * ANDRE with an acute accent -> ANDREA: PREVENTED by guard 3. Accents are
+        folded on BOTH sides, so the accented spelling is found in the book's
+        own word index and the label is left alone.
+      * YUSUF -> YUSUP (transliteration variants): PREVENTED by guard 3 when
+        the book uses both spellings. When the book only ever spells YUSUP, the
+        repair fires -- and is then correct by construction, since the other
+        spelling is the model's own invention.
+      * TWIN -> TWINS (plural/singular): PREVENTED by guard 3 on any book that
+        uses the singular word anywhere. A book that writes only "twins", never
+        "twin", would repair it. Accepted, and bounded: the result is an
+        existing roster name, so the cost is one line in the wrong existing
+        voice, never a new voice and never altered prose.
+
+    Pure: no I/O, no globals, and neither ``windows``, ``roster_index`` nor
+    ``source_words`` is mutated. Deterministic and idempotent -- a repaired
+    name attests, so feeding it back returns None (nothing left to repair).
+
+    Args:
+        canonical: the canonical UPPERCASE label the gate refused.
+        windows: the label's own source windows (as passed to attest_speaker).
+        roster_index: {roster_key: established_spelling} for this book.
+        source_words: the whole book's folded word set (source_word_index()).
+
+    Returns:
+        The repaired canonical name, or None.
+    """
+    if not canonical or canonical == "NARRATOR":
+        return None
+    if not roster_index or not source_words:
+        return None
+    if roster_key(canonical) in roster_index:
+        return None
+
+    core_tokens = _core_tokens(canonical)
+    if not core_tokens:
+        return None
+
+    window_words = set()
+    for window in windows or []:
+        if window:
+            window_words |= _window_words(window)
+    if not window_words:
+        return None
+
+    refuted = [token for token in core_tokens if token not in window_words]
+    if not refuted:
+        return None
+
+    # Guard 3: never touch a spelling the author's own text uses.
+    if any(token in source_words for token in refuted):
+        return None
+
+    roster_tokens = _roster_core_tokens(roster_index)
+    pool = _repair_candidate_pool(roster_index, window_words, source_words)
+
+    substitutions = {}
+    for token in set(refuted):
+        near_roster = [c for c in roster_tokens if _is_distance_one(token, c)]
+        if len(near_roster) != 1:
+            return None
+        near_pool = [c for c in pool if _is_distance_one(token, c)]
+        if len(near_pool) != 1:
+            return None
+        substitutions[token] = near_pool[0]
+
+    rebuilt = []
+    for raw_token in canonical.split():
+        base, suffix = _split_possessive(raw_token)
+        rebuilt.append(substitutions[base] + suffix if base in substitutions else raw_token)
+
+    repaired = " ".join(rebuilt).strip()
+    if not repaired or repaired == canonical:
+        return None
+    if attest_speaker(repaired, windows) != ATTESTED:
+        return None
+    return repaired
+
+
+def near_spellings(canonical, windows, roster_index):
+    """Established roster spellings within one edit of a refuted label token,
+    for use as a PROMPT HINT when repair declines.
+
+    Advisory only and deliberately unguarded compared with repair_speaker: it
+    lists possibilities for the model to choose from (or ignore -- a prompt
+    cannot enforce anything), it never changes a label. Returns a sorted list
+    of candidate tokens, possibly empty. Pure; mutates nothing.
+    """
+    if not canonical or not roster_index:
+        return []
+    window_words = set()
+    for window in windows or []:
+        if window:
+            window_words |= _window_words(window)
+    roster_tokens = _roster_core_tokens(roster_index)
+    candidates = set()
+    for token in _core_tokens(canonical):
+        if token in window_words:
+            continue
+        for candidate in roster_tokens:
+            if _is_distance_one(token, candidate):
+                candidates.add(candidate)
+    return sorted(candidates)

--- a/app/speaker_canon.py
+++ b/app/speaker_canon.py
@@ -10,6 +10,14 @@ Two tiers:
   single raw speaker label into a canonical UPPERCASE form. Safe to apply
   everywhere a speaker label is produced or compared.
 
+  Tier 1b (roster_key / remember_in_roster / resolve_against_roster):
+  roster-AWARE spelling resolution, kept strictly separate from canonicalize()
+  so the latter stays pure. It unifies two spellings ONLY when they are equal
+  after removing every boundary mark -- whitespace, hyphens, apostrophes --
+  ("ABBEMARIGNAN" -> "ABBE MARIGNAN", "OBRIEN" -> "O'BRIEN"), keeping the
+  more-punctuated form. Exact key equality, never fuzzy similarity, so names
+  that merely look alike are never merged.
+
   Tier 2 (suggest_aliases): advisory-only fuzzy matching across an already-
   canonicalized roster. It NEVER merges or mutates the roster; it only
   returns suggestion records for a human (via the Voices UI) to accept or
@@ -196,6 +204,134 @@ def canonicalize(raw: str) -> str:
         return "NARRATOR"
 
     return canonical
+
+
+# ---------------------------------------------------------------------------
+# Tier 1b: roster-aware spelling resolution
+#
+# canonicalize() is, and must remain, a PURE function of one string: it is
+# roster-free and idempotent, and suggest_aliases() depends on that for
+# comparison. Roster awareness therefore lives here, in separate functions
+# that take the roster explicitly.
+#
+# Why this exists: an LLM was observed emitting "ABBEMARIGNAN" one chunk after
+# correctly emitting "ABBE MARIGNAN", with the correct spelling right there in
+# its context. Ordinary spelling drift. canonicalize() has no space-deleting
+# path (correctly -- it must never invent or delete word boundaries), so both
+# forms otherwise survive as two roster entries, two voice assignments, and two
+# voices for one character.
+#
+# CONTRACT -- never auto-merge similar names. JON/JOHN and ELLA/BELLA are
+# different people and must stay distinct roster entries. The ONLY unification
+# permitted is EXACT equality on a derived key: no threshold, no similarity
+# score, nothing fuzzy. The key is the canonical form with every
+# non-alphanumeric character removed, so two spellings unify iff they have
+# identical letters and digits in identical order and differ ONLY in their
+# boundary marks -- spaces, hyphens and apostrophes:
+#
+#     ABBE MARIGNAN / ABBEMARIGNAN      -> ABBEMARIGNAN      (unified)
+#     O'BRIEN       / OBRIEN            -> OBRIEN            (unified)
+#     JEAN-LUC      / JEAN LUC          -> JEANLUC           (unified)
+#     JON / JOHN, ELLA / BELLA          -> different keys    (NOT unified)
+#
+# One key rather than a whitespace-tier-then-punctuation-tier lookup: the
+# two-tier version buys nothing here (a narrower whitespace-only match is
+# always also a punctuation match, so precedence never actually differs on
+# real data) and costs a second lookup plus a precedence rule to explain.
+#
+# MEASURED on the real 578-label production roster: the whitespace-only key
+# produced 2 collision families, and this wider key produces exactly the same
+# 2 -- both of them the known ABBE MARIGNAN pair ("ABBE MARIGNAN" and
+# "ABBE MARIGNAN'S NIECE"). Adding punctuation to the key introduced ZERO new
+# collisions on real data. test_real_roster_key_introduces_no_new_collisions
+# in test_speaker_canon.py pins that property so the key cannot silently widen.
+#
+# The residual risk this DOES carry: names where a boundary mark is a real
+# morpheme boundary rather than a typo -- transliterated Korean/Chinese/
+# Japanese short names such as LI NA vs LINA or O KIN vs OKIN would be unified
+# even if they are two people. Judged acceptable because the Voices UI's alias
+# mechanism is the escape hatch, though an imperfect one: aliasing can merge
+# two roster entries, it cannot split one that was wrongly merged here.
+#
+# SELECTION RULE -- MOST BOUNDARY MARKS WINS; ties go to the incumbent (the
+# first spelling seen). Two spellings sharing a key have identical letters and
+# digits, so the LONGER string is exactly the one carrying more boundary marks
+# -- that is the whole rule, and it is why the comparison below is a length
+# comparison. "ABBE MARIGNAN" beats "ABBEMARIGNAN", "O'BRIEN" beats "OBRIEN",
+# regardless of arrival order. Rationale: LLMs drop boundary marks far more
+# often than they insert them, so the more-punctuated form is the more likely
+# original. It picks correctly for both observed collision families.
+#
+# Equal-length variants are genuine ties -- "JEAN-LUC" vs "JEAN LUC",
+# "MARY-ANNE" vs "MARY ANNE" -- where neither form is more likely correct than
+# the other. The incumbent keeps the slot: deterministic, and the outcome
+# depends only on which spelling the roster met first.
+#
+# Critically, this rule is ORDER-INDEPENDENT wherever the lengths differ.
+# First-seen-wins was not: it made the canonical spelling depend on arrival
+# order, so one malformed first sighting would become canonical for the rest
+# of the book AND be fed back into the prompt's roster block, and generation
+# (chunk order) and review (entry order) could genuinely disagree about who
+# was "first".
+# ---------------------------------------------------------------------------
+
+# Everything that is not a letter or a digit. Applied to an ALREADY canonical
+# name, where the only survivors are spaces, hyphens and apostrophes.
+_KEY_STRIP_RE = re.compile(r"[^A-Z0-9]")
+
+
+def roster_key(name: str) -> str:
+    """Derived comparison key for a speaker name: the canonical form with all
+    boundary marks (whitespace, hyphens, apostrophes) removed.
+
+    Lossy, and used ONLY for exact-equality lookup -- never displayed, never
+    stored as a speaker label. Two names share a key iff they differ solely in
+    where their boundary marks fall.
+    """
+    return _KEY_STRIP_RE.sub("", canonicalize(name))
+
+
+def remember_in_roster(index: dict, name: str) -> str:
+    """Record ``name`` in a roster index and return the winning spelling.
+
+    ``index`` is a plain ``{roster_key: established_spelling}`` dict; callers
+    create it as ``{}`` and feed it back on every label, so each lookup is
+    O(1). It is mutated in place.
+
+    The winner is the spelling carrying the most boundary marks, which -- since
+    colliding spellings share every letter and digit -- is simply the longer
+    string; equal-length ties keep the incumbent. See the section comment above
+    for why this rule, and not first-seen-wins, is the safe one. Returns the
+    winning spelling, or "" for a name that canonicalizes to nothing.
+    """
+    canonical = canonicalize(name)
+    if not canonical:
+        return ""
+
+    key = _KEY_STRIP_RE.sub("", canonical)
+    established = index.get(key)
+    if established is None:
+        index[key] = canonical
+        return canonical
+
+    if len(canonical) > len(established):
+        index[key] = canonical
+        return canonical
+    return established
+
+
+def resolve_against_roster(raw: str, index: dict) -> str:
+    """Canonicalize ``raw`` and snap it onto the established spelling that
+    differs from it only in its boundary marks, if the roster has one.
+
+    Read-only counterpart to ``remember_in_roster``: ``index`` is never
+    mutated, and a name the roster has not seen simply passes through as
+    ``canonicalize(raw)``. Idempotent.
+    """
+    canonical = canonicalize(raw)
+    if not canonical:
+        return ""
+    return (index or {}).get(_KEY_STRIP_RE.sub("", canonical)) or canonical
 
 
 # ---------------------------------------------------------------------------

--- a/app/speaker_canon.py
+++ b/app/speaker_canon.py
@@ -1,0 +1,215 @@
+"""Speaker-name canonicalization for the Alexandria audiobook pipeline.
+
+This module is standalone and dependency-light (stdlib + rapidfuzz only).
+It must NOT import anything from app.py / review_script.py / generate_script.py —
+those modules will import THIS module in a later integration stage.
+
+Two tiers:
+
+  Tier 1 (canonicalize): fully automatic, deterministic normalization of a
+  single raw speaker label into a canonical UPPERCASE form. Safe to apply
+  everywhere a speaker label is produced or compared.
+
+  Tier 2 (suggest_aliases): advisory-only fuzzy matching across an already-
+  canonicalized roster. It NEVER merges or mutates the roster; it only
+  returns suggestion records for a human (via the Voices UI) to accept or
+  reject. JON/JOHN and ELLA/BELLA are deliberately treated as *distinct*
+  people in the roster even though they are similar strings -- this module
+  will surface a suggestion for a human to review, but will not merge them.
+
+IMPORTANT: canonicalization applies to speaker LABELS only. Audiobook body
+text must remain byte-for-byte verbatim; nothing in this module should ever
+be applied to spoken/narrated text.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from rapidfuzz import fuzz
+
+# ---------------------------------------------------------------------------
+# Tier 1: canonicalize()
+# ---------------------------------------------------------------------------
+
+# Honorifics stripped from the front of a name, longest-first so multi-word
+# honorifics (e.g. "Professor") aren't shadowed by a shorter prefix match.
+# Matched case-insensitively, with an optional trailing period, followed by
+# whitespace (so "Drake" is never mistaken for "Dr" + "ake").
+_HONORIFICS = [
+    "professor", "captain", "prof", "capt", "mrs", "miss", "lady", "lord",
+    "dame", "col", "rev", "sgt", "mr", "ms", "mx", "dr", "sir", "lt", "fr",
+    "st",
+]
+
+_HONORIFIC_RE = re.compile(
+    r"^(?:" + "|".join(_HONORIFICS) + r")\.?\s+",
+    re.IGNORECASE,
+)
+
+# A parenthetical (and any surrounding whitespace) anywhere in the string,
+# e.g. "MARK (shouting)" -> "MARK", "MARK (angrily) enters" -> "MARK enters".
+_PARENS_RE = re.compile(r"\s*\([^)]*\)\s*")
+
+# Characters allowed to remain in a canonical name: letters, digits,
+# whitespace, apostrophes (O'Brien), and hyphens (Jean-Luc). Everything else
+# is considered "stray punctuation" and stripped. This intentionally runs
+# AFTER accent normalization (NFKD + combining-mark strip), so accented
+# letters have already been folded down to plain ASCII letters by this point.
+_ALLOWED_CHARS_RE = re.compile(r"[^A-Za-z0-9'\-\s]")
+
+# Collapse any run of whitespace to a single space.
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _strip_accents(text: str) -> str:
+    """Fold accented characters down to their base ASCII form.
+
+    e.g. 'José' -> 'Jose', 'François' -> 'Francois'.
+    """
+    normalized = unicodedata.normalize("NFKD", text)
+    return "".join(ch for ch in normalized if not unicodedata.combining(ch))
+
+
+def canonicalize(raw: str) -> str:
+    """Canonicalize a raw speaker label into its canonical UPPERCASE form.
+
+    Steps (in order):
+      1. Bail out to "" for empty/whitespace-only input.
+      2. Strip accents (NFKD decompose + drop combining marks).
+      3. Remove parenthetical asides, e.g. "MARK (shouting)" -> "MARK".
+      4. Strip stray punctuation, keeping apostrophes and hyphens (so
+         "O'Brien" and "Jean-Luc" survive intact).
+      5. Collapse internal whitespace runs and strip leading/trailing space.
+      6. Strip a single leading honorific (Mr, Mrs, Dr, Professor, ...) --
+         but never let this reduce a non-empty input to emptiness; if
+         stripping the honorific would leave nothing, keep the honorific
+         itself as the name (e.g. "Dr." alone -> "DR").
+      7. Uppercase the result.
+      8. Map any casing of "narrator" to exactly "NARRATOR".
+
+    Canonicalization is idempotent: canonicalize(canonicalize(x)) ==
+    canonicalize(x).
+    """
+    if raw is None:
+        return ""
+
+    text = raw.strip()
+    if not text:
+        return ""
+
+    text = _strip_accents(text)
+    text = _PARENS_RE.sub(" ", text)
+    text = _ALLOWED_CHARS_RE.sub(" ", text)
+    text = _WHITESPACE_RE.sub(" ", text).strip()
+
+    if not text:
+        return ""
+
+    honorific_match = _HONORIFIC_RE.match(text)
+    if honorific_match:
+        remainder = text[honorific_match.end():].strip()
+        if remainder:
+            text = remainder
+        # else: stripping would empty the name out -- keep original text
+        # (the honorific itself becomes the canonical name).
+
+    text = _WHITESPACE_RE.sub(" ", text).strip()
+    canonical = text.upper()
+
+    if canonical == "NARRATOR":
+        return "NARRATOR"
+
+    return canonical
+
+
+# ---------------------------------------------------------------------------
+# Tier 2: suggest_aliases()
+# ---------------------------------------------------------------------------
+
+# Similarity metric: rapidfuzz.fuzz.ratio, which is an Indel/Levenshtein-based
+# normalized similarity in the range [0, 100]. Chosen (over Jaro-Winkler)
+# because it penalizes inserted/deleted characters roughly in proportion to
+# name length, which lines up well with short-name confusions like
+# JON/JOHN (single inserted "H") and ELLA/BELLA (single inserted "B") while
+# still keeping unrelated names like MARCUS/ELENA far apart.
+#
+# Threshold: 75 (out of 100). Chosen empirically:
+#   - JON vs JOHN     -> ratio ~85.7  (>= 75, suggestion emitted)
+#   - ELLA vs BELLA   -> ratio ~88.9  (>= 75, suggestion emitted)
+#   - MARCUS vs ELENA -> ratio ~18.2  (< 75, no suggestion)
+#
+# Direction rule: the SHORTER canonical name is suggested as an alias of the
+# LONGER canonical name (ties broken alphabetically, shorter/earlier name
+# first). Rationale: honorific/typo/nickname variants are usually shorter
+# than or equal in length to the "fuller" form (e.g. JON -> JOHN), so the
+# longer string is treated as the more complete / likely-canonical target.
+# This is a heuristic default, not a claim about which name is "more
+# frequent" in the manuscript -- callers with real frequency counts from the
+# roster may want to override this ordering.
+_SIMILARITY_THRESHOLD = 75.0
+
+
+def suggest_aliases(roster: list) -> list:
+    """Suggest advisory alias pairs within an already-canonicalized roster.
+
+    This function is READ-ONLY: it never mutates `roster` and never merges
+    or removes any entry. It only returns a list of suggestion dicts for a
+    human reviewer (e.g. the Voices UI) to accept or reject. Names deemed
+    similar (e.g. JON/JOHN, ELLA/BELLA) remain fully distinct roster entries
+    -- this function does not, and must not, auto-merge them.
+
+    Args:
+        roster: list of speaker name strings. Names are expected to already
+            be canonical (e.g. produced by `canonicalize`), but this function
+            re-canonicalizes defensively and de-duplicates before comparing,
+            so raw/mixed-case input degrades gracefully rather than raising.
+
+    Returns:
+        A list of dicts, each shaped like:
+            {"name": <shorter name>, "alias_of": <longer name>, "score": <float 0-1>}
+        sorted by descending score. "score" is normalized to the 0.0-1.0
+        range (rapidfuzz's 0-100 ratio divided by 100), per the example in
+        the design brief. NARRATOR is always excluded, from either side of
+        a pair.
+    """
+    if not roster:
+        return []
+
+    # Defensive re-canonicalization + de-duplication, preserving first-seen
+    # order. This does NOT mutate the caller's list/object.
+    seen = set()
+    names = []
+    for raw_name in roster:
+        name = canonicalize(raw_name)
+        if not name or name == "NARRATOR":
+            continue
+        if name in seen:
+            continue
+        seen.add(name)
+        names.append(name)
+
+    suggestions = []
+    for i in range(len(names)):
+        for j in range(i + 1, len(names)):
+            a, b = names[i], names[j]
+            score = fuzz.ratio(a, b)
+            if score < _SIMILARITY_THRESHOLD:
+                continue
+
+            # Direction: shorter name is the alias, longer name is the
+            # target. Ties broken alphabetically for determinism.
+            if len(a) < len(b) or (len(a) == len(b) and a < b):
+                shorter, longer = a, b
+            else:
+                shorter, longer = b, a
+
+            suggestions.append({
+                "name": shorter,
+                "alias_of": longer,
+                "score": round(score / 100.0, 4),
+            })
+
+    suggestions.sort(key=lambda s: s["score"], reverse=True)
+    return suggestions

--- a/app/speaker_canon.py
+++ b/app/speaker_canon.py
@@ -32,7 +32,10 @@ Two tiers:
   Tier 3 (attest_label / attest_speaker): advisory local-window attestation
   -- flags labels whose core name tokens don't appear near the label's own
   entries in the source, catching drift/invention the LLM produces (e.g.
-  transposed letters, invented names). READ-ONLY / advisory: never mutates
+  transposed letters, invented names). A MULTI-token label must occur as a
+  PHRASE, not merely as tokens scattered through the window, or a name
+  recombined from two real characters' name parts attests. READ-ONLY /
+  advisory: never mutates
   anything. attest_label() returns the boolean detail record the Voices UI
   badge consumes; attest_speaker() returns the three-way ATTESTED /
   UNATTESTED / UNVERIFIABLE verdict a would-be *gate* needs, because a
@@ -765,6 +768,101 @@ def _window_words(window: str) -> set:
     return words
 
 
+def _window_token_sequence(window: str) -> list:
+    """The ORDERED list of folded word tokens in a source window.
+
+    Companion to _window_words (which is an unordered set): adjacency cannot be
+    decided from a set, and a multi-token label is only attested when its parts
+    occur next to each other -- see _phrase_present.
+
+    Hyphens are split, not joined, on BOTH sides of the comparison (here and in
+    _phrase_present's label side), so "ARCH-VOTARY" and a source "Arch votary"
+    or "Arch-votary" all reduce to the same two-element run. Folding is
+    _fold_word, so case, accents, curly apostrophes and one trailing possessive
+    are already normalized -- which is what makes "X'S DAD" match a source
+    "X's dad" without any possessive-specific rule here.
+    """
+    sequence = []
+    for raw_token in _scan_tokens(window, join_hyphens=False):
+        folded = _fold_word(raw_token)
+        if folded:
+            sequence.extend(part for part in folded.split("-") if part)
+    return sequence
+
+
+# Source words allowed to sit BETWEEN two core tokens without breaking the
+# phrase: the words _core_tokens drops from the label, MINUS the conjunctions,
+# so a label and the source phrase it came from stay comparable ("MOTHER OF
+# MONSTERS" matches "Mother of Monsters"; a leading article or title either
+# side carries or omits is invisible to both).
+#
+# CONJUNCTIONS ARE EXCLUDED ON PURPOSE. "and"/"or" is precisely the shape that
+# joins two DIFFERENT entities -- "the TV and the DVD", "Kit and Nita" -- so
+# skipping them would re-admit the recombined label this rule exists to refuse.
+# MEASURED: keeping them let 2 of the 5 fabricated labels back through.
+_PHRASE_SKIPPABLE = (
+    (_CORE_TOKEN_STOPWORDS - {"AND", "OR"}) | _CORE_TOKEN_TITLES
+)
+
+
+def _phrase_present(core_tokens: list, windows: list) -> bool:
+    """True iff ``core_tokens`` occur ADJACENT and IN ORDER in some window.
+
+    "Adjacent" tolerates only _PHRASE_SKIPPABLE words in between. Nothing fuzzy:
+    every token must match exactly after folding.
+    """
+    # ponytail: adjacency is measured in WORDS, so punctuation and even a
+    # sentence break between two tokens is invisible ("...the TV. The news...")
+    # -- it only ever makes the gate more permissive, never less. Track
+    # sentence boundaries here if a real book is measured slipping through.
+    wanted = []
+    for token in core_tokens:
+        wanted.extend(part for part in token.split("-") if part)
+    if not wanted:
+        return False
+
+    for window in windows or []:
+        if not window:
+            continue
+        sequence = _window_token_sequence(window)
+        for start in range(len(sequence)):
+            index = start
+            matched = 0
+            while index < len(sequence) and matched < len(wanted):
+                if sequence[index] == wanted[matched]:
+                    matched += 1
+                elif matched == 0 or sequence[index] not in _PHRASE_SKIPPABLE:
+                    break
+                index += 1
+            if matched == len(wanted):
+                return True
+    return False
+
+
+def _is_possessive_composition(label: str) -> bool:
+    """True when the label carries a possessive token -- "X'S DAD", "X'S
+    FATHER": a RELATION described in terms of a named person, not a name.
+
+    Such labels are EXEMPT from the phrase requirement, and the exemption is
+    load-bearing rather than cosmetic. MEASURED: on one 8,081-entry artifact
+    "NITA'S DAD" carries 50 correctly-attributed entries, and the source spells
+    that phrase just 5 times in 790,543 characters -- the character is
+    overwhelmingly referred to by pronoun near his own speech, so demanding the
+    phrase inside his own attestation window refuses 50 good entries to catch
+    none. (A label built on a name the book names OFTEN, "ROSHAUN'S FATHER"
+    with 25 occurrences, happens to survive the phrase rule -- which is exactly
+    the point: without the exemption the verdict depends on how chatty the
+    narrator is, not on whether the label is real.)
+
+    Safe against the recombination the phrase rule exists to catch: an invented
+    name is assembled from two NAME parts ("<first> <surname-of-someone-else>")
+    and carries no possessive. The residual cost is stated in attest_label.
+
+    A property of how labels are composed in English, not of any book.
+    """
+    return any(_split_possessive(token)[1] for token in (label or "").split())
+
+
 def _core_tokens(label: str) -> list:
     """Extract the "core" identifying tokens from a canonical speaker label.
 
@@ -802,9 +900,32 @@ def attest_label(label: str, windows: list) -> dict:
     Returns:
         {"attested": bool, "missing_tokens": [str, ...], "core_tokens": [str, ...]}
 
-        A label is attested=True iff EVERY core token extracted from it
-        appears (accent-folded, case-insensitive, possessive-stripped) as a
-        whole word in at least one window.
+        A SINGLE-core-token label is attested=True iff that token appears
+        (accent-folded, case-insensitive, possessive-stripped) as a whole word
+        in at least one window.
+
+        A MULTI-core-token label must additionally occur as a PHRASE: its
+        tokens adjacent and in order in one window, with only stopwords/titles
+        allowed between them (_phrase_present). Per-token set membership alone
+        attests any label whose parts merely appear somewhere nearby, which is
+        how a plausible-looking name assembled from two different characters'
+        name parts passed the gate, entered the roster, and was then never
+        re-checked for the rest of the book. Measured on one clean 8,081-entry
+        artifact: 5 such labels carrying 11 entries occur nowhere in the
+        790,543-character book as a phrase, while all 16 legitimate multi-token
+        labels do and still pass.
+
+        EXEMPT from the phrase requirement: a possessive composition ("X'S
+        DAD"), which is a relation, not a name -- see _is_possessive_composition
+        for the measurement that forces the exemption. The cost of the
+        exemption is that a possessive label whose relation word is invented
+        ("X'S FATHER" where the book only ever says "X's dad") still attests on
+        per-token evidence; bounded, because the named half must still attest.
+
+        When every token is present but not adjacent, missing_tokens is []
+        and note="tokens_not_adjacent" -- attested=False with nothing missing.
+        Callers must not read an empty missing_tokens as "nothing wrong"; that
+        distinction is what attest_speaker turns into UNATTESTED.
 
         If the label has ZERO core tokens (e.g. it is only a title, or only
         stopwords -- "MISTER", "NARRATOR"-like edge cases), this is treated
@@ -838,10 +959,21 @@ def attest_label(label: str, windows: list) -> dict:
 
     missing = [token for token in core_tokens if token not in words_seen]
 
+    if missing or len(core_tokens) < 2 or _is_possessive_composition(label):
+        return {
+            "attested": not missing,
+            "missing_tokens": missing,
+            "core_tokens": core_tokens,
+        }
+
+    if _phrase_present(core_tokens, windows or []):
+        return {"attested": True, "missing_tokens": [], "core_tokens": core_tokens}
+
     return {
-        "attested": len(missing) == 0,
-        "missing_tokens": missing,
+        "attested": False,
+        "missing_tokens": [],
         "core_tokens": core_tokens,
+        "note": "tokens_not_adjacent",
     }
 
 
@@ -926,7 +1058,9 @@ def attest_speaker(label, windows, roster_index=None):
     scripts this module cannot tokenize.
 
     Verdicts:
-      ATTESTED      every core token appears as a whole word in some window.
+      ATTESTED      every core token appears as a whole word in some window,
+                    AND (for a multi-token label) they appear there adjacent
+                    and in order -- see attest_label.
       UNVERIFIABLE  the label yields no core tokens at all (it is only
                     titles/stopwords), or every otherwise-missing token IS
                     present in a window but not at a word boundary. The
@@ -955,12 +1089,16 @@ def attest_speaker(label, windows, roster_index=None):
     common noun the model copied out of the prose, which would gut the gate.
     Requiring a ROSTER token is what keeps it narrow.
 
-    Its cost, stated plainly: the roster is not itself guaranteed clean, so a
-    junk name that reached the roster earlier (an UNVERIFIABLE acceptance, say)
-    lends its tokens to later multi-token labels. The failure is bounded --
-    those labels are ACCEPTED-and-counted rather than silently correct, and
-    prose is never involved -- but it is a real widening of the gate on a book
-    whose roster has already been polluted.
+    Its cost, stated plainly, and NARROWED but not closed by the adjacency
+    rule: a label whose tokens all occur nearby but never adjacently is now
+    refuted before this rule is consulted, so the commonest abuse -- a name
+    recombined from two established characters' name parts -- no longer reaches
+    it. What remains: a label with a token that occurs NOWHERE in the window is
+    still rescued to UNVERIFIABLE by one roster token that does, and the roster
+    is not itself guaranteed clean, so a junk name accepted earlier lends its
+    tokens onward. The failure stays bounded -- such labels are
+    ACCEPTED-and-counted rather than silently correct, and prose is never
+    involved -- but it is a real widening of the gate on a polluted roster.
 
     ``roster_index`` is an explicit argument, never module state: this function
     stays a pure function of its inputs, and canonicalize() stays roster-free
@@ -989,6 +1127,16 @@ def attest_speaker(label, windows, roster_index=None):
         return UNVERIFIABLE
     if result["attested"]:
         return ATTESTED
+
+    # Non-adjacency is positive evidence, not absence of evidence: every token
+    # IS in the window as a whole word, and the book still never puts them
+    # together. Refuted outright, and deliberately BEFORE the roster path --
+    # the recombined label's parts are usually roster names (that is what makes
+    # it plausible), so letting the roster rule see it would rescue exactly the
+    # case this refutes. Unsegmented scripts never reach here: their tokens are
+    # individually missing, so they take the substring probe below as before.
+    if result.get("note") == "tokens_not_adjacent":
+        return UNATTESTED
 
     # Roster-name partial attestation (see docstring). Checked before the
     # substring probe because it is the cheaper and more specific rule.

--- a/app/speaker_canon.py
+++ b/app/speaker_canon.py
@@ -1191,6 +1191,170 @@ def repair_speaker(canonical, windows, roster_index, source_words):
     return repaired
 
 
+# ---------------------------------------------------------------------------
+# Tier 3c: attribution-tag agreement
+#
+# THE DEFECT THIS ANSWERS. Attestation asks "does this NAME occur somewhere
+# nearby?". It never asks "is it the name the adjacent attribution tag actually
+# gives". Measured on one clean 8,081-entry production artifact: of 1,117
+# dialogue spans followed by a machine-checkable name tag, 60 (5.4%) were
+# labelled with a DIFFERENT established character than the tag names -- every
+# one of them attested, so no existing check saw them.
+#
+# DETECT, NEVER REWRITE. These functions are read-only and return evidence.
+# Relabelling a span from the tag would be a second repair_speaker: nearby
+# evidence silently overriding the model. The caller routes a detection into
+# the retry path (ask the model again, naming the tag) and, failing that, into
+# the degradation report.
+#
+# ENGLISH-ONLY, BY CONSTRUCTION, AND IT DEGRADES TO SILENCE. Recognizing an
+# attribution tag requires recognizing a speech verb, and there is no
+# language-neutral way to do that -- so _SPEECH_VERBS below is an English word
+# list, in the same acknowledged-limitation class as _RANK_TITLES (English
+# titles) and span_tokenizer's quote-mark table. On a French or Japanese book
+# NOTHING in the tag pattern matches: no token equals "said"/"asked"/..., so
+# attribution_tag_name() returns None for every span, contradicts_attribution()
+# returns None for every span, and the caller's counters stay at zero. The
+# failure mode is zero detections -- never a false accusation and never a
+# wrong retry. It is not book-fitted: it contains no name, idiom or phrasing
+# from any particular novel, only the verbs any English narration uses.
+# ---------------------------------------------------------------------------
+
+# English speech verbs that introduce or close an attribution tag. Deliberately
+# SHORT and unambiguous: every entry is a verb whose subject is the speaker of
+# the adjacent quotation. Verbs that are commonly NOT attributive ("continued",
+# "went on", "laughed") are left out -- this list is tuned for precision,
+# because a false detection costs a wasted retry and a false degradation.
+_SPEECH_VERBS = frozenset({
+    "said", "says", "asked", "asks", "replied", "answered", "called",
+    "shouted", "whispered", "murmured", "added", "muttered", "agreed",
+    "snapped", "told",
+})
+
+# A word for tag-matching purposes: a letter-initial token, apostrophes and
+# internal hyphens included ("O'Brien", "Jean-Luc", "Nita's"). `[^\W\d_]` is
+# "any letter in any script", same intent as _is_name_char.
+_TAG_WORD = r"[^\W\d_][\w'‘’\-]*"
+
+# The two shapes an attribution tag takes right after a quotation:
+# "<Name> said ..." and "said <Name> ...". Leading whitespace, commas, colons
+# and dashes are skipped; anything else means this is not a tag.
+_TAG_RE = re.compile(
+    r"^[\s,;:\-–—]*(" + _TAG_WORD + r")\s+(" + _TAG_WORD + r")",
+    re.UNICODE,
+)
+
+# A blank line before the tag means the narration starts a new paragraph, so it
+# belongs to what FOLLOWS, not to the quotation before it.
+_PARAGRAPH_BREAK_RE = re.compile(r"^[^\S\n]*\n\s*\n")
+
+# Only the first line or so can hold the tag; scanning further invites matches
+# deep inside unrelated narration.
+_TAG_SCAN_CHARS = 120
+
+
+def attribution_tag_name(text):
+    """The proper-name word of an attribution tag at the START of ``text``.
+
+    ``text`` is the narration immediately following a quotation. Returns the
+    name as it is spelled in the source ("Nita", "McAllister"), or None when
+    there is no recognizable tag. Pure, read-only, English-only (see the
+    section comment: a non-English book yields None for every span).
+
+    Refuses -- returns None -- in every ambiguous case:
+
+      * a blank line before the tag (the narration is a new paragraph, so the
+        tag introduces the NEXT quotation rather than closing the previous one);
+      * no ``_SPEECH_VERBS`` verb adjacent to the candidate word;
+      * a candidate that is not capitalized ("said the man", "said his
+        mother") -- a common noun is not a name;
+      * a POSSESSIVE candidate ("said Nita's dad"), where the name is a
+        modifier of somebody else. This case is the reason the check needs a
+        possessive test at all: the label "NITA'S DAD" is correct there, and a
+        naive name-grab reads the tag as NITA and reports a contradiction.
+    """
+    if not text:
+        return None
+    if _PARAGRAPH_BREAK_RE.match(text):
+        return None
+
+    match = _TAG_RE.match(text[:_TAG_SCAN_CHARS])
+    if not match:
+        return None
+
+    first, second = match.group(1), match.group(2)
+    if first.lower() in _SPEECH_VERBS:
+        candidate = second
+    elif second.lower() in _SPEECH_VERBS:
+        candidate = first
+    else:
+        return None
+
+    if candidate.lower() in _SPEECH_VERBS:
+        return None
+    if not candidate[:1].isupper():
+        return None
+    if _split_possessive(candidate)[1]:
+        return None
+    return candidate
+
+
+def contradicts_attribution(speaker, following_text, roster_index):
+    """The established roster name an attribution tag gives, when it CONTRADICTS
+    ``speaker``. Returns None whenever the two are compatible, or whenever the
+    evidence does not decide -- which is most of the time, by design.
+
+    ``speaker`` is a canonical label; ``following_text`` is the narration span
+    immediately after that speaker's quotation; ``roster_index`` is a
+    ``{roster_key: spelling}`` index (see remember_in_roster) used to turn a tag
+    word into an established name. Roster-aware and therefore explicit-argument,
+    like every other roster consumer here; nothing is mutated.
+
+    Compatible -- and so NOT reported -- includes:
+
+      * case and apostrophe-glyph differences (MCALLISTER vs McAllister,
+        SKER'RET vs Sker’ret): both sides go through _fold_word;
+      * GRANULARITY variants (TOM vs TOM SWALE, DARRYL vs DARRYL MCALLISTER):
+        the label and the tagged name sharing any core token is agreement about
+        a person, not a contradiction;
+      * an AMBIGUOUS tag word matching two or more roster names (two characters
+        sharing a first name): discarded, never guessed;
+      * a tag word the roster does not know at all. Recall is deliberately
+        sacrificed here: an unknown word cannot be compared with a label
+        without guessing, and a guess is what this check exists to avoid.
+    """
+    if not speaker or speaker == "NARRATOR" or not roster_index:
+        return None
+
+    word = attribution_tag_name(following_text)
+    if not word:
+        return None
+
+    base = _fold_word(word)
+    if not base:
+        return None
+
+    speaker_tokens = set(_core_tokens(speaker))
+    if base in speaker_tokens:
+        return None
+
+    tagged = {name for name in roster_index.values() if base in _core_tokens(name)}
+    if len(tagged) > 1:
+        # A bare tag word that IS an established name in its own right resolves
+        # to that name, even though longer names contain it too: a roster
+        # holding both "NITA" and "NITA'S DAD" is not ambiguous about who
+        # "Nita said" means. Two names merely CONTAINING the word and neither
+        # equal to it (two characters sharing a first name) stays ambiguous.
+        tagged = {name for name in tagged if _core_tokens(name) == [base]}
+    if len(tagged) != 1:
+        return None
+
+    tagged_name = next(iter(tagged))
+    if speaker_tokens & set(_core_tokens(tagged_name)):
+        return None
+    return tagged_name
+
+
 def near_spellings(canonical, windows, roster_index):
     """Established roster spellings within one edit of a refuted label token,
     for use as a PROMPT HINT when repair declines.

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -266,7 +266,30 @@
                             <div class="mb-3">
                                 <label class="form-label">Banned Tokens</label>
                                 <input type="text" class="form-control" id="banned-tokens" placeholder="e.g. <think>, <reasoning>">
-                                <div class="form-text">Comma-separated tokens the LLM is forbidden from generating. Use to disable thinking mode (e.g. <code>&lt;think&gt;</code>).</div>
+                                <div class="form-text">
+                                    Comma-separated tokens the LLM is forbidden from generating.
+                                    <strong>Ignored by Ollama</strong>, which implements no token-banning
+                                    parameter and does not support <code>logit_bias</code> either, so this
+                                    cannot disable thinking mode there &mdash; use Reasoning Effort below.
+                                    Kept for backends that do honour it.
+                                </div>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Reasoning Effort</label>
+                                <select class="form-select" id="reasoning-effort">
+                                    <option value="">Server default (thinking models reason freely)</option>
+                                    <option value="none">none &mdash; disable thinking</option>
+                                    <option value="low">low</option>
+                                    <option value="medium">medium</option>
+                                    <option value="high">high</option>
+                                    <option value="max">max</option>
+                                </select>
+                                <div class="form-text">
+                                    The reliable way to disable thinking mode on Ollama's OpenAI-compatible
+                                    endpoint. A reasoning model can spend its <em>entire</em> token budget
+                                    thinking and return an empty response, which labels nothing and narrates
+                                    the whole chunk. Set <code>none</code> if your model reasons.
+                                </div>
                             </div>
                             <div class="mb-3 form-check form-switch">
                                 <input class="form-check-input" type="checkbox" id="merge-narrators">
@@ -1176,6 +1199,9 @@
                 document.getElementById('llm-url').value = config.llm.base_url;
                 document.getElementById('llm-key').value = config.llm.api_key;
                 document.getElementById('llm-model').value = config.llm.model_name;
+                // "" is a meaningful value here: it means "send nothing", which
+                // leaves the server's own thinking default in place.
+                document.getElementById('reasoning-effort').value = config.llm.reasoning_effort || '';
                 document.getElementById('tts-mode').value = config.tts.mode || 'external';
                 document.getElementById('tts-url').value = config.tts.url || 'http://127.0.0.1:7860';
                 document.getElementById('tts-device').value = config.tts.device || 'auto';
@@ -1326,6 +1352,10 @@
             document.getElementById('min-p').value = 0;
             document.getElementById('presence-penalty').value = 0;
             document.getElementById('banned-tokens').value = '';
+            // Reset to "server default", matching LLMConfig.reasoning_effort's
+            // None default -- resetting must not start sending a field that was
+            // previously absent.
+            document.getElementById('reasoning-effort').value = '';
             document.getElementById('merge-narrators').checked = false;
         };
 
@@ -1351,7 +1381,11 @@
                 llm: {
                     base_url: document.getElementById('llm-url').value,
                     api_key: document.getElementById('llm-key').value,
-                    model_name: document.getElementById('llm-model').value
+                    model_name: document.getElementById('llm-model').value,
+                    // null (not "") when unset, so the key is dropped by
+                    // save_config's exclude_none and the request keeps the
+                    // server default rather than sending an empty string.
+                    reasoning_effort: document.getElementById('reasoning-effort').value || null
                 },
                 tts: {
                     mode: document.getElementById('tts-mode').value,

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1579,12 +1579,9 @@
                             <div class="col-md-3">
                                 <h5 class="card-title">${escapeHtml(voice.name)} ${config.alias_of ? `<span class="badge bg-info ms-2" title="Alias of ${escapeHtml(config.alias_of)}">${escapeHtml(config.alias_of)}</span>` : ''}</h5>
                                 <div class="form-text small text-muted mt-1">Alias of:</div>
-                                <select class="form-select form-select-sm alias-select mt-1">
+                                <select class="form-select form-select-sm alias-select mt-1" data-populated="false">
                                     <option value="">-- None --</option>
-                                    ${(() => {
-                                        const names = (window._voicesNames || []).filter(n => n !== voice.name);
-                                        return names.map(n => `<option value="${escapeHtml(n)}" ${config.alias_of === n ? 'selected' : ''}>${escapeHtml(n)}</option>`).join('');
-                                    })()}
+                                    ${config.alias_of ? `<option value="${escapeHtml(config.alias_of)}" selected>${escapeHtml(config.alias_of)}</option>` : ''}
                                 </select>
                             </div>
                             <div class="col-md-9">
@@ -1717,6 +1714,22 @@
             `;
         }
 
+        // Lazily populate the "Alias of" select's full option list only when the user
+        // actually opens it. With large rosters (n voices), building n options per card
+        // up front is O(n^2) DOM nodes on load; this defers that work to a one-time,
+        // per-select population on first interaction.
+        function populateAliasSelect(select) {
+            if (!select || select.dataset.populated === 'true') return;
+            select.dataset.populated = 'true';
+            const card = select.closest('.voice-card');
+            const voiceName = card ? card.dataset.voice : null;
+            const currentValue = select.value;
+            const names = (window._voicesNames || []).filter(n => n !== voiceName);
+            const optionsHtml = names.map(n => `<option value="${escapeHtml(n)}" ${n === currentValue ? 'selected' : ''}>${escapeHtml(n)}</option>`).join('');
+            select.innerHTML = `<option value="">-- None --</option>${optionsHtml}`;
+            select.value = currentValue;
+        }
+
         window.toggleVoiceType = (radio) => {
             const card = radio.closest('.card-body');
             card.querySelector('.custom-opts').style.display = radio.value === 'custom' ? 'block' : 'none';
@@ -1840,22 +1853,75 @@
             debouncedSaveVoices();
         });
 
+        // Populate an "Alias of" select's full option list on first interaction (mouse
+        // open or keyboard focus) instead of at initial render — see populateAliasSelect.
+        document.getElementById('voices-list').addEventListener('mousedown', (e) => {
+            if (e.target && e.target.classList && e.target.classList.contains('alias-select')) {
+                populateAliasSelect(e.target);
+            }
+        });
+        document.getElementById('voices-list').addEventListener('focusin', (e) => {
+            if (e.target && e.target.classList && e.target.classList.contains('alias-select')) {
+                populateAliasSelect(e.target);
+            }
+        });
+
         // --- Editor Tab ---
         let isPlayingSequence = false;
         let isRenderingAll = false;
         let cachedChunks = []; // Cache to track changes
 
-        function buildSpeakerSelect(chunk) {
+        // Render the speaker select with only its current value (plus a neutral
+        // placeholder when unset) instead of the full roster. With thousands of chunk
+        // rows, building the entire voice roster as <option>s per row up front is
+        // O(rows * roster) DOM nodes; this defers that to a one-time, per-select
+        // population on first interaction (see populateSpeakerSelect).
+        // `knownVoiceSet` is an optional pre-built Set of trimmed voice names, computed
+        // once per table redraw (not per row) so the "(custom)" hint still works cheaply.
+        function buildSpeakerSelect(chunk, knownVoiceSet) {
             const current = (chunk.speaker || '').trim();
+            let currentOption;
+            if (!current) {
+                currentOption = `<option value="" selected>-- Select speaker --</option>`;
+            } else {
+                const isKnown = knownVoiceSet ? knownVoiceSet.has(current) : true;
+                currentOption = `<option value="${escapeHtml(current)}" selected>${escapeHtml(current)}${isKnown ? '' : ' (custom)'}</option>`;
+            }
+
+            return `<select class="form-select form-select-sm chunk-speaker-select" data-populated="false" onchange="updateChunk(${chunk.id}, 'speaker', this.value)">${currentOption}</select>`;
+        }
+
+        // One-time full population of a speaker select's option list, triggered on
+        // first interaction (mouse open or keyboard focus) instead of at render time.
+        function populateSpeakerSelect(select) {
+            if (!select || select.dataset.populated === 'true') return;
+            select.dataset.populated = 'true';
+            const currentValue = select.value;
             const names = Array.isArray(window._voicesNames) ? window._voicesNames : [];
             const normalized = [...new Set(names.map(n => (n || '').trim()).filter(Boolean))].sort((a, b) => a.localeCompare(b));
-            const options = normalized.map(name => `<option value="${escapeHtml(name)}" ${name === current ? 'selected' : ''}>${escapeHtml(name)}</option>`).join('');
-            const unknownOption = current && !normalized.includes(current)
-                ? `<option value="${escapeHtml(current)}" selected>${escapeHtml(current)} (custom)</option>`
+            const options = normalized.map(name => `<option value="${escapeHtml(name)}" ${name === currentValue ? 'selected' : ''}>${escapeHtml(name)}</option>`).join('');
+            const unknownOption = currentValue && !normalized.includes(currentValue)
+                ? `<option value="${escapeHtml(currentValue)}" selected>${escapeHtml(currentValue)} (custom)</option>`
                 : '';
-
-            return `<select class="form-select form-select-sm" onchange="updateChunk(${chunk.id}, 'speaker', this.value)">${unknownOption}${options}</select>`;
+            select.innerHTML = `${unknownOption}${options}`;
+            select.value = currentValue;
         }
+
+        // Populate a chunk row's speaker select's full option list on first interaction
+        // (mouse open or keyboard focus) instead of at render time — see
+        // populateSpeakerSelect. Attached once to the table body, which survives the
+        // tbody.innerHTML full-redraw in loadChunks (same delegation pattern used for
+        // #voices-list's alias-select).
+        document.getElementById('chunks-table-body').addEventListener('mousedown', (e) => {
+            if (e.target && e.target.classList && e.target.classList.contains('chunk-speaker-select')) {
+                populateSpeakerSelect(e.target);
+            }
+        });
+        document.getElementById('chunks-table-body').addEventListener('focusin', (e) => {
+            if (e.target && e.target.classList && e.target.classList.contains('chunk-speaker-select')) {
+                populateSpeakerSelect(e.target);
+            }
+        });
 
         // Check if any audio is currently playing
         function isAudioPlaying() {
@@ -1983,6 +2049,14 @@
                     });
                 } else {
                     // Full redraw needed
+                    // Build the "known voice" lookup once for the whole redraw (not per
+                    // row) so buildSpeakerSelect's "(custom)" hint stays O(1) per row
+                    // instead of re-scanning the full roster for every chunk.
+                    const knownVoiceSet = new Set(
+                        (Array.isArray(window._voicesNames) ? window._voicesNames : [])
+                            .map(n => (n || '').trim())
+                            .filter(Boolean)
+                    );
                     tbody.innerHTML = chunks.map(chunk => {
                         const statusColor = chunk.status === 'done' ? 'success' :
                                           chunk.status === 'generating' ? 'warning' :
@@ -2003,7 +2077,7 @@
                                 <td class="text-center align-middle" style="white-space:nowrap;">
                                     <button class="chunk-action-btn chunk-toggle-btn" onclick="toggleChunkExpand(this)" title="Expand/collapse"><i class="fas fa-chevron-down"></i></button><button class="chunk-action-btn" onclick="insertChunkAfter(${chunk.id})" title="Insert line below"><i class="fas fa-plus"></i></button><button class="chunk-action-btn" onclick="deleteChunk(${chunk.id})" title="Delete line"><i class="fas fa-trash" style="color:#dc3545;"></i></button>
                                 </td>
-                                <td>${buildSpeakerSelect(chunk)}</td>
+                                <td>${buildSpeakerSelect(chunk, knownVoiceSet)}</td>
                                 <td><textarea class="form-control form-control-sm chunk-text" rows="2" onchange="updateChunk(${chunk.id}, 'text', this.value)">${escapeHtml(chunk.text)}</textarea></td>
                                 <td>
                                     <textarea class="form-control form-control-sm chunk-instruct" rows="2" onchange="updateChunk(${chunk.id}, 'instruct', this.value)" title="Short TTS direction (3-8 words)">${escapeHtml(chunk.instruct || '')}</textarea>
@@ -2865,6 +2939,9 @@
                     if (card) {
                         const aliasSel = card.querySelector('.alias-select');
                         if (aliasSel) {
+                            // Ensure the full option list exists before assigning a value that
+                            // may not be among the lazily-rendered options yet.
+                            populateAliasSelect(aliasSel);
                             aliasSel.value = selectedAlias || '';
                             // Trigger save via existing auto-save debounce
                             debouncedSaveVoices();

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1572,12 +1572,22 @@
             const config = voice.config || {};
             const voiceType = config.type || 'custom';
 
+            const flag = (window._labelFlagsMap || {})[voice.name];
+            const attestBadge = (flag && flag.attested === false)
+                ? `<span class="badge bg-warning text-dark ms-2" title="Missing near its lines: ${escapeHtml((flag.missing_tokens || []).join(', '))}">⚠ not found near its lines</span>`
+                : '';
+            const aliasHint = (window._aliasHintMap || {})[voice.name];
+            const aliasHintBadge = aliasHint
+                ? `<div class="form-text small text-muted mt-1">similar to ${escapeHtml(aliasHint)} — review</div>`
+                : '';
+
             return `
                 <div class="card voice-card mb-3" data-voice="${escapeHtml(voice.name)}">
                     <div class="card-body">
                         <div class="row">
                             <div class="col-md-3">
-                                <h5 class="card-title">${escapeHtml(voice.name)} ${config.alias_of ? `<span class="badge bg-info ms-2" title="Alias of ${escapeHtml(config.alias_of)}">${escapeHtml(config.alias_of)}</span>` : ''}</h5>
+                                <h5 class="card-title">${escapeHtml(voice.name)} ${config.alias_of ? `<span class="badge bg-info ms-2" title="Alias of ${escapeHtml(config.alias_of)}">${escapeHtml(config.alias_of)}</span>` : ''}${attestBadge}</h5>
+                                ${aliasHintBadge}
                                 <div class="form-text small text-muted mt-1">Alias of:</div>
                                 <select class="form-select form-select-sm alias-select mt-1" data-populated="false">
                                     <option value="">-- None --</option>
@@ -1760,12 +1770,89 @@
                 container.innerHTML = '<div class="alert alert-info">No voices found. Generate a script first.</div>';
                 return;
             }
+
+            // Fetch advisory label-attestation flags and alias suggestions ONCE
+            // per load (not per row) and index them by name for O(1) lookup
+            // while rendering -- mirrors the lazy alias-select population
+            // pattern above; never loop the roster doing per-row fetches/DOM work.
+            let labelFlags = [];
+            try {
+                const flagsResp = await API.get('/api/voices/label_flags');
+                labelFlags = flagsResp.flags || [];
+            } catch (e) { /* advisory only; ignore if unavailable */ }
+            window._labelFlagsMap = {};
+            labelFlags.forEach(f => { window._labelFlagsMap[f.name] = f; });
+
+            let aliasSuggestions = [];
+            try {
+                const aliasResp = await API.get('/api/voices/alias_suggestions');
+                aliasSuggestions = aliasResp.suggestions || [];
+            } catch (e) { /* advisory only; ignore if unavailable */ }
+            // Hint attaches to the shorter ("name") side of each suggestion pair.
+            window._aliasHintMap = {};
+            aliasSuggestions.forEach(s => { window._aliasHintMap[s.name] = s.alias_of; });
+
+            renderVoicesSummaryStrip(labelFlags, aliasSuggestions);
+
             container.innerHTML = voices.map((v, i) => createVoiceCard(v, i)).join('');
 
             // If any voice has no saved config, save defaults immediately
             if (voices.some(v => !v.config || Object.keys(v.config).length === 0)) {
                 debouncedSaveVoices();
             }
+        }
+
+        // Dismissable summary strip at the top of the Voices screen, combining
+        // attestation flags and alias suggestions, ordered by entry count
+        // descending (biggest-impact problems first). Purely informational --
+        // never pre-selects or auto-applies anything.
+        function renderVoicesSummaryStrip(labelFlags, aliasSuggestions) {
+            const existing = document.getElementById('voices-summary-strip');
+            if (existing) existing.remove();
+            if (sessionStorage.getItem('voicesSummaryDismissed') === '1') return;
+
+            const entryCountByName = {};
+            labelFlags.forEach(f => { entryCountByName[f.name] = f.entry_count; });
+
+            const problems = [];
+            labelFlags.filter(f => f.attested === false).forEach(f => {
+                problems.push({
+                    name: f.name,
+                    entry_count: f.entry_count,
+                    text: `${escapeHtml(f.name)}: not found near its lines`,
+                });
+            });
+            aliasSuggestions.forEach(s => {
+                problems.push({
+                    name: s.name,
+                    entry_count: entryCountByName[s.name] || 0,
+                    text: `${escapeHtml(s.name)}: similar to ${escapeHtml(s.alias_of)} — review`,
+                });
+            });
+            if (problems.length === 0) return;
+
+            problems.sort((a, b) => b.entry_count - a.entry_count);
+
+            const container = document.getElementById('voices-list');
+            const strip = document.createElement('div');
+            strip.id = 'voices-summary-strip';
+            strip.className = 'alert alert-warning d-flex justify-content-between align-items-start';
+            strip.innerHTML = `
+                <div>
+                    <strong>Flagged voices for review:</strong>
+                    <ul class="mb-0 small">
+                        ${problems.map(p => `<li>${p.text} (${p.entry_count} line${p.entry_count === 1 ? '' : 's'})</li>`).join('')}
+                    </ul>
+                </div>
+                <button type="button" class="btn-close" aria-label="Dismiss" onclick="dismissVoicesSummaryStrip()"></button>
+            `;
+            container.parentNode.insertBefore(strip, container);
+        }
+
+        function dismissVoicesSummaryStrip() {
+            sessionStorage.setItem('voicesSummaryDismissed', '1');
+            const existing = document.getElementById('voices-summary-strip');
+            if (existing) existing.remove();
         }
 
         function collectVoiceConfig() {

--- a/app/test_api.py
+++ b/app/test_api.py
@@ -42,6 +42,29 @@ try:
     from default_prompts import DEFAULT_SYSTEM_PROMPT, DEFAULT_USER_PROMPT
     from test_span_integration import FakeClient, FakeResponse, labels_for
     from test_epub_extract import make_epub, opf, extract_epub_text
+
+    # app.py pulls in `project` (-> tts.py -> numpy/torch/etc.) purely for
+    # unrelated TTS/project-management functionality this file's offline
+    # test does not exercise. Stub it out before importing, same pattern as
+    # test_canon_wiring.py, so this best-effort import block degrades
+    # gracefully rather than requiring torch just to test a read-only helper.
+    import types as _types
+    if 'project' not in sys.modules:
+        _fake_project = _types.ModuleType('project')
+
+        class _FakeProjectManager:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __getattr__(self, name):
+                def _noop(*args, **kwargs):
+                    return None
+                return _noop
+
+        _fake_project.ProjectManager = _FakeProjectManager
+        sys.modules['project'] = _fake_project
+
+    import app as app_module
 except Exception as _e:  # pragma: no cover - environment-dependent
     _PIPELINE_IMPORT_ERROR = _e
 
@@ -1600,6 +1623,67 @@ def test_real_annotated_script_word_coverage_if_present():
         )
 
 
+def test_label_flags_endpoint_logic_never_writes_files():
+    """The advisory GET /api/voices/label_flags endpoint (app.py's
+    _compute_label_flags, called directly here rather than over HTTP so this
+    stays offline) must never write or mutate voice_config.json or
+    annotated_script.json on disk -- it is READ-ONLY / advisory tooling per
+    CLAUDE.md's frozen contracts.
+    """
+    _require_pipeline_modules()
+
+    script_path = app_module.SCRIPT_PATH
+    voice_config_path = app_module.VOICE_CONFIG_PATH
+
+    def _snapshot(path):
+        if not os.path.exists(path):
+            return None
+        return (os.path.getmtime(path), os.path.getsize(path))
+
+    before_script = _snapshot(script_path)
+    before_voice_config = _snapshot(voice_config_path)
+
+    source_text = (
+        'Elena walked into the hall. "We should go," Elena said quietly. '
+        "A ghostly figure watched from the shadows without speaking."
+    )
+    script_data = [
+        {"speaker": "Elena", "text": "We should go,", "instruct": "quiet"},
+        # PHANTASMAGORIA never appears in source_text -> exercises the
+        # "flagged unattested" path too, not just the happy path.
+        {"speaker": "Phantasmagoria", "text": "A ghostly figure watched from the shadows", "instruct": "eerie"},
+    ]
+
+    flags = app_module._compute_label_flags(script_data, source_text)
+
+    after_script = _snapshot(script_path)
+    after_voice_config = _snapshot(voice_config_path)
+
+    if before_script != after_script:
+        raise TestFailure(
+            f"_compute_label_flags touched annotated_script.json on disk: "
+            f"before={before_script!r} after={after_script!r}"
+        )
+    if before_voice_config != after_voice_config:
+        raise TestFailure(
+            f"_compute_label_flags touched voice_config.json on disk: "
+            f"before={before_voice_config!r} after={after_voice_config!r}"
+        )
+
+    names = {f["name"] for f in flags}
+    if names != {"ELENA", "PHANTASMAGORIA"}:
+        raise TestFailure(f"expected flags for ELENA and PHANTASMAGORIA, got: {names!r}")
+
+    by_name = {f["name"]: f for f in flags}
+    if by_name["ELENA"]["attested"] is not True:
+        raise TestFailure(f"ELENA should be attested (appears near its own line): {by_name['ELENA']!r}")
+    if by_name["PHANTASMAGORIA"]["attested"] is not False:
+        raise TestFailure(
+            f"PHANTASMAGORIA should be flagged unattested (name never appears in source): "
+            f"{by_name['PHANTASMAGORIA']!r}"
+        )
+
+
 # ── Run all tests ────────────────────────────────────────────
 
 def run_all_tests():
@@ -1743,6 +1827,7 @@ def run_offline_invariant_tests():
     run_test("word_coverage_digits_and_abbreviations_survive_verbatim",
               test_word_coverage_digits_and_abbreviations_survive_verbatim)
     run_test("real_annotated_script_word_coverage_if_present", test_real_annotated_script_word_coverage_if_present)
+    run_test("label_flags_endpoint_logic_never_writes_files", test_label_flags_endpoint_logic_never_writes_files)
 
 
 # ── Cleanup ──────────────────────────────────────────────────

--- a/app/test_api.py
+++ b/app/test_api.py
@@ -1556,6 +1556,102 @@ def test_word_coverage_exact_one_across_failure_modes():
         raise TestFailure("WORD COVERAGE INVARIANT (== 1.0) VIOLATED: " + "; ".join(bad))
 
 
+def _legacy_split_into_chunks(text, max_size=3000):
+    """The pre-fix chunker, verbatim, kept ONLY so the test below can prove the
+    byte-fidelity assertion is failable (it drops a paragraph break at every
+    chunk seam). Not used by the pipeline."""
+    paragraphs = re.split(r'\n\s*\n', text)
+    chunks = []
+    current_chunk = ""
+    for para in paragraphs:
+        para = para.strip()
+        if not para:
+            continue
+        if len(current_chunk) + len(para) + 2 > max_size:
+            if current_chunk:
+                chunks.append(current_chunk.strip())
+                current_chunk = ""
+            if len(para) > max_size:
+                sentences = re.split(r'(?<=[.!?])\s+', para)
+                for sentence in sentences:
+                    if len(current_chunk) + len(sentence) + 1 > max_size:
+                        if current_chunk:
+                            chunks.append(current_chunk.strip())
+                        current_chunk = sentence
+                    else:
+                        current_chunk += " " + sentence if current_chunk else sentence
+            else:
+                current_chunk = para
+        else:
+            current_chunk += "\n\n" + para if current_chunk else para
+    if current_chunk:
+        chunks.append(current_chunk.strip())
+    return chunks
+
+
+# Synthetic, corpus-independent document exercising every whitespace edge the
+# chunker can meet: leading/trailing blank lines, a whitespace-only "paragraph"
+# (NBSP), CRLF, an indented paragraph, and an oversized paragraph that forces
+# the sentence-split path.
+CHUNK_FIDELITY_DOC = (
+    "\n\n  \n"
+    "Chapter One\n\n"
+    "He turned away.\n\n"
+    '"That\'s it," she said.\n\n'
+    " \n\n"
+    "   An indented paragraph follows a blank-ish one.\r\n\r\n"
+    + " ".join(f"Sentence number {i} runs on for a while here." for i in range(60))
+    + "\n\n"
+    "The end.\n \n\n"
+)
+
+
+def test_chunking_is_byte_lossless_over_source():
+    """INVARIANT (byte-verbatim, whole-document half of contract 4): the
+    concatenation of split_into_chunks() output must reproduce the source
+    file BYTE-FOR-BYTE. The existing word-coverage test cannot see a
+    violation here, because review_script.normalize_text() maps punctuation
+    to spaces before tokenizing and every chunk seam sits at punctuation --
+    so a lost paragraph break still scores 1.0. This asserts the raw bytes.
+
+    The paired counter-case runs the pre-fix chunker on the same document and
+    requires it to LOSE characters, proving the assertion is failable rather
+    than tautological.
+    """
+    _require_pipeline_modules()
+    doc = CHUNK_FIDELITY_DOC
+    bad = []
+
+    for max_size in (120, 300, 3000):
+        chunks = split_into_chunks(doc, max_size=max_size)
+        rejoined = "".join(chunks)
+        if rejoined != doc:
+            bad.append(
+                f"max_size={max_size}: rejoined chunks differ from source "
+                f"({len(rejoined)} chars vs {len(doc)}); "
+                f"first divergence at offset "
+                f"{next((i for i, (a, b) in enumerate(zip(rejoined, doc)) if a != b), min(len(doc), len(rejoined)))}"
+            )
+        if any(c == "" for c in chunks):
+            bad.append(f"max_size={max_size}: produced an empty chunk")
+
+    # Degenerate inputs must round-trip too.
+    for edge in ("", "   ", "\n\n\n", "one paragraph"):
+        if "".join(split_into_chunks(edge, max_size=50)) != edge:
+            bad.append(f"edge input {edge!r} did not round-trip")
+
+    if bad:
+        raise TestFailure("CHUNK BYTE-FIDELITY INVARIANT VIOLATED: " + "; ".join(bad))
+
+    # Counter-case: the old chunker must fail this same assertion.
+    legacy = "".join(_legacy_split_into_chunks(doc, max_size=300))
+    if legacy == doc:
+        raise TestFailure(
+            "CHUNK BYTE-FIDELITY test is not failable: the pre-fix chunker "
+            "round-tripped this fixture, so the fixture no longer exercises the bug"
+        )
+
+
 def test_word_coverage_digits_and_abbreviations_survive_verbatim():
     """INVARIANT (word coverage == 1.0) + verbatim: digits, currency, and
     abbreviations ("Dr. Smith owed $1,000 on Elm St.") survive into the
@@ -1824,6 +1920,7 @@ def run_offline_invariant_tests():
     run_test("epub_spine_item_under_200_chars_would_be_flagged",
               test_epub_spine_item_under_200_chars_would_be_flagged)
     run_test("word_coverage_exact_one_across_failure_modes", test_word_coverage_exact_one_across_failure_modes)
+    run_test("chunking_is_byte_lossless_over_source", test_chunking_is_byte_lossless_over_source)
     run_test("word_coverage_digits_and_abbreviations_survive_verbatim",
               test_word_coverage_digits_and_abbreviations_survive_verbatim)
     run_test("real_annotated_script_word_coverage_if_present", test_real_annotated_script_word_coverage_if_present)

--- a/app/test_api.py
+++ b/app/test_api.py
@@ -1556,6 +1556,42 @@ def test_word_coverage_exact_one_across_failure_modes():
         raise TestFailure("WORD COVERAGE INVARIANT (== 1.0) VIOLATED: " + "; ".join(bad))
 
 
+def test_no_character_entry_mixes_quotation_and_narration():
+    """INVARIANT (one entry, one kind of text): the renderer gives an entry a
+    single voice, so a character-voiced entry holding both a quotation and the
+    narration around it means the narration is spoken by the character.
+
+    Measured on one 8,083-entry artifact before the fix: 13,337 chars of
+    narration read in a character voice, 73 entries mixing the two kinds. The
+    model is simulated at its worst here -- EVERY span, quoted or not, labelled
+    with the same character -- which is exactly how attribution tags ("said
+    Marcus") got swallowed into the preceding line.
+    """
+    _require_pipeline_modules()
+    from span_tokenizer import tokenize as _tokenize
+
+    bad = []
+    for name, chunk in PIPELINE_FIXTURES.items():
+        labels = [
+            {"id": span.id, "speaker": "ELENA", "role": "dialogue", "instruct": "Flat."}
+            for span in _tokenize(chunk)
+        ]
+        entries, _stats = _sc_run_chunk(
+            FakeClient(FakeResponse(json.dumps(labels))), chunk)
+
+        if "".join(entry["text"] for entry in entries) != chunk:
+            bad.append(f"{name}: text is no longer byte-identical")
+        for entry in entries:
+            if entry["speaker"] == "NARRATOR":
+                continue
+            kinds = {span.kind for span in _tokenize(entry["text"])
+                     if entry["text"][span.start:span.end].strip()}
+            if len(kinds) > 1:
+                bad.append(f"{name}: character entry mixes {sorted(kinds)}: {entry['text']!r}")
+    if bad:
+        raise TestFailure("ONE-ENTRY-ONE-KIND INVARIANT VIOLATED: " + "; ".join(bad))
+
+
 def _legacy_split_into_chunks(text, max_size=3000):
     """The pre-fix chunker, verbatim, kept ONLY so the test below can prove the
     byte-fidelity assertion is failable (it drops a paragraph break at every
@@ -1920,6 +1956,7 @@ def run_offline_invariant_tests():
     run_test("epub_spine_item_under_200_chars_would_be_flagged",
               test_epub_spine_item_under_200_chars_would_be_flagged)
     run_test("word_coverage_exact_one_across_failure_modes", test_word_coverage_exact_one_across_failure_modes)
+    run_test("no_character_entry_mixes_quotation_and_narration", test_no_character_entry_mixes_quotation_and_narration)
     run_test("chunking_is_byte_lossless_over_source", test_chunking_is_byte_lossless_over_source)
     run_test("word_coverage_digits_and_abbreviations_survive_verbatim",
               test_word_coverage_digits_and_abbreviations_survive_verbatim)

--- a/app/test_api.py
+++ b/app/test_api.py
@@ -4,20 +4,52 @@
 Usage:
     python test_api.py                    # Quick tests only
     python test_api.py --full             # Include TTS/LLM-dependent tests
+    python test_api.py --offline          # Offline pipeline-invariant tests only
+                                           # (no server, no LLM; alias: --offline-only)
     python test_api.py --url http://host:port
 """
 
 import argparse
 import io
 import json
+import os
+import re
 import sys
+import tempfile
 import time
+from contextlib import redirect_stdout
+
 import requests
+
+# ── Offline pipeline invariant tests: optional local imports ────────────────
+#
+# Section 15 below (Pipeline Invariants) exercises the span-classifier
+# pipeline modules directly -- no live server, no live LLM. Those modules
+# pull in heavier local/optional dependencies (openai, rapidfuzz, fastapi,
+# aiofiles, ...) that the rest of this file has never required: historically
+# test_api.py only needs `requests` and can run from a minimal environment
+# against a remote deployed server. To avoid regressing that use case, these
+# imports are best-effort: if they fail, Section 15's tests SKIP individually
+# (via the usual "SKIP:" TestFailure convention) instead of the whole script
+# refusing to import.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+_PIPELINE_IMPORT_ERROR = None
+try:
+    from span_tokenizer import tokenize, reassemble, validate_spans
+    from generate_script import process_chunk, split_into_chunks
+    from review_script import normalize_text, check_text_loss
+    from default_prompts import DEFAULT_SYSTEM_PROMPT, DEFAULT_USER_PROMPT
+    from test_span_integration import FakeClient, FakeResponse, labels_for
+    from test_epub_extract import make_epub, opf, extract_epub_text
+except Exception as _e:  # pragma: no cover - environment-dependent
+    _PIPELINE_IMPORT_ERROR = _e
 
 # ── Global state ─────────────────────────────────────────────
 
 BASE_URL = ""
 FULL_MODE = False
+OFFLINE_ONLY = False
 TEST_PREFIX = "_test_"
 
 results = {"passed": 0, "failed": 0, "skipped": 0}
@@ -1208,6 +1240,366 @@ def test_dataset_builder_generate_sample():
     delete(f"/api/dataset_builder/{TEST_PREFIX}gen_proj")
 
 
+# ── Section 15: Pipeline Invariants (Offline, no server/LLM) ───────────────
+#
+# The span-classifier audiobook pipeline (span_tokenizer.py, generate_script.py,
+# app.extract_epub_text) makes three promises that must never regress:
+#
+#   1. REASSEMBLY: span reassembly is byte-identical to the source text.
+#   2. SPINE YIELD (>200 chars): every EPUB spine item yields more than 200
+#      characters of extracted text.
+#   3. WORD COVERAGE (== 1.0): source -> annotated_script.json word coverage
+#      is exactly 1.0 -- not a tolerance band.
+#
+# These tests build their own fixtures with tempfile/zipfile and a fake LLM
+# client (see test_span_integration.FakeClient), so they need neither a live
+# server nor a live LLM, and MUST pass even when every server-dependent test
+# above is failing/skipping for lack of a running server.
+
+def _require_pipeline_modules():
+    if _PIPELINE_IMPORT_ERROR is not None:
+        raise TestFailure(f"SKIP: offline pipeline modules unavailable ({_PIPELINE_IMPORT_ERROR})")
+
+
+# --- fixtures ----------------------------------------------------------------
+
+PIPELINE_FIXTURE_MIXED_QUOTES = (
+    '"You are certain?" Elena asked.\n'
+    '\n'
+    '“I am,” Marcus replied, “completely certain.”\n'
+)
+
+PIPELINE_FIXTURE_ATTRIBUTION_TAGS = (
+    '"We should leave," he said, pulling on his coat, "now, before they notice."'
+)
+
+PIPELINE_FIXTURE_EM_DASH_DIALOGUE = (
+    "—Are you coming with us? Elena asked, not turning around.\n"
+    "\n"
+    "—Not yet, Marcus said, still watching the door.\n"
+)
+
+PIPELINE_FIXTURE_MULTI_PARAGRAPH = (
+    "The rain had not stopped for three days.\n"
+    "\n"
+    '"I told you it would flood," Elena said, arms crossed.\n'
+    "\n"
+    "Marcus said nothing. He watched the water climb the third step, then the fourth.\n"
+    "\n"
+    '"We should go," she said again, quieter this time.\n'
+)
+
+# At least 4 fixtures: mixed straight/curly quotes, attribution tags,
+# em-dash dialogue, multi-paragraph.
+PIPELINE_FIXTURES = {
+    "mixed_quotes": PIPELINE_FIXTURE_MIXED_QUOTES,
+    "attribution_tags": PIPELINE_FIXTURE_ATTRIBUTION_TAGS,
+    "em_dash_dialogue": PIPELINE_FIXTURE_EM_DASH_DIALOGUE,
+    "multi_paragraph": PIPELINE_FIXTURE_MULTI_PARAGRAPH,
+}
+
+PIPELINE_DIGITS_ABBREV_FIXTURE = (
+    'Dr. Smith owed $1,000 on Elm St. by noon, or so Mrs. Vance claimed.'
+)
+
+
+# --- helpers -------------------------------------------------------------
+
+def _sc_run_chunk(client, chunk, **kwargs):
+    """process_chunk with the real default prompts, stdout suppressed.
+
+    `client` stands in for the LLM (test_span_integration.FakeClient) --
+    no network I/O happens here.
+    """
+    buffer = io.StringIO()
+    options = dict(system_prompt=DEFAULT_SYSTEM_PROMPT, user_prompt_template=DEFAULT_USER_PROMPT, max_retries=1)
+    options.update(kwargs)
+    with redirect_stdout(buffer):
+        entries, stats = process_chunk(client, "fake-model", chunk, 1, 1, **options)
+    return entries, stats
+
+
+def _sc_modes_for(chunk):
+    """The three LLM behaviors the span classifier must survive without losing prose."""
+    full = json.dumps(labels_for(chunk))
+    return {
+        "full_labels": FakeResponse(full),
+        "truncated_finish_length": FakeResponse(full[:max(1, len(full) // 2)], finish_reason="length"),
+        "total_failure": RuntimeError("connection refused (fake)"),
+    }
+
+
+def _sc_coverage(source_text, entries):
+    """(ratio, sequence_identical, orig_words, corr_words) using review_script's
+    OWN normalize_text/check_text_loss (lowercase, strip [^\\w\\s], collapse
+    whitespace, split to words) -- so this enforces the exact same definition
+    the review stage uses, rather than a reimplementation that could drift.
+    """
+    _passed, orig_joined, corr_joined, ratio = check_text_loss(
+        [{"text": source_text}], entries, threshold=1.0, upper_bound=1.0
+    )
+    return ratio, orig_joined == corr_joined, orig_joined, corr_joined
+
+
+# --- Invariant 1: reassembly byte-identity --------------------------------
+
+def test_span_tokenizer_reassembly_is_byte_identical():
+    """INVARIANT (reassembly): tokenize()+reassemble() reproduce the source
+    byte-for-byte for every fixture, independent of the LLM entirely."""
+    _require_pipeline_modules()
+    bad = []
+    for name, text in PIPELINE_FIXTURES.items():
+        spans = tokenize(text)
+        try:
+            validate_spans(spans, text)
+        except ValueError as e:
+            bad.append(f"{name}: span tiling invalid ({e})")
+            continue
+        if reassemble(spans, text) != text:
+            bad.append(f"{name}: reassemble() != source")
+    if bad:
+        raise TestFailure("REASSEMBLY INVARIANT VIOLATED: " + "; ".join(bad))
+
+
+def test_process_chunk_reassembly_byte_identical_across_fixtures_and_modes():
+    """INVARIANT (reassembly): whatever the LLM does -- labels everything,
+    truncates mid-response, or fails every attempt -- process_chunk's entries
+    concatenate back to the exact source chunk. Covers >=4 distinct fixtures
+    (mixed straight/curly quotes, attribution tags, em-dash dialogue,
+    multi-paragraph) x 3 failure modes = 12 cases.
+    """
+    _require_pipeline_modules()
+    bad = []
+    for fixture_name, chunk in PIPELINE_FIXTURES.items():
+        for mode_name, response in _sc_modes_for(chunk).items():
+            client = FakeClient(response)
+            entries, stats = _sc_run_chunk(client, chunk)
+            rebuilt = "".join(e["text"] for e in entries)
+            if rebuilt != chunk:
+                bad.append(f"{fixture_name}/{mode_name}: reassembled text != source chunk")
+            elif stats["labelled"] + stats["fallback"] != stats["spans"]:
+                bad.append(
+                    f"{fixture_name}/{mode_name}: span accounting mismatch "
+                    f"(labelled={stats['labelled']} fallback={stats['fallback']} spans={stats['spans']})"
+                )
+    if bad:
+        raise TestFailure("REASSEMBLY INVARIANT VIOLATED: " + "; ".join(bad))
+
+
+# --- Invariant 2: EPUB spine yield > 200 chars ----------------------------
+
+def test_epub_spine_items_yield_over_200_chars():
+    """INVARIANT (spine yield > 200 chars): every EPUB spine item yields more
+    than 200 characters of extracted text.
+
+    Reads the per-chapter char-count report app.extract_epub_text() prints to
+    stdout, rather than re-deriving counts by splitting the joined return
+    value on '\\n\\n': that join is not a reliable per-chapter delimiter,
+    since a chapter's own paragraphs are blank-line-separated too. Capturing
+    stdout instead exercises the actual reporting mechanism a human/CI
+    consumer of this function reads.
+    """
+    _require_pipeline_modules()
+    chapter_bodies = {
+        "ch1.xhtml": (
+            "The lighthouse keeper had not seen another soul in eleven weeks, "
+            "and the silence had started to sound like company. Every morning "
+            "he counted the gulls circling the rocks below, and every evening "
+            "he wrote the count in a ledger nobody would ever read."
+        ),
+        "ch2.xhtml": (
+            '"You are certain no one is coming?" she asked, not for the first time. '
+            '"Certain," he said. "The last supply boat won\'t be back until spring, '
+            'and even then only if the ice breaks early enough to matter. We will '
+            'simply have to wait it out, the way we always do."'
+        ),
+        "ch3.xhtml": (
+            "Three winters had passed since the keeper first climbed the tower "
+            "stairs, and each one had carved a little more silence into him. "
+            "He no longer minded it. The lamp still turned, the gulls still "
+            "circled, and somewhere past the horizon, ships still needed the light."
+        ),
+    }
+    for href, body in chapter_bodies.items():
+        if len(body) <= 200:
+            raise TestFailure(f"test fixture bug: '{href}' body is only {len(body)} chars, need > 200")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        epub_path = os.path.join(tmp, "book.epub")
+        manifest_items = [
+            (f"ch{i}", href, "application/xhtml+xml", None)
+            for i, href in enumerate(chapter_bodies, start=1)
+        ]
+        spine = [item_id for item_id, _, _, _ in manifest_items]
+        opf_xml = opf(manifest_items, spine)
+        files = {
+            f"OEBPS/{href}": f"<html><body><p>{body}</p></body></html>"
+            for href, body in chapter_bodies.items()
+        }
+        make_epub(epub_path, opf_xml, files)
+
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            text = extract_epub_text(epub_path)
+        report = buffer.getvalue()
+
+    missing = [href for href, body in chapter_bodies.items() if body not in text]
+    if missing:
+        raise TestFailure(f"SPINE YIELD INVARIANT: chapter text missing from extracted output for: {missing}")
+
+    counts = dict(re.findall(r'chapter \d+: (.+?) -> (\d+) chars', report))
+    if len(counts) != len(chapter_bodies):
+        raise TestFailure(
+            f"SPINE YIELD INVARIANT (>200 chars): expected {len(chapter_bodies)} per-chapter "
+            f"report lines, parsed {len(counts)} from stdout: {report!r}"
+        )
+    at_or_under_200 = {href: int(n) for href, n in counts.items() if int(n) <= 200}
+    if at_or_under_200:
+        raise TestFailure(
+            f"SPINE YIELD INVARIANT (>200 chars) VIOLATED: spine item(s) at/under the "
+            f"200-char floor: {at_or_under_200}"
+        )
+
+
+def test_epub_spine_item_under_200_chars_would_be_flagged():
+    """INVARIANT (spine yield > 200 chars) counter-case: a legitimate short
+    front-matter page (a bare title) yields fewer than 200 chars. This
+    documents that the floor is a real, failable signal for genuine front
+    matter -- not a tautology every fixture trivially satisfies -- by
+    asserting the fixture's own reported count is <= 200, i.e. exactly the
+    condition a real ">200 chars per spine item" gate would flag.
+    """
+    _require_pipeline_modules()
+    short_body = "Moonrise"  # a bare, single-word title page: far under 200 chars
+
+    with tempfile.TemporaryDirectory() as tmp:
+        epub_path = os.path.join(tmp, "book.epub")
+        manifest_items = [("front", "front.xhtml", "application/xhtml+xml", None)]
+        opf_xml = opf(manifest_items, ["front"])
+        files = {"OEBPS/front.xhtml": f"<html><body><p>{short_body}</p></body></html>"}
+        make_epub(epub_path, opf_xml, files)
+
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            extract_epub_text(epub_path)
+        report = buffer.getvalue()
+
+    matches = re.findall(r'chapter \d+: (.+?) -> (\d+) chars', report)
+    if not matches:
+        raise TestFailure(
+            f"SPINE YIELD INVARIANT: expected a per-chapter report line for the front-matter "
+            f"fixture, got: {report!r}"
+        )
+    _href, count = matches[0]
+    count = int(count)
+    if count > 200:
+        raise TestFailure(
+            f"SPINE YIELD INVARIANT fixture is broken: front-matter body yielded {count} chars "
+            "(> 200); this test needs a genuinely short fixture to demonstrate the floor is failable"
+        )
+    # `count` (<= 200) IS the FAIL signal a real ">200 chars per spine item"
+    # gate would raise for this legitimate short front-matter page.
+
+
+# --- Invariant 3: word coverage == 1.0 exact -------------------------------
+
+def test_word_coverage_exact_one_across_failure_modes():
+    """INVARIANT (word coverage == 1.0): source -> script word coverage is
+    exactly 1.0 in every LLM failure mode (full labels, truncated, total
+    failure) -- the entire point of the span-classifier design is that
+    labels can be lost, but not a single source word can be. Word SEQUENCE
+    identity is checked too, not just counts.
+    """
+    _require_pipeline_modules()
+    source_text = "\n\n".join(PIPELINE_FIXTURES.values())
+    bad = []
+    for mode in ("full_labels", "truncated_finish_length", "total_failure"):
+        chunks = split_into_chunks(source_text, max_size=300)
+        if len(chunks) < 2:
+            raise TestFailure(f"test fixture bug: expected multiple chunks, got {len(chunks)}")
+        all_entries = []
+        for chunk in chunks:
+            response = _sc_modes_for(chunk)[mode]
+            client = FakeClient(response)
+            entries, _stats = _sc_run_chunk(client, chunk)
+            all_entries.extend(entries)
+
+        ratio, seq_match, _orig_words, _corr_words = _sc_coverage(source_text, all_entries)
+        if ratio != 1.0:
+            bad.append(f"{mode}: coverage ratio={ratio!r} (expected exactly 1.0)")
+        if not seq_match:
+            bad.append(f"{mode}: word sequence differs from source (counts may match but order/content does not)")
+    if bad:
+        raise TestFailure("WORD COVERAGE INVARIANT (== 1.0) VIOLATED: " + "; ".join(bad))
+
+
+def test_word_coverage_digits_and_abbreviations_survive_verbatim():
+    """INVARIANT (word coverage == 1.0) + verbatim: digits, currency, and
+    abbreviations ("Dr. Smith owed $1,000 on Elm St.") survive into the
+    script UNTOUCHED in every failure mode, and still contribute exactly to
+    word coverage.
+    """
+    _require_pipeline_modules()
+    source_text = PIPELINE_DIGITS_ABBREV_FIXTURE
+    bad = []
+    for mode in ("full_labels", "truncated_finish_length", "total_failure"):
+        client = FakeClient(_sc_modes_for(source_text)[mode])
+        entries, _stats = _sc_run_chunk(client, source_text)
+
+        rebuilt = "".join(e["text"] for e in entries)
+        if rebuilt != source_text:
+            bad.append(f"{mode}: reassembly not verbatim: {rebuilt!r} != {source_text!r}")
+            continue
+        for literal in ("Dr. Smith", "$1,000", "Elm St.", "Mrs. Vance"):
+            if literal not in rebuilt:
+                bad.append(f"{mode}: '{literal}' altered or lost")
+
+        ratio, seq_match, _orig_words, _corr_words = _sc_coverage(source_text, entries)
+        if ratio != 1.0 or not seq_match:
+            bad.append(f"{mode}: coverage ratio={ratio!r} sequence_match={seq_match} (expected ratio==1.0 and match)")
+    if bad:
+        raise TestFailure(
+            "WORD COVERAGE INVARIANT (== 1.0) / REASSEMBLY INVARIANT VIOLATED on "
+            "digits/abbreviations fixture: " + "; ".join(bad)
+        )
+
+
+def test_real_annotated_script_word_coverage_if_present():
+    """Opportunistic: if a real annotated_script.json + its resolvable source
+    input exist on disk (the live-artifact path from a prior
+    /api/generate_script run), check INVARIANT (word coverage == 1.0)
+    against them. Skips cleanly when either artifact is absent -- this is
+    the common case for a fresh checkout.
+    """
+    _require_pipeline_modules()
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    script_path = os.path.join(repo_root, "annotated_script.json")
+    state_path = os.path.join(repo_root, "state.json")
+
+    if not os.path.exists(script_path):
+        raise TestFailure("SKIP: no annotated_script.json at repo root")
+    if not os.path.exists(state_path):
+        raise TestFailure("SKIP: no state.json to locate the source input file")
+
+    with open(state_path, "r", encoding="utf-8") as f:
+        state = json.load(f)
+    input_file = state.get("input_file_path")
+    if not input_file or not os.path.exists(input_file):
+        raise TestFailure("SKIP: state.json has no resolvable input_file_path")
+
+    with open(script_path, "r", encoding="utf-8") as f:
+        entries = json.load(f)
+    with open(input_file, "r", encoding="utf-8") as f:
+        source_text = f.read()
+
+    ratio, seq_match, _orig_words, _corr_words = _sc_coverage(source_text, entries)
+    if ratio != 1.0 or not seq_match:
+        raise TestFailure(
+            f"WORD COVERAGE INVARIANT (== 1.0) VIOLATED on real artifacts: "
+            f"ratio={ratio!r} sequence_match={seq_match}"
+        )
+
+
 # ── Run all tests ────────────────────────────────────────────
 
 def run_all_tests():
@@ -1331,6 +1723,27 @@ def run_all_tests():
     section("Dataset Builder Generate (TTS)")
     run_test("dataset_builder_generate_sample", test_dataset_builder_generate_sample, requires_full=True)
 
+    run_offline_invariant_tests()
+
+
+def run_offline_invariant_tests():
+    """The genuinely server-free subset of the suite: Section 15's pipeline
+    invariants. No network I/O happens in here -- safe (and fast) to run with
+    `--offline` / `--offline-only` when no server is up, and also called from
+    run_all_tests() above so default behavior is unchanged.
+    """
+    section("Pipeline Invariants (Offline, no server/LLM)")
+    run_test("span_tokenizer_reassembly_byte_identical", test_span_tokenizer_reassembly_is_byte_identical)
+    run_test("process_chunk_reassembly_byte_identical_across_fixtures_and_modes",
+              test_process_chunk_reassembly_byte_identical_across_fixtures_and_modes)
+    run_test("epub_spine_items_yield_over_200_chars", test_epub_spine_items_yield_over_200_chars)
+    run_test("epub_spine_item_under_200_chars_would_be_flagged",
+              test_epub_spine_item_under_200_chars_would_be_flagged)
+    run_test("word_coverage_exact_one_across_failure_modes", test_word_coverage_exact_one_across_failure_modes)
+    run_test("word_coverage_digits_and_abbreviations_survive_verbatim",
+              test_word_coverage_digits_and_abbreviations_survive_verbatim)
+    run_test("real_annotated_script_word_coverage_if_present", test_real_annotated_script_word_coverage_if_present)
+
 
 # ── Cleanup ──────────────────────────────────────────────────
 
@@ -1381,26 +1794,42 @@ def cleanup():
 # ── Main ─────────────────────────────────────────────────────
 
 def main():
-    global BASE_URL, FULL_MODE
+    global BASE_URL, FULL_MODE, OFFLINE_ONLY
 
     parser = argparse.ArgumentParser(description="Alexandria API test suite")
     parser.add_argument("--url", default="http://127.0.0.1:4200",
                         help="Server URL (default: http://127.0.0.1:4200)")
     parser.add_argument("--full", action="store_true",
                         help="Include TTS/LLM-dependent tests")
+    parser.add_argument("--offline", "--offline-only", dest="offline", action="store_true",
+                        help="Run ONLY the offline pipeline-invariant tests (Section 15): "
+                             "no server, no LLM, no network calls at all. Ignores --full and "
+                             "--url. Use this to check the span-classifier invariants in "
+                             "seconds instead of waiting through connection-refused timeouts "
+                             "on every server-dependent test.")
     args = parser.parse_args()
 
     BASE_URL = args.url.rstrip("/")
     FULL_MODE = args.full
+    OFFLINE_ONLY = args.offline
 
     print(f"Alexandria API Tests")
-    print(f"Server: {BASE_URL}")
-    print(f"Mode:   {'FULL (includes TTS/LLM tests)' if FULL_MODE else 'QUICK (no TTS/LLM)'}")
+    if OFFLINE_ONLY:
+        print(f"Mode:   OFFLINE ONLY (pipeline invariants; no server, no LLM, no network)")
+    else:
+        print(f"Server: {BASE_URL}")
+        print(f"Mode:   {'FULL (includes TTS/LLM tests)' if FULL_MODE else 'QUICK (no TTS/LLM)'}")
 
-    try:
-        run_all_tests()
-    finally:
-        cleanup()
+    if OFFLINE_ONLY:
+        # Genuinely server-free: skip run_all_tests() (which would otherwise
+        # dial out to BASE_URL for ~90 tests first) and skip cleanup() too,
+        # since it only deletes server-side test fixtures via HTTP.
+        run_offline_invariant_tests()
+    else:
+        try:
+            run_all_tests()
+        finally:
+            cleanup()
 
     # Summary
     total = results["passed"] + results["failed"] + results["skipped"]

--- a/app/test_canon_wiring.py
+++ b/app/test_canon_wiring.py
@@ -422,10 +422,30 @@ def test_generation_imports_the_repair_helpers_rather_than_reimplementing_them()
           generate_script.near_spellings is speaker_canon.near_spellings)
 
     source = inspect.getsource(generate_script)
-    for banned in ("difflib", "rapidfuzz", "def _is_distance_one",
-                   "levenshtein", "Levenshtein"):
+    for banned in ("difflib", "def _is_distance_one",
+                   "from rapidfuzz import fuzz", "ratio("):
         check(f"generate_script does not reimplement matching ({banned})",
               banned not in source)
+
+    # generate_script may measure exact edit distance for ONE purpose: folding a
+    # misspelled JSON schema key back onto the fixed four-word key vocabulary.
+    # That vocabulary is this code's own, not the book's, so a near miss there
+    # has one possible meaning -- unlike JON/JOHN. Keeping the measurement
+    # confined to that function is what stops it from drifting onto names, so
+    # pin the location rather than the mere absence of the word.
+    key_recovery = inspect.getsource(generate_script._recover_label_keys)
+    distance_lines = [line for line in source.splitlines()
+                      if "Levenshtein" in line and not line.lstrip().startswith("#")]
+    check("generate_script measures edit distance only for schema-key recovery",
+          all(line in key_recovery or line.startswith("from rapidfuzz")
+              for line in distance_lines),
+          detail=repr([line for line in distance_lines
+                       if line not in key_recovery
+                       and not line.startswith("from rapidfuzz")]))
+    check("schema-key recovery never targets the 'text' key",
+          "text" not in generate_script._RECOVERABLE_LABEL_KEYS)
+    check("speaker names are still matched only by speaker_canon",
+          "Levenshtein" not in inspect.getsource(generate_script.resolve_span_labels))
 
 
 def main():

--- a/app/test_canon_wiring.py
+++ b/app/test_canon_wiring.py
@@ -403,8 +403,34 @@ def test_label_flags_computation_never_mutates_entries_or_roster():
           by_name["ZORBLAX"]["attested"] is False, detail=repr(by_name["ZORBLAX"]))
 
 
+def test_generation_imports_the_repair_helpers_rather_than_reimplementing_them():
+    """Speaker repair -- and the edit-distance predicate it rests on -- lives in
+    speaker_canon, which is where the guards, the docstring and the tests are.
+    A local reimplementation in generate_script would drift from all three, and
+    is exactly how a bounded distance-1 check turns into an unbounded fuzzy
+    match. Assert the wiring, and assert that no distance/similarity logic was
+    copied into the caller."""
+    import inspect
+    import generate_script
+    import speaker_canon
+
+    check("generate_script imports repair_speaker from speaker_canon",
+          generate_script.repair_speaker is speaker_canon.repair_speaker)
+    check("generate_script imports source_word_index from speaker_canon",
+          generate_script.source_word_index is speaker_canon.source_word_index)
+    check("generate_script imports near_spellings from speaker_canon",
+          generate_script.near_spellings is speaker_canon.near_spellings)
+
+    source = inspect.getsource(generate_script)
+    for banned in ("difflib", "rapidfuzz", "def _is_distance_one",
+                   "levenshtein", "Levenshtein"):
+        check(f"generate_script does not reimplement matching ({banned})",
+              banned not in source)
+
+
 def main():
     tests = [
+        test_generation_imports_the_repair_helpers_rather_than_reimplementing_them,
         test_label_flags_computation_never_mutates_entries_or_roster,
         test_voices_roster_consolidates_whitespace_drift,
         test_voices_roster_selection_is_order_independent,

--- a/app/test_canon_wiring.py
+++ b/app/test_canon_wiring.py
@@ -489,8 +489,70 @@ def test_gate_refuses_a_recombined_multi_token_label():
           poss != generate_script.GATE_REJECTED, detail=repr(poss))
 
 
+def test_adjacent_tag_vetoes_a_spelling_repair():
+    """A repair the spelling guards accept is REFUSED when the attribution tag
+    beside that very line names a different established character -- and kept
+    when the tag agrees or is absent. Independent of check_attribution_tags:
+    _gate_speaker takes the tag text directly.
+
+    Synthesized fixture -- invented names, no book.
+    """
+    import generate_script as gs
+
+    window = ("Verrin and Calder stood in the doorway. “Then we go,” "
+              "Calder said. “Not yet,” Verrin said.")
+    roster = {}
+    gs.remember_in_roster(roster, "VERRIN")
+    gs.remember_in_roster(roster, "CALDER")
+    words = gs.source_word_index(window)
+
+    # VERRAN: absent from the book, exactly one roster name one edit away.
+    name, outcome = gs._gate_speaker("VERRAN", window, roster, words)
+    check("a refuted spelling still repairs with no tag evidence",
+          (name, outcome) == ("VERRIN", gs.GATE_REPAIRED),
+          detail=f"{name!r} {outcome!r}")
+
+    name, outcome = gs._gate_speaker("VERRAN", window, roster, words,
+                                     " Verrin said, and stepped back.")
+    check("an agreeing tag leaves the repair alone",
+          (name, outcome) == ("VERRIN", gs.GATE_REPAIRED),
+          detail=f"{name!r} {outcome!r}")
+
+    name, outcome = gs._gate_speaker("VERRAN", window, roster, words,
+                                     " Calder said, and stepped back.")
+    check("a contradicting tag refuses the repair",
+          (name, outcome) == ("VERRAN", gs.GATE_REPAIR_REFUSED),
+          detail=f"{name!r} {outcome!r}")
+
+    # The veto must never rewrite the label onto the tagged name (that would be
+    # a second repair_speaker) and must never promote a non-repair to a refusal.
+    name, outcome = gs._gate_speaker("CALDER", window, roster, words,
+                                     " Verrin said, and stepped back.")
+    check("an established name is untouched by the veto",
+          outcome == gs.GATE_ESTABLISHED, detail=f"{name!r} {outcome!r}")
+
+
+def test_tag_adjacency_bounds_have_one_definition():
+    """_tag_contradictions and the repair veto must read tag text through the
+    same helper, or the two can disagree about which narration closes a line."""
+    import inspect
+    import generate_script
+
+    source = inspect.getsource(generate_script._tag_contradictions)
+    check("_tag_contradictions uses _closing_tag_text_by_id",
+          "_closing_tag_text_by_id" in source)
+    check("_tag_contradictions has no second adjacency rule",
+          "_CLOSING_QUOTES" not in source, detail=source)
+    for func in (generate_script.resolve_span_labels,
+                 generate_script._unattested_speaker_ids):
+        check(f"{func.__name__} feeds the gate tag text from the shared helper",
+              "_closing_tag_text_by_id" in inspect.getsource(func))
+
+
 def main():
     tests = [
+        test_adjacent_tag_vetoes_a_spelling_repair,
+        test_tag_adjacency_bounds_have_one_definition,
         test_gate_refuses_a_recombined_multi_token_label,
         test_generation_imports_the_repair_helpers_rather_than_reimplementing_them,
         test_label_flags_computation_never_mutates_entries_or_roster,

--- a/app/test_canon_wiring.py
+++ b/app/test_canon_wiring.py
@@ -448,8 +448,50 @@ def test_generation_imports_the_repair_helpers_rather_than_reimplementing_them()
           "Levenshtein" not in inspect.getsource(generate_script.resolve_span_labels))
 
 
+def test_gate_refuses_a_recombined_multi_token_label():
+    """The gate, not just the detector: a label whose parts each appear in the
+    window but never adjacently must be REJECTED, and the retry predicate must
+    agree with the gate about it (they share _gate_speaker).
+
+    Synthesized fixture -- invented names, no book.
+    """
+    import generate_script
+
+    window = "Then Verrin spoke, and Calder answered him from the doorway."
+    roster = {}
+    generate_script.remember_in_roster(roster, "VERRIN")
+    generate_script.remember_in_roster(roster, "CALDER")
+
+    name, outcome = generate_script._gate_speaker(
+        "VERRIN CALDER", window, roster, generate_script.source_word_index(window))
+    check("a recombined label is rejected by the gate",
+          outcome == generate_script.GATE_REJECTED, detail=f"{name!r} {outcome!r}")
+
+    # And the established-roster shortcut must not have let it in first.
+    check("the recombined label is not treated as established",
+          not generate_script._speaker_is_established("VERRIN CALDER", roster))
+
+    # A label the source actually spells as a phrase still passes.
+    good_window = "Then Verrin Calder spoke from the doorway."
+    _, good = generate_script._gate_speaker(
+        "VERRIN CALDER", good_window, roster,
+        generate_script.source_word_index(good_window))
+    check("a genuine phrase label still passes the gate",
+          good == generate_script.GATE_ATTESTED, detail=repr(good))
+
+    # A possessive composition must survive on per-token evidence: this is the
+    # high-volume shape (a relation named obliquely near its own speech).
+    scattered = "Verrin looked up. Some while later, his father spoke."
+    _, poss = generate_script._gate_speaker(
+        "VERRIN'S FATHER", scattered, roster,
+        generate_script.source_word_index(scattered))
+    check("a possessive composition is not rejected for non-adjacency",
+          poss != generate_script.GATE_REJECTED, detail=repr(poss))
+
+
 def main():
     tests = [
+        test_gate_refuses_a_recombined_multi_token_label,
         test_generation_imports_the_repair_helpers_rather_than_reimplementing_them,
         test_label_flags_computation_never_mutates_entries_or_roster,
         test_voices_roster_consolidates_whitespace_drift,

--- a/app/test_canon_wiring.py
+++ b/app/test_canon_wiring.py
@@ -57,7 +57,7 @@ if 'project' not in sys.modules:
     sys.modules['project'] = _fake_project
 
 import app as app_module  # noqa: E402
-from app import build_voice_roster, _canonical_roster_names  # noqa: E402
+from app import build_voice_roster, _canonical_roster_names, _compute_label_flags  # noqa: E402
 from speaker_canon import suggest_aliases  # noqa: E402
 from review_script import _canonicalize_speakers  # noqa: E402
 
@@ -74,7 +74,6 @@ def check(name, condition, detail=""):
 def test_roster_canonicalizes_and_dedupes():
     script_data = [
         {"speaker": "mark", "text": "a"},
-        {"speaker": "Mr. Mark", "text": "b"},
         {"speaker": "MARK (shouting)", "text": "c"},
         {"speaker": "JON", "text": "d"},
         {"speaker": "JOHN", "text": "e"},
@@ -104,26 +103,30 @@ def test_roster_handles_legacy_type_field_and_empty():
 
 
 def test_config_backcompat_resolution():
+    # A config written under a raw, non-canonical spelling of the speaker
+    # must still resolve for the canonical roster name. Note the canonical
+    # name now KEEPS the gender-marking title ("Mr. Mark" -> "MISTER MARK"),
+    # so Mr. Mark and a bare Mark are two roster entries, not one.
     script_data = [
-        {"speaker": "mark", "text": "a"},
-        {"speaker": "MARK (shouting)", "text": "b"},
+        {"speaker": "Mr. Mark", "text": "a"},
+        {"speaker": "mister mark (shouting)", "text": "b"},
     ]
     voice_config = {"Mr. Mark": {"engine": "clone", "ref": "mark.wav"}}
     roster_names, config_lookup = build_voice_roster(script_data, voice_config)
 
     check(
-        "config back-compat: roster resolves to MARK",
-        roster_names == ["MARK"],
+        "config back-compat: roster resolves to MISTER MARK",
+        roster_names == ["MISTER MARK"],
         detail=repr(roster_names),
     )
     check(
-        "config back-compat: non-canonical 'Mr. Mark' key resolves for MARK",
-        config_lookup.get("MARK") == {"engine": "clone", "ref": "mark.wav"},
+        "config back-compat: non-canonical 'Mr. Mark' key resolves for MISTER MARK",
+        config_lookup.get("MISTER MARK") == {"engine": "clone", "ref": "mark.wav"},
         detail=repr(config_lookup),
     )
 
     # Simulate what the handler does to derive persona_pending.
-    persona_pending = "MARK" not in config_lookup
+    persona_pending = "MISTER MARK" not in config_lookup
     check(
         "config back-compat: persona_pending is False when config resolves",
         persona_pending is False,
@@ -133,16 +136,44 @@ def test_config_backcompat_resolution():
 def test_config_exact_key_wins_over_scan():
     # If BOTH an exact canonical key and a differently-cased key that would
     # canonicalize to the same name exist, the exact match must win.
-    script_data = [{"speaker": "mark", "text": "a"}]
+    script_data = [{"speaker": "Mr. Mark", "text": "a"}]
     voice_config = {
-        "MARK": {"engine": "exact"},
+        "MISTER MARK": {"engine": "exact"},
         "Mr. Mark": {"engine": "scanned"},
     }
     roster_names, config_lookup = build_voice_roster(script_data, voice_config)
     check(
         "config back-compat: exact canonical key wins over scanned fallback",
-        config_lookup.get("MARK") == {"engine": "exact"},
+        config_lookup.get("MISTER MARK") == {"engine": "exact"},
         detail=repr(config_lookup),
+    )
+
+
+def test_roster_keeps_husband_and_wife_apart():
+    # The defect: "Mr. Smith" and "Mrs. Smith" used to collapse into a single
+    # roster entry, hence a single voice, with no way back.
+    script_data = [
+        {"speaker": "Mr. Smith", "text": "a"},
+        {"speaker": "Mrs. Smith", "text": "b"},
+    ]
+    roster_names, _ = build_voice_roster(script_data, {})
+    check(
+        "roster: Mr. Smith and Mrs. Smith are two entries",
+        roster_names == ["MISSUS SMITH", "MISTER SMITH"],
+        detail=repr(roster_names),
+    )
+
+
+def test_config_metadata_keys_are_not_speakers():
+    # voice_config.json carries a "_canon_version" stamp. Underscore-prefixed
+    # keys are metadata and must never be scanned as a speaker name.
+    script_data = [{"speaker": "mark", "text": "a"}]
+    voice_config = {"_canon_version": 2, "MARK": {"engine": "exact"}}
+    roster_names, config_lookup = build_voice_roster(script_data, voice_config)
+    check(
+        "config: '_canon_version' never resolves as a voice entry",
+        roster_names == ["MARK"] and config_lookup == {"MARK": {"engine": "exact"}},
+        detail=repr((roster_names, config_lookup)),
     )
 
 
@@ -259,7 +290,7 @@ def test_review_canonicalizes_speaker_not_text():
 
     check(
         "review: speakers canonicalized",
-        [e["speaker"] for e in result] == ["NARRATOR", "ELENA", "MARK"],
+        [e["speaker"] for e in result] == ["NARRATOR", "ELENA", "MISTER MARK"],
         detail=repr([e["speaker"] for e in result]),
     )
     check(
@@ -333,8 +364,48 @@ def test_voices_config_lookup_survives_whitespace_drift():
 
 
 
+def test_label_flags_computation_never_mutates_entries_or_roster():
+    """_compute_label_flags (backing GET /api/voices/label_flags) is
+    advisory-only: running it must leave every entry's "speaker" value and
+    the derived roster list byte-identical before and after, whether or not
+    it flags anything."""
+    import copy
+
+    source_text = (
+        "Alice walked into the room. \"Hello,\" said Alice. "
+        "A stranger lurked nearby, saying nothing."
+    )
+    script_data = [
+        {"speaker": "Alice", "text": "Hello,", "instruct": "warm"},
+        # ZORBLAX never appears in source_text at all -> should be flagged.
+        {"speaker": "Zorblax", "text": "A stranger lurked nearby", "instruct": "flat"},
+    ]
+
+    before_entries = copy.deepcopy(script_data)
+    before_roster = _canonical_roster_names(script_data)
+
+    flags = _compute_label_flags(script_data, source_text)
+
+    after_entries = copy.deepcopy(script_data)
+    after_roster = _canonical_roster_names(script_data)
+
+    check("label_flags: script entries unchanged after computation",
+          before_entries == after_entries, detail=repr(after_entries))
+    check("label_flags: roster unchanged after computation",
+          before_roster == after_roster, detail=repr((before_roster, after_roster)))
+    check("label_flags: returns a flag record for each non-NARRATOR speaker",
+          {f["name"] for f in flags} == {"ALICE", "ZORBLAX"}, detail=repr(flags))
+
+    by_name = {f["name"]: f for f in flags}
+    check("label_flags: ALICE is attested (appears near its own line)",
+          by_name["ALICE"]["attested"] is True, detail=repr(by_name["ALICE"]))
+    check("label_flags: ZORBLAX is flagged unattested (name never appears in source)",
+          by_name["ZORBLAX"]["attested"] is False, detail=repr(by_name["ZORBLAX"]))
+
+
 def main():
     tests = [
+        test_label_flags_computation_never_mutates_entries_or_roster,
         test_voices_roster_consolidates_whitespace_drift,
         test_voices_roster_selection_is_order_independent,
         test_voices_roster_unifies_punctuation_drift,
@@ -344,6 +415,8 @@ def main():
         test_roster_handles_legacy_type_field_and_empty,
         test_config_backcompat_resolution,
         test_config_exact_key_wins_over_scan,
+        test_roster_keeps_husband_and_wife_apart,
+        test_config_metadata_keys_are_not_speakers,
         test_build_voice_roster_return_shape_is_two_tuple,
         test_build_voice_roster_does_not_compute_alias_suggestions,
         test_alias_suggestions_endpoint_helpers_match_old_inline_path,

--- a/app/test_canon_wiring.py
+++ b/app/test_canon_wiring.py
@@ -1,0 +1,238 @@
+"""Standalone tests for the speaker_canon wiring in app.py / review_script.py.
+
+Covers:
+  - app.build_voice_roster(): canonical, deduped, fragment-free roster
+    construction from raw script entries; advisory alias_suggestions;
+    back-compat config lookup against non-canonical voice_config.json keys.
+  - review_script._canonicalize_speakers(): canonicalizes "speaker" fields
+    only, leaving "text" byte-identical.
+
+Run directly:
+    python app/test_canon_wiring.py
+Exits 0 if all tests pass, non-zero otherwise.
+"""
+import os
+import sys
+import types
+import traceback
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# app.py pulls in `project` (-> tts.py -> numpy/torch/etc.) purely for
+# unrelated TTS/project-management functionality that this test does not
+# exercise. Stub it out before importing app.py, same pattern as
+# app/test_epub_extract.py, to keep this test lightweight and standalone.
+if 'project' not in sys.modules:
+    _fake_project = types.ModuleType('project')
+
+    class _FakeProjectManager:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def load_chunks(self):
+            return []
+
+        def save_chunks(self, chunks):
+            pass
+
+        def __getattr__(self, name):
+            def _noop(*args, **kwargs):
+                return None
+            return _noop
+
+    _fake_project.ProjectManager = _FakeProjectManager
+    sys.modules['project'] = _fake_project
+
+from app import build_voice_roster  # noqa: E402
+from review_script import _canonicalize_speakers  # noqa: E402
+
+
+results = []
+
+
+def check(name, condition, detail=""):
+    status = "PASS" if condition else "FAIL"
+    results.append((name, condition, detail))
+    print(f"[{status}] {name}" + (f" -- {detail}" if detail and not condition else ""))
+
+
+def test_roster_canonicalizes_and_dedupes():
+    script_data = [
+        {"speaker": "mark", "text": "a"},
+        {"speaker": "Mr. Mark", "text": "b"},
+        {"speaker": "MARK (shouting)", "text": "c"},
+        {"speaker": "JON", "text": "d"},
+        {"speaker": "JOHN", "text": "e"},
+        {"speaker": "narrator", "text": "f"},
+    ]
+    roster_names, alias_suggestions, config_lookup = build_voice_roster(script_data, {})
+
+    check(
+        "roster: exactly 4 canonical names, MARK collapsed, JON/JOHN distinct",
+        roster_names == sorted(["JON", "JOHN", "MARK", "NARRATOR"]),
+        detail=repr(roster_names),
+    )
+
+    # JON/JOHN should produce a suggestion; MARK should not appear in any
+    # suggestion (no other roster name is similar enough to it).
+    names_in_suggestions = {s["name"] for s in alias_suggestions} | {
+        s["alias_of"] for s in alias_suggestions
+    }
+    check(
+        "roster: JON/JOHN produce an alias suggestion",
+        {"JON", "JOHN"} <= names_in_suggestions,
+        detail=repr(alias_suggestions),
+    )
+    check(
+        "roster: MARK has no alias suggestion",
+        "MARK" not in names_in_suggestions,
+        detail=repr(alias_suggestions),
+    )
+    check(
+        "roster: NARRATOR excluded from suggestions",
+        "NARRATOR" not in names_in_suggestions,
+        detail=repr(alias_suggestions),
+    )
+
+
+def test_roster_handles_legacy_type_field_and_empty():
+    script_data = [
+        {"type": "elena", "text": "a"},
+        {"speaker": "", "text": "b"},
+        {"speaker": "   ", "text": "c"},
+    ]
+    roster_names, alias_suggestions, config_lookup = build_voice_roster(script_data, {})
+    check(
+        "roster: legacy 'type' field used, blanks dropped",
+        roster_names == ["ELENA"],
+        detail=repr(roster_names),
+    )
+
+
+def test_config_backcompat_resolution():
+    script_data = [
+        {"speaker": "mark", "text": "a"},
+        {"speaker": "MARK (shouting)", "text": "b"},
+    ]
+    voice_config = {"Mr. Mark": {"engine": "clone", "ref": "mark.wav"}}
+    roster_names, alias_suggestions, config_lookup = build_voice_roster(script_data, voice_config)
+
+    check(
+        "config back-compat: roster resolves to MARK",
+        roster_names == ["MARK"],
+        detail=repr(roster_names),
+    )
+    check(
+        "config back-compat: non-canonical 'Mr. Mark' key resolves for MARK",
+        config_lookup.get("MARK") == {"engine": "clone", "ref": "mark.wav"},
+        detail=repr(config_lookup),
+    )
+
+    # Simulate what the handler does to derive persona_pending.
+    persona_pending = "MARK" not in config_lookup
+    check(
+        "config back-compat: persona_pending is False when config resolves",
+        persona_pending is False,
+    )
+
+
+def test_config_exact_key_wins_over_scan():
+    # If BOTH an exact canonical key and a differently-cased key that would
+    # canonicalize to the same name exist, the exact match must win.
+    script_data = [{"speaker": "mark", "text": "a"}]
+    voice_config = {
+        "MARK": {"engine": "exact"},
+        "Mr. Mark": {"engine": "scanned"},
+    }
+    roster_names, alias_suggestions, config_lookup = build_voice_roster(script_data, voice_config)
+    check(
+        "config back-compat: exact canonical key wins over scanned fallback",
+        config_lookup.get("MARK") == {"engine": "exact"},
+        detail=repr(config_lookup),
+    )
+
+
+def test_alias_suggestions_attached_per_voice():
+    """Mirrors what the get_voices handler does with alias_suggestions."""
+    script_data = [
+        {"speaker": "JON", "text": "a"},
+        {"speaker": "JOHN", "text": "b"},
+        {"speaker": "MARK", "text": "c"},
+    ]
+    roster_names, alias_suggestions, config_lookup = build_voice_roster(script_data, {})
+
+    per_voice = {
+        name: [s for s in alias_suggestions if s["name"] == name]
+        for name in roster_names
+    }
+    check(
+        "alias_suggestions: MARK gets an empty list",
+        per_voice.get("MARK") == [],
+        detail=repr(per_voice),
+    )
+    non_empty = [name for name, sugs in per_voice.items() if sugs]
+    check(
+        "alias_suggestions: exactly one of JON/JOHN carries the suggestion "
+        "(the shorter/alias side)",
+        non_empty == ["JON"],
+        detail=repr(per_voice),
+    )
+
+
+def test_review_canonicalizes_speaker_not_text():
+    entries = [
+        {"speaker": "Narrator", "text": "Once upon a time.", "instruct": "calm"},
+        {"speaker": "elena", "text": "  Hello there!  ", "instruct": "warm"},
+        {"speaker": "Mr. Mark (shouting)", "text": "Stop!", "instruct": "angry"},
+    ]
+    result = _canonicalize_speakers(entries)
+
+    check(
+        "review: speakers canonicalized",
+        [e["speaker"] for e in result] == ["NARRATOR", "ELENA", "MARK"],
+        detail=repr([e["speaker"] for e in result]),
+    )
+    check(
+        "review: text fields byte-identical to input",
+        [e["text"] for e in result] == [e["text"] for e in entries],
+        detail=repr([e["text"] for e in result]),
+    )
+    check(
+        "review: instruct fields untouched",
+        [e["instruct"] for e in result] == [e["instruct"] for e in entries],
+    )
+    check(
+        "review: original entries list not mutated",
+        entries[0]["speaker"] == "Narrator" and entries[2]["speaker"] == "Mr. Mark (shouting)",
+        detail=repr(entries),
+    )
+
+
+def main():
+    tests = [
+        test_roster_canonicalizes_and_dedupes,
+        test_roster_handles_legacy_type_field_and_empty,
+        test_config_backcompat_resolution,
+        test_config_exact_key_wins_over_scan,
+        test_alias_suggestions_attached_per_voice,
+        test_review_canonicalizes_speaker_not_text,
+    ]
+    for t in tests:
+        try:
+            t()
+        except Exception:
+            check(t.__name__, False, detail=traceback.format_exc())
+
+    failed = [name for name, ok, _ in results if not ok]
+    print()
+    print(f"{len(results) - len(failed)}/{len(results)} checks passed")
+    if failed:
+        print("FAILED:")
+        for name in failed:
+            print(f"  - {name}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/app/test_canon_wiring.py
+++ b/app/test_canon_wiring.py
@@ -1,10 +1,10 @@
 """Standalone tests for the speaker_canon wiring in app.py / review_script.py.
 
 Covers:
-  - app.build_voice_roster(): canonical, deduped, fragment-free roster
+  - build_voice_roster(): canonical, deduped, fragment-free roster
     construction from raw script entries; back-compat config lookup
     against non-canonical voice_config.json keys.
-  - app._canonical_roster_names() + GET /api/voices/alias_suggestions'
+  - _canonical_roster_names() + GET /api/voices/alias_suggestions'
     underlying helpers: the on-demand, split-out alias-suggestion path.
   - review_script._canonicalize_speakers(): canonicalizes "speaker" fields
     only, leaving "text" byte-identical.
@@ -17,7 +17,7 @@ field (measured on a real 589-speaker roster: ~52ms of an ~80ms request,
 suggest_aliases() at all -- it now returns a (roster_names, config_lookup)
 2-tuple. Alias suggestions are computed only on demand, via a new
 GET /api/voices/alias_suggestions endpoint backed by
-app._canonical_roster_names() + speaker_canon.suggest_aliases().
+_canonical_roster_names() + speaker_canon.suggest_aliases().
 
 Run directly:
     python app/test_canon_wiring.py
@@ -278,8 +278,68 @@ def test_review_canonicalizes_speaker_not_text():
     )
 
 
+
+# ---------------------------------------------------------------------------
+# F15: roster-aware spelling resolution in the voices roster
+# ---------------------------------------------------------------------------
+
+def test_voices_roster_consolidates_whitespace_drift():
+    script = [
+        {"speaker": "ABBE MARIGNAN", "text": "a"},
+        {"speaker": "NARRATOR", "text": "b"},
+        {"speaker": "ABBEMARIGNAN", "text": "c"},
+    ]
+    names, _ = build_voice_roster(script, {})
+    check("voices roster consolidates ABBEMARIGNAN onto first-seen ABBE MARIGNAN",
+          names == ["ABBE MARIGNAN", "NARRATOR"], detail=repr(names))
+
+
+def test_voices_roster_selection_is_order_independent():
+    forward = _canonical_roster_names([
+        {"speaker": "ABBE MARIGNAN", "text": "a"},
+        {"speaker": "ABBEMARIGNAN", "text": "b"},
+    ])
+    backward = _canonical_roster_names([
+        {"speaker": "ABBEMARIGNAN", "text": "a"},
+        {"speaker": "ABBE MARIGNAN", "text": "b"},
+    ])
+    check("voices roster picks the more-punctuated spelling in either order",
+          forward == backward == ["ABBE MARIGNAN"],
+          detail=f"{forward!r} vs {backward!r}")
+
+
+def test_voices_roster_unifies_punctuation_drift():
+    names = _canonical_roster_names([
+        {"speaker": "OBRIEN", "text": "a"},
+        {"speaker": "O'BRIEN", "text": "b"},
+        {"speaker": "OBRIAN", "text": "c"},
+    ])
+    check("O'BRIEN/OBRIEN unify; OBRIAN stays a separate character",
+          names == ["O'BRIEN", "OBRIAN"], detail=repr(names))
+
+
+def test_voices_roster_never_merges_similar_names():
+    script = [{"speaker": n, "text": "x"} for n in ("JON", "JOHN", "ELLA", "BELLA")]
+    names = _canonical_roster_names(script)
+    check("JON/JOHN/ELLA/BELLA stay four distinct roster entries",
+          names == ["BELLA", "ELLA", "JOHN", "JON"], detail=repr(names))
+
+
+def test_voices_config_lookup_survives_whitespace_drift():
+    script = [{"speaker": "ABBE MARIGNAN", "text": "a"}]
+    names, lookup = build_voice_roster(script, {"ABBEMARIGNAN": {"voice": "v1"}})
+    check("voice_config saved under a drifted spelling still resolves",
+          lookup.get("ABBE MARIGNAN") == {"voice": "v1"}, detail=repr(lookup))
+
+
+
 def main():
     tests = [
+        test_voices_roster_consolidates_whitespace_drift,
+        test_voices_roster_selection_is_order_independent,
+        test_voices_roster_unifies_punctuation_drift,
+        test_voices_roster_never_merges_similar_names,
+        test_voices_config_lookup_survives_whitespace_drift,
         test_roster_canonicalizes_and_dedupes,
         test_roster_handles_legacy_type_field_and_empty,
         test_config_backcompat_resolution,

--- a/app/test_canon_wiring.py
+++ b/app/test_canon_wiring.py
@@ -2,10 +2,22 @@
 
 Covers:
   - app.build_voice_roster(): canonical, deduped, fragment-free roster
-    construction from raw script entries; advisory alias_suggestions;
-    back-compat config lookup against non-canonical voice_config.json keys.
+    construction from raw script entries; back-compat config lookup
+    against non-canonical voice_config.json keys.
+  - app._canonical_roster_names() + GET /api/voices/alias_suggestions'
+    underlying helpers: the on-demand, split-out alias-suggestion path.
   - review_script._canonicalize_speakers(): canonicalizes "speaker" fields
     only, leaving "text" byte-identical.
+
+F13: suggest_aliases() is O(n^2) in roster size and was previously run
+unconditionally inside build_voice_roster() on every GET /api/voices call,
+even though the frontend never read the resulting "alias_suggestions"
+field (measured on a real 589-speaker roster: ~52ms of an ~80ms request,
+~160KB of unused response payload). build_voice_roster() no longer touches
+suggest_aliases() at all -- it now returns a (roster_names, config_lookup)
+2-tuple. Alias suggestions are computed only on demand, via a new
+GET /api/voices/alias_suggestions endpoint backed by
+app._canonical_roster_names() + speaker_canon.suggest_aliases().
 
 Run directly:
     python app/test_canon_wiring.py
@@ -13,6 +25,7 @@ Exits 0 if all tests pass, non-zero otherwise.
 """
 import os
 import sys
+import time
 import types
 import traceback
 
@@ -43,7 +56,9 @@ if 'project' not in sys.modules:
     _fake_project.ProjectManager = _FakeProjectManager
     sys.modules['project'] = _fake_project
 
-from app import build_voice_roster  # noqa: E402
+import app as app_module  # noqa: E402
+from app import build_voice_roster, _canonical_roster_names  # noqa: E402
+from speaker_canon import suggest_aliases  # noqa: E402
 from review_script import _canonicalize_speakers  # noqa: E402
 
 
@@ -65,33 +80,12 @@ def test_roster_canonicalizes_and_dedupes():
         {"speaker": "JOHN", "text": "e"},
         {"speaker": "narrator", "text": "f"},
     ]
-    roster_names, alias_suggestions, config_lookup = build_voice_roster(script_data, {})
+    roster_names, config_lookup = build_voice_roster(script_data, {})
 
     check(
         "roster: exactly 4 canonical names, MARK collapsed, JON/JOHN distinct",
         roster_names == sorted(["JON", "JOHN", "MARK", "NARRATOR"]),
         detail=repr(roster_names),
-    )
-
-    # JON/JOHN should produce a suggestion; MARK should not appear in any
-    # suggestion (no other roster name is similar enough to it).
-    names_in_suggestions = {s["name"] for s in alias_suggestions} | {
-        s["alias_of"] for s in alias_suggestions
-    }
-    check(
-        "roster: JON/JOHN produce an alias suggestion",
-        {"JON", "JOHN"} <= names_in_suggestions,
-        detail=repr(alias_suggestions),
-    )
-    check(
-        "roster: MARK has no alias suggestion",
-        "MARK" not in names_in_suggestions,
-        detail=repr(alias_suggestions),
-    )
-    check(
-        "roster: NARRATOR excluded from suggestions",
-        "NARRATOR" not in names_in_suggestions,
-        detail=repr(alias_suggestions),
     )
 
 
@@ -101,7 +95,7 @@ def test_roster_handles_legacy_type_field_and_empty():
         {"speaker": "", "text": "b"},
         {"speaker": "   ", "text": "c"},
     ]
-    roster_names, alias_suggestions, config_lookup = build_voice_roster(script_data, {})
+    roster_names, config_lookup = build_voice_roster(script_data, {})
     check(
         "roster: legacy 'type' field used, blanks dropped",
         roster_names == ["ELENA"],
@@ -115,7 +109,7 @@ def test_config_backcompat_resolution():
         {"speaker": "MARK (shouting)", "text": "b"},
     ]
     voice_config = {"Mr. Mark": {"engine": "clone", "ref": "mark.wav"}}
-    roster_names, alias_suggestions, config_lookup = build_voice_roster(script_data, voice_config)
+    roster_names, config_lookup = build_voice_roster(script_data, voice_config)
 
     check(
         "config back-compat: roster resolves to MARK",
@@ -144,7 +138,7 @@ def test_config_exact_key_wins_over_scan():
         "MARK": {"engine": "exact"},
         "Mr. Mark": {"engine": "scanned"},
     }
-    roster_names, alias_suggestions, config_lookup = build_voice_roster(script_data, voice_config)
+    roster_names, config_lookup = build_voice_roster(script_data, voice_config)
     check(
         "config back-compat: exact canonical key wins over scanned fallback",
         config_lookup.get("MARK") == {"engine": "exact"},
@@ -152,30 +146,106 @@ def test_config_exact_key_wins_over_scan():
     )
 
 
-def test_alias_suggestions_attached_per_voice():
-    """Mirrors what the get_voices handler does with alias_suggestions."""
+def test_build_voice_roster_return_shape_is_two_tuple():
+    """F13: build_voice_roster() no longer returns alias_suggestions --
+    its return shape shrank from a 3-tuple to (roster_names,
+    config_lookup)."""
+    script_data = [{"speaker": "mark", "text": "a"}]
+    result = build_voice_roster(script_data, {})
+    check(
+        "build_voice_roster: returns a 2-tuple (roster_names, config_lookup)",
+        isinstance(result, tuple) and len(result) == 2,
+        detail=repr(result),
+    )
+
+
+def test_build_voice_roster_does_not_compute_alias_suggestions():
+    """F13: build_voice_roster() must never call suggest_aliases() -- that
+    O(n^2) work moved off the GET /api/voices hot path entirely, onto the
+    new on-demand GET /api/voices/alias_suggestions endpoint. Monkeypatch
+    app's module-level suggest_aliases with a spy and confirm it is never
+    invoked during build_voice_roster(), even on a roster large enough
+    that a real call would be noticeable if it happened."""
+    calls = []
+    original = app_module.suggest_aliases
+
+    def _spy(*args, **kwargs):
+        calls.append(args)
+        return original(*args, **kwargs)
+
+    app_module.suggest_aliases = _spy
+    try:
+        script_data = [{"speaker": f"SPEAKER{i}", "text": "x"} for i in range(50)]
+        build_voice_roster(script_data, {})
+    finally:
+        app_module.suggest_aliases = original
+
+    check(
+        "build_voice_roster: suggest_aliases() is never called (moved off the hot path)",
+        calls == [],
+        detail=repr(calls),
+    )
+
+
+def test_alias_suggestions_endpoint_helpers_match_old_inline_path():
+    """The new on-demand endpoint's underlying helpers
+    (_canonical_roster_names() + suggest_aliases()) must produce the exact
+    same roster and suggestions the old inlined build_voice_roster() path
+    did for a fixed fixture roster -- this is a pure code-motion refactor,
+    not a behavior change to the suggestions themselves."""
     script_data = [
         {"speaker": "JON", "text": "a"},
         {"speaker": "JOHN", "text": "b"},
         {"speaker": "MARK", "text": "c"},
+        {"speaker": "ELLA", "text": "d"},
+        {"speaker": "BELLA", "text": "e"},
     ]
-    roster_names, alias_suggestions, config_lookup = build_voice_roster(script_data, {})
+    endpoint_roster_names = _canonical_roster_names(script_data)
+    endpoint_suggestions = suggest_aliases(endpoint_roster_names)
 
+    # What build_voice_roster() computes its roster from -- must be the
+    # exact same roster the on-demand endpoint's helper produces, since
+    # they're both derived from the same script_data.
+    roster_from_build_voice_roster, _config_lookup = build_voice_roster(script_data, {})
+
+    check(
+        "alias_suggestions endpoint: roster matches build_voice_roster's roster",
+        endpoint_roster_names == roster_from_build_voice_roster,
+        detail=repr((endpoint_roster_names, roster_from_build_voice_roster)),
+    )
     per_voice = {
-        name: [s for s in alias_suggestions if s["name"] == name]
-        for name in roster_names
+        name: [s for s in endpoint_suggestions if s["name"] == name]
+        for name in endpoint_roster_names
     }
     check(
-        "alias_suggestions: MARK gets an empty list",
+        "alias_suggestions endpoint: MARK gets an empty list (no similar name)",
         per_voice.get("MARK") == [],
         detail=repr(per_voice),
     )
-    non_empty = [name for name, sugs in per_voice.items() if sugs]
+    non_empty = sorted(name for name, sugs in per_voice.items() if sugs)
     check(
-        "alias_suggestions: exactly one of JON/JOHN carries the suggestion "
-        "(the shorter/alias side)",
-        non_empty == ["JON"],
+        "alias_suggestions endpoint: JON (of JON/JOHN) and ELLA (of ELLA/BELLA) "
+        "carry suggestions (the shorter/alias side of each pair)",
+        non_empty == ["ELLA", "JON"],
         detail=repr(per_voice),
+    )
+
+
+def test_alias_suggestions_perf_bound_600_names():
+    """Perf regression guard: suggest_aliases() must stay well clear of an
+    O(n^2) blowup on a roster as large as the biggest real one measured
+    (589 speakers). 500ms is generous headroom -- enough to not flake on a
+    slow CI machine -- while still catching a real algorithmic regression;
+    a correctly-implemented O(n^2) string-similarity pass over 600 short
+    names normally completes in well under 100ms."""
+    roster = [f"CHARACTER{i:04d}" for i in range(600)]
+    start = time.perf_counter()
+    suggestions = suggest_aliases(roster)
+    elapsed = time.perf_counter() - start
+    check(
+        f"suggest_aliases: 600-name roster completes in <500ms (actual: {elapsed * 1000:.1f}ms)",
+        elapsed < 0.5,
+        detail=f"elapsed={elapsed:.3f}s, suggestions_count={len(suggestions)}",
     )
 
 
@@ -214,7 +284,10 @@ def main():
         test_roster_handles_legacy_type_field_and_empty,
         test_config_backcompat_resolution,
         test_config_exact_key_wins_over_scan,
-        test_alias_suggestions_attached_per_voice,
+        test_build_voice_roster_return_shape_is_two_tuple,
+        test_build_voice_roster_does_not_compute_alias_suggestions,
+        test_alias_suggestions_endpoint_helpers_match_old_inline_path,
+        test_alias_suggestions_perf_bound_600_names,
         test_review_canonicalizes_speaker_not_text,
     ]
     for t in tests:

--- a/app/test_config_roundtrip.py
+++ b/app/test_config_roundtrip.py
@@ -1,0 +1,203 @@
+"""Standalone tests for F17: config keys silently dropped on save.
+
+Verifies that AppConfig/TTSConfig/GenerationConfig round-trip realistic
+configs without dropping keys the pipeline reads (num_ctx,
+max_context_roster_names, review_batch_char_budget, review_batch_size,
+enable_nemo_normalization), without introducing keys that weren't present
+in an untouched config, and without changing values. No pytest; exits 0 on
+success, 1 on failure.
+"""
+import copy
+import json
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+os.environ.setdefault("ALEXANDRIA_CONFIG_PATH",
+                       os.path.join(os.path.dirname(os.path.abspath(__file__)), "_nonexistent_config.json"))
+
+# app.py pulls in `project` (-> tts.py -> numpy/torch/etc.) purely for
+# unrelated TTS/project-management functionality that this test does not
+# exercise. Stub it out before importing app.py, same pattern as
+# app/test_canon_wiring.py, to keep this test lightweight and standalone.
+if 'project' not in sys.modules:
+    _fake_project = types.ModuleType('project')
+
+    class _FakeProjectManager:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def load_chunks(self):
+            return []
+
+        def save_chunks(self, chunks):
+            pass
+
+        def __getattr__(self, name):
+            def _noop(*args, **kwargs):
+                return None
+            return _noop
+
+    _fake_project.ProjectManager = _FakeProjectManager
+    sys.modules['project'] = _fake_project
+
+import app as app_module  # noqa: E402
+
+AppConfig = app_module.AppConfig
+
+failures = []
+
+
+def check(name, condition):
+    status = "PASS" if condition else "FAIL"
+    print(f"  [ {status} ] {name}")
+    if not condition:
+        failures.append(name)
+
+
+REALISTIC_CONFIG = {
+    "llm": {
+        "base_url": "http://127.0.0.1:11434/v1",
+        "api_key": "ollama",
+        "model_name": "qwen2.5:14b",
+    },
+    "tts": {
+        "mode": "local",
+        "url": "http://127.0.0.1:7860",
+        "device": "auto",
+        "language": "English",
+        "parallel_workers": 2,
+        "batch_seed": None,
+        "compile_codec": False,
+        "sub_batch_enabled": True,
+        "sub_batch_min_size": 4,
+        "sub_batch_ratio": 5.0,
+        "sub_batch_max_items": 0,
+        "batch_group_by_type": False,
+        "pause_between_speakers_ms": 500,
+        "pause_same_speaker_ms": 250,
+    },
+    "prompts": {
+        "system_prompt": "You are a script generator.",
+        "user_prompt": "Generate a script.",
+        "review_system_prompt": None,
+        "review_user_prompt": None,
+        "persona_system_prompt": None,
+        "persona_user_prompt": None,
+        "persona_advanced_prompt": None,
+    },
+    "generation": {
+        "chunk_size": 3000,
+        "max_tokens": 4096,
+        "temperature": 0.6,
+        "top_p": 0.8,
+        "top_k": 0,
+        "min_p": 0,
+        "presence_penalty": 0.0,
+        "banned_tokens": [],
+        "merge_narrators": False,
+    },
+}
+
+
+def save(config_dict):
+    """Mimic save_config's persistence logic without touching disk/FastAPI."""
+    cfg = AppConfig(**config_dict)
+    return cfg.model_dump(exclude_none=True)
+
+
+print("=" * 60)
+print("  F17: Config round-trip (save_config key preservation)")
+print("=" * 60)
+
+# 1. Untouched realistic config: no keys added that weren't there, no
+#    existing value changed. (New keys carry their own defaults which equal
+#    the pipeline's existing hard-coded defaults, so this is intentional
+#    growth of the schema, not silent corruption -- but nothing already
+#    present may be dropped or mutated, and num_ctx must NOT appear.)
+original = copy.deepcopy(REALISTIC_CONFIG)
+saved = save(original)
+
+check("llm section unchanged", saved["llm"] == original["llm"])
+check("tts: no existing tts key changed",
+      all(saved["tts"].get(k) == v for k, v in original["tts"].items() if v is not None))
+check("tts: batch_seed (None) omitted, not corrupted",
+      "batch_seed" not in saved["tts"] or saved["tts"]["batch_seed"] is None)
+check("generation: no existing generation key changed",
+      all(saved["generation"].get(k) == v for k, v in original["generation"].items()))
+check("prompts: non-null prompt values preserved",
+      saved["prompts"]["system_prompt"] == "You are a script generator." and
+      saved["prompts"]["user_prompt"] == "Generate a script.")
+check("num_ctx absent when never set (unset stays unset)",
+      "num_ctx" not in saved["generation"])
+
+# 2. New keys persist when explicitly set.
+cfg2 = copy.deepcopy(REALISTIC_CONFIG)
+cfg2["generation"]["num_ctx"] = 8192
+cfg2["generation"]["max_context_roster_names"] = 75
+cfg2["generation"]["review_batch_char_budget"] = 9000
+cfg2["generation"]["review_batch_size"] = 10
+cfg2["tts"]["enable_nemo_normalization"] = True
+saved2 = save(cfg2)
+
+check("num_ctx persists when set", saved2["generation"].get("num_ctx") == 8192)
+check("max_context_roster_names persists when set",
+      saved2["generation"].get("max_context_roster_names") == 75)
+check("review_batch_char_budget persists when set",
+      saved2["generation"].get("review_batch_char_budget") == 9000)
+check("review_batch_size persists when set",
+      saved2["generation"].get("review_batch_size") == 10)
+check("enable_nemo_normalization persists when set",
+      saved2["tts"].get("enable_nemo_normalization") is True)
+
+# 3. num_ctx stays absent through a second round-trip if left unset.
+cfg3 = copy.deepcopy(REALISTIC_CONFIG)
+saved3a = save(cfg3)
+saved3b = save(saved3a)
+check("num_ctx stays absent across repeated round-trips",
+      "num_ctx" not in saved3a["generation"] and "num_ctx" not in saved3b["generation"])
+
+# 4. Unknown/legacy keys are preserved (extra="allow" design choice).
+cfg4 = copy.deepcopy(REALISTIC_CONFIG)
+cfg4["generation"]["some_future_key_not_yet_declared"] = "keep-me"
+cfg4["tts"]["another_future_flag"] = 42
+cfg4["a_brand_new_top_level_section"] = {"foo": "bar"}
+saved4 = save(cfg4)
+check("unknown generation key preserved (extra='allow')",
+      saved4["generation"].get("some_future_key_not_yet_declared") == "keep-me")
+check("unknown tts key preserved (extra='allow')",
+      saved4["tts"].get("another_future_flag") == 42)
+check("unknown top-level section preserved (extra='allow')",
+      saved4.get("a_brand_new_top_level_section") == {"foo": "bar"})
+
+# 5. Defaults for the new keys match the pipeline's own hard-coded defaults
+#    (so a config that never mentions them behaves identically pre/post fix,
+#    except num_ctx which must stay entirely absent).
+minimal = {
+    "llm": REALISTIC_CONFIG["llm"],
+    "tts": {"mode": "local", "url": "http://x", "device": "auto"},
+    "generation": {},
+}
+saved_min = save(minimal)
+check("minimal config: max_context_roster_names defaults to 50",
+      saved_min["generation"]["max_context_roster_names"] == 50)
+check("minimal config: review_batch_size defaults to 25",
+      saved_min["generation"]["review_batch_size"] == 25)
+check("minimal config: review_batch_char_budget defaults to 12000",
+      saved_min["generation"]["review_batch_char_budget"] == 12000)
+check("minimal config: enable_nemo_normalization defaults to False",
+      saved_min["tts"]["enable_nemo_normalization"] is False)
+check("minimal config: num_ctx still absent by default",
+      "num_ctx" not in saved_min["generation"])
+
+print("=" * 60)
+if failures:
+    print(f"  {len(failures)} check(s) FAILED:")
+    for f in failures:
+        print(f"    - {f}")
+    sys.exit(1)
+else:
+    print("  All checks passed.")
+    sys.exit(0)

--- a/app/test_config_roundtrip.py
+++ b/app/test_config_roundtrip.py
@@ -152,6 +152,38 @@ check("review_batch_size persists when set",
 check("enable_nemo_normalization persists when set",
       saved2["tts"].get("enable_nemo_normalization") is True)
 
+# 2b. The attestation gate and the LLM timeout, same contract as above:
+#     absent unless set, preserved once set, and (for the timeout) living in
+#     the llm section, which had no extra="allow" and therefore used to drop
+#     every key it did not declare.
+cfg2b = copy.deepcopy(REALISTIC_CONFIG)
+cfg2b["generation"]["require_attested_speakers"] = True
+cfg2b["generation"]["attestation_lookback_chars"] = 1500
+cfg2b["llm"]["timeout"] = 900
+saved2b = save(cfg2b)
+
+check("require_attested_speakers persists when set",
+      saved2b["generation"].get("require_attested_speakers") is True)
+check("attestation_lookback_chars persists when set",
+      saved2b["generation"].get("attestation_lookback_chars") == 1500)
+check("llm.timeout persists when set",
+      saved2b["llm"].get("timeout") == 900)
+check("llm section keeps its unknown keys too (extra='allow')",
+      save({**copy.deepcopy(REALISTIC_CONFIG),
+            "llm": {**REALISTIC_CONFIG["llm"], "future_llm_key": "keep-me"}}
+           )["llm"].get("future_llm_key") == "keep-me")
+
+# The gate must default OFF and the timeout must stay ABSENT when unset, or
+# enabling either becomes a silent behaviour change for existing installs.
+check("require_attested_speakers defaults to False",
+      save(copy.deepcopy(REALISTIC_CONFIG))["generation"].get(
+          "require_attested_speakers") is False)
+check("llm.timeout absent when never set (SDK default preserved)",
+      "timeout" not in save(copy.deepcopy(REALISTIC_CONFIG))["llm"])
+check("attestation_lookback_chars absent when never set",
+      "attestation_lookback_chars" not in save(
+          copy.deepcopy(REALISTIC_CONFIG))["generation"])
+
 # 3. num_ctx stays absent through a second round-trip if left unset.
 cfg3 = copy.deepcopy(REALISTIC_CONFIG)
 saved3a = save(cfg3)

--- a/app/test_config_roundtrip.py
+++ b/app/test_config_roundtrip.py
@@ -168,6 +168,12 @@ check("attestation_lookback_chars persists when set",
       saved2b["generation"].get("attestation_lookback_chars") == 1500)
 check("llm.timeout persists when set",
       saved2b["llm"].get("timeout") == 900)
+check("llm.reasoning_effort persists when set",
+      save({**copy.deepcopy(REALISTIC_CONFIG),
+            "llm": {**REALISTIC_CONFIG["llm"], "reasoning_effort": "none"}}
+           )["llm"].get("reasoning_effort") == "none")
+check("llm.reasoning_effort absent when never set (server default preserved)",
+      "reasoning_effort" not in save(copy.deepcopy(REALISTIC_CONFIG))["llm"])
 check("llm section keeps its unknown keys too (extra='allow')",
       save({**copy.deepcopy(REALISTIC_CONFIG),
             "llm": {**REALISTIC_CONFIG["llm"], "future_llm_key": "keep-me"}}

--- a/app/test_epub_extract.py
+++ b/app/test_epub_extract.py
@@ -1,0 +1,351 @@
+"""Standalone tests for extract_epub_text (app/app.py).
+
+Builds small EPUB fixtures programmatically with `zipfile` in a temp
+directory and exercises href resolution (percent-encoding, '../'
+traversal, case variants), paragraph-structure preservation, EPUB3 nav
+doc skipping, and the ValueError raised for an unresolvable href.
+
+Run directly:
+    python app/test_epub_extract.py
+Exits 0 if all tests pass, non-zero otherwise.
+"""
+import os
+import re
+import sys
+import types
+import zipfile
+import tempfile
+import traceback
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# app.py pulls in `project` (-> tts.py -> numpy/torch/etc.) purely for
+# unrelated TTS/project-management functionality that this test does not
+# exercise. Those heavy, possibly-uninstalled dependencies have nothing to
+# do with EPUB text extraction, so stub the `project` module in sys.modules
+# before importing app.py to keep this test lightweight and standalone.
+if 'project' not in sys.modules:
+    _fake_project = types.ModuleType('project')
+
+    class _FakeProjectManager:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def load_chunks(self):
+            return []
+
+        def save_chunks(self, chunks):
+            pass
+
+        def __getattr__(self, name):
+            # Any other attribute app.py's module-level code happens to
+            # touch becomes a harmless no-op callable.
+            def _noop(*args, **kwargs):
+                return None
+            return _noop
+
+    _fake_project.ProjectManager = _FakeProjectManager
+    sys.modules['project'] = _fake_project
+
+from app import extract_epub_text  # noqa: E402
+
+
+CONTAINER_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>
+"""
+
+
+def make_epub(path, opf_xml, files):
+    """Build a minimal EPUB zip at `path`.
+
+    files: dict of archive-relative-path -> str content (written under
+    OEBPS/ except for META-INF/container.xml and mimetype).
+    """
+    with zipfile.ZipFile(path, 'w') as zf:
+        zf.writestr('mimetype', 'application/epub+zip')
+        zf.writestr('META-INF/container.xml', CONTAINER_XML)
+        zf.writestr('OEBPS/content.opf', opf_xml)
+        for name, content in files.items():
+            zf.writestr(name, content)
+
+
+def opf(manifest_items, spine_items):
+    """Build a minimal OPF XML string.
+
+    manifest_items: list of (id, href, media_type, properties_or_None)
+    spine_items: list of idref strings
+    """
+    items = []
+    for item_id, href, media_type, props in manifest_items:
+        props_attr = f' properties="{props}"' if props else ''
+        items.append(
+            f'<item id="{item_id}" href="{href}" media-type="{media_type}"{props_attr}/>'
+        )
+    refs = [f'<itemref idref="{idref}"/>' for idref in spine_items]
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="bookid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Test Book</dc:title>
+    <dc:identifier id="bookid">test-book-id</dc:identifier>
+  </metadata>
+  <manifest>
+    {''.join(items)}
+  </manifest>
+  <spine>
+    {''.join(refs)}
+  </spine>
+</package>
+"""
+
+
+results = []
+
+
+def check(name, condition, detail=""):
+    status = "PASS" if condition else "FAIL"
+    results.append((name, condition, detail))
+    print(f"[{status}] {name}" + (f" -- {detail}" if detail and not condition else ""))
+
+
+def test_href_resolution_percent_and_traversal():
+    """3 chapters: plain href, percent-encoded href, '../' traversal href."""
+    with tempfile.TemporaryDirectory() as tmp:
+        epub_path = os.path.join(tmp, "book.epub")
+        manifest_items = [
+            ("ch1", "text/ch1.xhtml", "application/xhtml+xml", None),
+            ("ch2", "ch%202.xhtml", "application/xhtml+xml", None),
+            ("ch3", "../text/ch3.xhtml", "application/xhtml+xml", None),
+        ]
+        spine = ["ch1", "ch2", "ch3"]
+        opf_xml = opf(manifest_items, spine)
+        files = {
+            "OEBPS/text/ch1.xhtml": "<html><body><p>Chapter one content.</p></body></html>",
+            # OPF references "ch%202.xhtml" (percent-encoded space) -> actual
+            # member on disk is "OEBPS/ch 2.xhtml" (real space).
+            "OEBPS/ch 2.xhtml": "<html><body><p>Chapter two content.</p></body></html>",
+            # OPF references "../text/ch3.xhtml" relative to OEBPS/, i.e.
+            # normalizes to "text/ch3.xhtml" (no OEBPS/ prefix).
+            "text/ch3.xhtml": "<html><body><p>Chapter three content.</p></body></html>",
+        }
+        make_epub(epub_path, opf_xml, files)
+        text = extract_epub_text(epub_path)
+        check(
+            "href_resolution: all 3 chapters present",
+            "Chapter one content." in text
+            and "Chapter two content." in text
+            and "Chapter three content." in text,
+            detail=repr(text),
+        )
+
+
+def test_case_variant_href():
+    with tempfile.TemporaryDirectory() as tmp:
+        epub_path = os.path.join(tmp, "book.epub")
+        manifest_items = [
+            ("ch1", "Ch1.XHTML", "application/xhtml+xml", None),
+        ]
+        spine = ["ch1"]
+        opf_xml = opf(manifest_items, spine)
+        files = {
+            "OEBPS/ch1.xhtml": "<html><body><p>Case variant content.</p></body></html>",
+        }
+        make_epub(epub_path, opf_xml, files)
+        text = extract_epub_text(epub_path)
+        check(
+            "case_variant_href: chapter extracted",
+            "Case variant content." in text,
+            detail=repr(text),
+        )
+
+
+def test_paragraph_structure_preserved():
+    with tempfile.TemporaryDirectory() as tmp:
+        epub_path = os.path.join(tmp, "book.epub")
+        manifest_items = [
+            ("ch1", "ch1.xhtml", "application/xhtml+xml", None),
+        ]
+        spine = ["ch1"]
+        opf_xml = opf(manifest_items, spine)
+        paragraphs = [
+            "This is the first paragraph.",
+            "This is the second paragraph, a bit longer than the first.",
+            "Third paragraph here.",
+            "And a fourth and final paragraph.",
+        ]
+        body = "".join(f"<p>{p}</p>" for p in paragraphs)
+        files = {
+            "OEBPS/ch1.xhtml": f"<html><body>{body}</body></html>",
+        }
+        make_epub(epub_path, opf_xml, files)
+        text = extract_epub_text(epub_path)
+        pieces = re.split(r'\n\s*\n', text)
+        check(
+            "paragraph_structure: N paragraphs -> N pieces via \\n\\s*\\n split",
+            len(pieces) == len(paragraphs),
+            detail=f"expected {len(paragraphs)} pieces, got {len(pieces)}: {pieces!r}",
+        )
+        check(
+            "paragraph_structure: paragraph text matches in order",
+            pieces == paragraphs,
+            detail=repr(pieces),
+        )
+
+
+def test_nav_doc_skipped():
+    with tempfile.TemporaryDirectory() as tmp:
+        epub_path = os.path.join(tmp, "book.epub")
+        manifest_items = [
+            ("nav", "nav.xhtml", "application/xhtml+xml", "nav"),
+            ("ch1", "ch1.xhtml", "application/xhtml+xml", None),
+        ]
+        spine = ["nav", "ch1"]
+        opf_xml = opf(manifest_items, spine)
+        files = {
+            "OEBPS/nav.xhtml": (
+                "<html><body><nav epub:type='toc'>"
+                "<h1>Table of Contents</h1><ol><li>Chapter 1</li></ol>"
+                "</nav></body></html>"
+            ),
+            "OEBPS/ch1.xhtml": "<html><body><p>Real chapter content.</p></body></html>",
+        }
+        make_epub(epub_path, opf_xml, files)
+        text = extract_epub_text(epub_path)
+        check(
+            "nav_doc_skipped: nav content absent, chapter content present",
+            "Table of Contents" not in text and "Real chapter content." in text,
+            detail=repr(text),
+        )
+
+
+def test_broken_href_raises_valueerror():
+    with tempfile.TemporaryDirectory() as tmp:
+        epub_path = os.path.join(tmp, "book.epub")
+        manifest_items = [
+            ("ch1", "does-not-exist.xhtml", "application/xhtml+xml", None),
+        ]
+        spine = ["ch1"]
+        opf_xml = opf(manifest_items, spine)
+        files = {
+            # Deliberately no file matching "does-not-exist.xhtml" under any
+            # fallback (normalized, case-insensitive, or basename).
+            "OEBPS/unrelated.xhtml": "<html><body><p>Unrelated.</p></body></html>",
+        }
+        make_epub(epub_path, opf_xml, files)
+        raised = False
+        try:
+            extract_epub_text(epub_path)
+        except ValueError:
+            raised = True
+        except Exception as e:
+            check(
+                "broken_href: raises ValueError (not some other exception)",
+                False,
+                detail=f"raised {type(e).__name__}: {e}",
+            )
+            return
+        check("broken_href: raises ValueError instead of silently skipping", raised)
+
+
+def test_non_html_spine_item_skipped():
+    """A spine may legally reference non-text content (e.g. an SVG cover
+    page). That manifest item DOES exist -- it must be skipped with a
+    notice, not raise, and must not derail extraction of the real chapter.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        epub_path = os.path.join(tmp, "book.epub")
+        manifest_items = [
+            ("cover", "cover.svg", "image/svg+xml", None),
+            ("ch1", "ch1.xhtml", "application/xhtml+xml", None),
+        ]
+        spine = ["cover", "ch1"]
+        opf_xml = opf(manifest_items, spine)
+        files = {
+            "OEBPS/cover.svg": (
+                '<svg xmlns="http://www.w3.org/2000/svg">'
+                '<title>Cover</title></svg>'
+            ),
+            "OEBPS/ch1.xhtml": "<html><body><p>Real chapter content.</p></body></html>",
+        }
+        make_epub(epub_path, opf_xml, files)
+        try:
+            text = extract_epub_text(epub_path)
+        except Exception as e:
+            check(
+                "non_html_spine_item: extraction succeeds without raising",
+                False,
+                detail=f"raised {type(e).__name__}: {e}",
+            )
+            return
+        check("non_html_spine_item: extraction succeeds without raising", True)
+        check(
+            "non_html_spine_item: chapter text present",
+            "Real chapter content." in text,
+            detail=repr(text),
+        )
+
+
+def test_missing_idref_raises_valueerror():
+    """A spine idref that has NO corresponding manifest item at all (as
+    opposed to a manifest item that exists but is non-HTML) must still
+    raise -- this is the genuinely-missing-item case, distinct from the
+    legally-non-text-item case above.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        epub_path = os.path.join(tmp, "book.epub")
+        manifest_items = [
+            ("ch1", "ch1.xhtml", "application/xhtml+xml", None),
+        ]
+        spine = ["ch1", "ghost"]  # "ghost" has no manifest entry whatsoever
+        opf_xml = opf(manifest_items, spine)
+        files = {
+            "OEBPS/ch1.xhtml": "<html><body><p>Chapter content.</p></body></html>",
+        }
+        make_epub(epub_path, opf_xml, files)
+        raised = False
+        try:
+            extract_epub_text(epub_path)
+        except ValueError:
+            raised = True
+        except Exception as e:
+            check(
+                "missing_idref: raises ValueError (not some other exception)",
+                False,
+                detail=f"raised {type(e).__name__}: {e}",
+            )
+            return
+        check("missing_idref: raises ValueError for idref absent from manifest", raised)
+
+
+def main():
+    tests = [
+        test_href_resolution_percent_and_traversal,
+        test_case_variant_href,
+        test_paragraph_structure_preserved,
+        test_nav_doc_skipped,
+        test_broken_href_raises_valueerror,
+        test_non_html_spine_item_skipped,
+        test_missing_idref_raises_valueerror,
+    ]
+    for t in tests:
+        try:
+            t()
+        except Exception:
+            check(t.__name__, False, detail=traceback.format_exc())
+
+    failed = [name for name, ok, _ in results if not ok]
+    print()
+    print(f"{len(results) - len(failed)}/{len(results)} checks passed")
+    if failed:
+        print("FAILED:")
+        for name in failed:
+            print(f"  - {name}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/app/test_epub_extract.py
+++ b/app/test_epub_extract.py
@@ -195,6 +195,47 @@ def test_paragraph_structure_preserved():
         )
 
 
+def test_head_title_not_in_body_text():
+    """<head><title> is document metadata, not book text.
+
+    HTMLParser reports it through handle_data like any other text, so an
+    unskipped <title> gets spliced into the narration. The body's own
+    heading must survive untouched.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        epub_path = os.path.join(tmp, "book.epub")
+        manifest_items = [
+            ("ch1", "ch1.xhtml", "application/xhtml+xml", None),
+        ]
+        opf_xml = opf(manifest_items, ["ch1"])
+        files = {
+            "OEBPS/ch1.xhtml": (
+                "<html><head><title>Document Metadata Title</title>"
+                "<meta charset=\"utf-8\"/></head><body>"
+                "<h1>3: Initial Reconnaissance</h1>"
+                "<p>The body paragraph survives.</p>"
+                "</body></html>"
+            ),
+        }
+        make_epub(epub_path, opf_xml, files)
+        text = extract_epub_text(epub_path)
+        check(
+            "head_title: <title> text is not extracted",
+            "Document Metadata Title" not in text,
+            detail=repr(text),
+        )
+        check(
+            "head_title: body heading survives",
+            "3: Initial Reconnaissance" in text,
+            detail=repr(text),
+        )
+        check(
+            "head_title: body paragraph survives",
+            "The body paragraph survives." in text,
+            detail=repr(text),
+        )
+
+
 def test_nav_doc_skipped():
     with tempfile.TemporaryDirectory() as tmp:
         epub_path = os.path.join(tmp, "book.epub")
@@ -325,6 +366,7 @@ def main():
         test_href_resolution_percent_and_traversal,
         test_case_variant_href,
         test_paragraph_structure_preserved,
+        test_head_title_not_in_body_text,
         test_nav_doc_skipped,
         test_broken_href_raises_valueerror,
         test_non_html_spine_item_skipped,

--- a/app/test_integration_fixes.py
+++ b/app/test_integration_fixes.py
@@ -22,6 +22,8 @@ Run directly:
     python app/test_integration_fixes.py
 Exits 0 if all tests pass, non-zero otherwise.
 """
+import contextlib
+import io
 import os
 import sys
 import types
@@ -149,21 +151,111 @@ def test_resolve_voice_canonical_hit_narrator():
 
 def test_resolve_voice_canonicalized_key_scan():
     # Legacy voice_config keyed by a raw, non-canonical label ("Mr. Mark"),
-    # while the script/UI now uses the canonical speaker "MARK".
+    # while the script/UI uses the canonical speaker "MISTER MARK".
     voice_config = {"Mr. Mark": {"type": "custom", "voice": "Ryan"}}
     check_eq(
-        "canonicalized-key scan: canonical speaker 'MARK' resolves 'Mr. Mark' config",
-        resolve_voice(voice_config, "MARK"),
+        "canonicalized-key scan: canonical speaker 'MISTER MARK' resolves 'Mr. Mark' config",
+        resolve_voice(voice_config, "MISTER MARK"),
         "Mr. Mark",
     )
     # And the reverse direction: config already keyed canonically, raw
-    # honorific-prefixed speaker label should still resolve to it.
-    voice_config2 = {"MARK": {"type": "custom", "voice": "Ryan"}}
+    # title-prefixed speaker label should still resolve to it.
+    voice_config2 = {"MISTER MARK": {"type": "custom", "voice": "Ryan"}}
     check_eq(
-        "canonicalized-key scan (reverse): raw 'Mr. Mark' resolves 'MARK' config",
+        "canonicalized-key scan (reverse): raw 'Mr. Mark' resolves 'MISTER MARK' config",
         resolve_voice(voice_config2, "Mr. Mark"),
+        "MISTER MARK",
+    )
+
+
+# ---------------------------------------------------------------------------
+# resolve_voice strategy 4: the gendered-title migration shim.
+#
+# canonicalize() used to DROP Mr/Mrs/Mme/..., so a voice_config.json written
+# before the change keys "Mr. Mark" as "MARK". It now preserves them, so the
+# speaker arriving from the script is "MISTER MARK". Without a shim, every
+# line of every pre-existing project would miss its voice.
+# ---------------------------------------------------------------------------
+def test_resolve_voice_legacy_bare_config_voices_gendered_speaker():
+    # Direction 1, unguarded: a legacy config cannot contain a gendered rival,
+    # and refusing here would silently drop the character's lines.
+    voice_config = {"MARK": {"type": "custom", "voice": "Ryan"}}
+    check_eq(
+        "migration: legacy 'MARK' config voices 'Mr. Mark'",
+        resolve_voice(voice_config, "Mr. Mark"),
         "MARK",
     )
+    check_eq(
+        "migration: legacy 'MARK' config voices canonical 'MISTER MARK'",
+        resolve_voice(voice_config, "MISTER MARK"),
+        "MARK",
+    )
+
+
+def test_resolve_voice_migration_matrix_legacy_bare_config():
+    # One legacy key, three speaker spellings, all must render.
+    voice_config = {"SMITH": {"type": "custom", "voice": "Ryan"}}
+    for speaker in ("MISTER SMITH", "MISSUS SMITH", "SMITH"):
+        check_eq(
+            f"migration matrix: legacy {{SMITH}} config voices '{speaker}'",
+            resolve_voice(voice_config, speaker),
+            "SMITH",
+        )
+
+
+def test_resolve_voice_gendered_rival_does_not_unvoice_the_other():
+    # The regression that matters most: assigning a voice to MRS SMITH must
+    # not steal, or silence, MISTER SMITH's legacy bare entry.
+    voice_config = {"SMITH": {"voice": "a"}, "MRS SMITH": {"voice": "b"}}
+    check_eq(
+        "migration: 'MISTER SMITH' still resolves to legacy SMITH beside a MRS SMITH key",
+        resolve_voice(voice_config, "MISTER SMITH"),
+        "SMITH",
+    )
+    check_eq(
+        "migration: 'MRS SMITH' resolves to its own key",
+        resolve_voice(voice_config, "Mrs. Smith"),
+        "MRS SMITH",
+    )
+
+
+def test_resolve_voice_bare_speaker_finds_a_single_gendered_key():
+    # Direction 2, unambiguous: only one gendered key could be meant.
+    voice_config = {"MRS SMITH": {"voice": "b"}}
+    check_eq(
+        "migration: bare 'SMITH' resolves the single gendered key",
+        resolve_voice(voice_config, "SMITH"),
+        "MRS SMITH",
+    )
+
+
+def test_resolve_voice_bare_speaker_ambiguous_between_gendered_keys():
+    # Direction 2, guarded: two gendered rivals and no evidence which one an
+    # unqualified "SMITH" meant. Picking by insertion order would give a
+    # character the wrong person's voice, so refuse -- in BOTH orders.
+    forward = {"MR SMITH": {"voice": "a"}, "MRS SMITH": {"voice": "b"}}
+    backward = {"MRS SMITH": {"voice": "b"}, "MR SMITH": {"voice": "a"}}
+    check("migration: ambiguous bare 'SMITH' returns None (MR first)",
+          resolve_voice(forward, "SMITH") is None)
+    check("migration: ambiguous bare 'SMITH' returns None (MRS first)",
+          resolve_voice(backward, "SMITH") is None)
+
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        resolve_voice(forward, "SMITH")
+    printed = buffer.getvalue()
+    check("migration: the ambiguous miss warns loudly and names the speaker",
+          "SMITH" in printed and "ambiguous" in printed.lower(),
+          f"stdout was {printed!r}")
+
+
+def test_resolve_voice_ignores_metadata_keys():
+    # "_canon_version" is file metadata, never a speaker.
+    voice_config = {"_canon_version": 2, "MARK": {"voice": "a"}}
+    check_eq("metadata: '_canon_version' is skipped by the key scan",
+             resolve_voice(voice_config, "MARK"), "MARK")
+    check("metadata: '_canon_version' is never returned as a resolved key",
+          resolve_voice(voice_config, "_canon_version") is None)
 
 
 def test_resolve_voice_miss_returns_none():
@@ -369,6 +461,118 @@ def test_join_newline_boundary_not_doubled():
 
 
 # ---------------------------------------------------------------------------
+# Over-long entry splitting (nothing between the script and the TTS call
+# bounded entry length before this; group_into_chunks capped MERGING only).
+#
+# Properties, not fixtures: every assertion below holds for any text, and the
+# inputs are generated rather than quoted from a book.
+# ---------------------------------------------------------------------------
+def test_split_long_text_join_is_byte_exact():
+    # THE fidelity property: choosing cut points must never change the text.
+    cap = 50
+    for text in (
+        "word " * 200,                      # whitespace everywhere
+        "Sentence one. Sentence two! " * 40,  # sentence enders
+        "para\n\nbreak\n\n" * 40,           # paragraph breaks
+        "x" * 500,                          # no boundary at all
+        "林" * 300,                     # unsegmented script, no spaces
+        "a",                                # shorter than the cap
+        "",                                 # empty
+    ):
+        pieces = project.split_long_text(text, cap)
+        check_eq(f"split join byte-exact for {text[:12]!r}", "".join(pieces), text)
+        check(
+            f"every piece within cap for {text[:12]!r}",
+            all(len(p) <= cap for p in pieces),
+        )
+
+
+def test_split_long_text_hard_cuts_unsegmented_script():
+    # Chinese/Japanese/Thai have no whitespace to cut at. A hard cut is the
+    # only option and must still bound the piece length rather than giving up
+    # and returning the whole string.
+    text = "林" * 260
+    pieces = project.split_long_text(text, 100)
+    check_eq("unsegmented text is split into bounded pieces", len(pieces), 3)
+    check_eq("unsegmented split is lossless", "".join(pieces), text)
+
+
+def test_split_long_text_prefers_natural_boundaries():
+    # A paragraph break inside the window wins over a mid-word cut.
+    text = "alpha beta\n\n" + ("gamma " * 40)
+    pieces = project.split_long_text(text, 30)
+    check("paragraph break is preferred as a cut point", pieces[0].endswith("\n\n"))
+
+    # With no line breaks, a sentence end beats an arbitrary space.
+    text = "One two three. Four five six seven eight nine ten eleven."
+    pieces = project.split_long_text(text, 20)
+    check("sentence end is preferred over a mid-clause space",
+          pieces[0].startswith("One two three."))
+
+
+def test_group_into_chunks_bounds_a_single_oversize_entry():
+    # Before the split, ONE entry longer than the cap passed through whole.
+    long_text = "This is a sentence. " * 60  # 1200 chars, one entry
+    entries = [{"speaker": "NARRATOR", "text": long_text, "instruct": "x"}]
+    chunks = group_into_chunks(entries)
+    check("an oversize entry is split into several chunks", len(chunks) > 1)
+    check(
+        "no chunk exceeds MAX_CHUNK_CHARS after grouping",
+        all(len(c["text"]) <= project.MAX_CHUNK_CHARS for c in chunks),
+    )
+    check_eq(
+        "splitting an oversize entry preserves its text exactly",
+        "".join(c["text"] for c in chunks),
+        long_text,
+    )
+
+
+def test_split_pieces_do_not_introduce_pauses():
+    # Same-speaker chunks get SAME_SPEAKER_PAUSE_MS between them, which would
+    # insert silence mid-sentence. Only the LAST piece keeps the original
+    # pause; the rest are pinned to 0 ("no gap" to combine_audio_with_pauses).
+    entries = [{
+        "speaker": "NARRATOR",
+        "text": "Filler sentence here. " * 60,
+        "instruct": "x",
+        "pause_after": 700,
+    }]
+    chunks = group_into_chunks(entries)
+    check("test needs a split to be meaningful", len(chunks) > 1)
+    check_eq(
+        "all but the last piece suppress the pause",
+        [c.get("pause_after") for c in chunks[:-1]],
+        [0] * (len(chunks) - 1),
+    )
+    check_eq("the last piece keeps the original pause",
+             chunks[-1].get("pause_after"), 700)
+
+
+def test_split_preserves_speaker_and_instruct():
+    entries = [{"speaker": "ALICE", "text": "Talking. " * 100, "instruct": "warm"}]
+    chunks = group_into_chunks(entries)
+    check("test needs a split to be meaningful", len(chunks) > 1)
+    check("every piece keeps the speaker, so the voice does not change mid-line",
+          all(c["speaker"] == "ALICE" for c in chunks))
+    check("every piece keeps the instruct",
+          all(c["instruct"] == "warm" for c in chunks))
+
+
+def test_grouping_is_unchanged_for_normal_entries():
+    # The split must be a no-op on anything already within the cap, so this
+    # change cannot perturb the overwhelming majority of chunks.
+    entries = [
+        {"speaker": "NARRATOR", "text": "Short one. ", "instruct": ""},
+        {"speaker": "ALICE", "text": "A line of dialogue.", "instruct": "warm"},
+        {"speaker": "NARRATOR", "text": " And narration after it.", "instruct": ""},
+    ]
+    chunks = group_into_chunks(entries)
+    check_eq("no-op on within-cap entries: chunk count", len(chunks), 3)
+    check("no-op on within-cap entries: no pause keys invented",
+          all("pause_after" not in c for c in chunks))
+
+
+# ---------------------------------------------------------------------------
 # app._process_completion_message tests
 # ---------------------------------------------------------------------------
 def test_process_completion_message_success():
@@ -418,6 +622,12 @@ def run():
         test_resolve_voice_raw_hit,
         test_resolve_voice_canonical_hit_narrator,
         test_resolve_voice_canonicalized_key_scan,
+        test_resolve_voice_legacy_bare_config_voices_gendered_speaker,
+        test_resolve_voice_migration_matrix_legacy_bare_config,
+        test_resolve_voice_gendered_rival_does_not_unvoice_the_other,
+        test_resolve_voice_bare_speaker_finds_a_single_gendered_key,
+        test_resolve_voice_bare_speaker_ambiguous_between_gendered_keys,
+        test_resolve_voice_ignores_metadata_keys,
         test_resolve_voice_miss_returns_none,
         test_resolve_voice_alias_chain,
         test_resolve_voice_alias_cycle_safe,
@@ -430,6 +640,13 @@ def run():
         test_join_verbatim_leading_space_on_second,
         test_join_legacy_stripped_entries_get_readable_join,
         test_join_newline_boundary_not_doubled,
+        test_split_long_text_join_is_byte_exact,
+        test_split_long_text_hard_cuts_unsegmented_script,
+        test_split_long_text_prefers_natural_boundaries,
+        test_group_into_chunks_bounds_a_single_oversize_entry,
+        test_split_pieces_do_not_introduce_pauses,
+        test_split_preserves_speaker_and_instruct,
+        test_grouping_is_unchanged_for_normal_entries,
         test_process_completion_message_success,
         test_process_completion_message_exit3_script_task,
         test_process_completion_message_other_nonzero_unchanged,

--- a/app/test_integration_fixes.py
+++ b/app/test_integration_fixes.py
@@ -1,0 +1,457 @@
+"""Standalone tests for the F3 integration fixes:
+
+  - tts.resolve_voice: canonical-aware voice_config lookup (audit #4),
+    shared between project.py's _resolve_alias and tts.py's own lookups.
+  - tts._prepare_batch_chunks: exactly-once text normalization + speaker
+    resolution for generate_batch's entry point (audit #5), built as a
+    read-only pure helper (audit re-finding N3) -- it must never mutate
+    the caller's chunk dicts in place.
+  - project.group_into_chunks: whitespace-aware join (audit #9-partial).
+  - app._process_completion_message: exit-code-3 message selection for
+    the "script" task family (audit #7 UX).
+
+`tts.py` / `project.py` import numpy, soundfile, and pydub for their real
+TTS/audio-processing work, none of which this test exercises (it only
+calls resolve_voice(), _prepare_batch_chunks(), group_into_chunks(), and
+_process_completion_message -- all pure functions with no audio/tensor
+dependencies). Those heavy, possibly-uninstalled third-party packages are
+stubbed in sys.modules before import, following the same pattern used by
+test_epub_extract.py for the (unrelated) `project` stub there.
+
+Run directly:
+    python app/test_integration_fixes.py
+Exits 0 if all tests pass, non-zero otherwise.
+"""
+import os
+import sys
+import types
+import traceback
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# ---------------------------------------------------------------------------
+# Stub heavy/possibly-uninstalled third-party deps that tts.py / project.py
+# import at module level purely for real audio/model work this test never
+# calls into. `speaker_canon` (rapidfuzz) is a real, light dependency and is
+# NOT stubbed -- resolve_voice's canonicalization must be genuine.
+# ---------------------------------------------------------------------------
+for _mod_name in ("numpy", "soundfile"):
+    if _mod_name not in sys.modules:
+        sys.modules[_mod_name] = types.ModuleType(_mod_name)
+
+if "pydub" not in sys.modules:
+    _fake_pydub = types.ModuleType("pydub")
+
+    class _FakeAudioSegment:
+        """Placeholder; tts.py/project.py only reference AudioSegment inside
+        function bodies this test never calls."""
+        pass
+
+    _fake_pydub.AudioSegment = _FakeAudioSegment
+    sys.modules["pydub"] = _fake_pydub
+
+if "huggingface_hub" not in sys.modules:
+    sys.modules["huggingface_hub"] = types.ModuleType("huggingface_hub")
+
+import tts  # noqa: E402
+import project  # noqa: E402
+
+resolve_voice = tts.resolve_voice
+group_into_chunks = project.group_into_chunks
+
+
+# ---------------------------------------------------------------------------
+# Stub 'project' for app.py's import, so importing app.py (for
+# _process_completion_message) doesn't need a real ProjectManager or pull in
+# anything else transitively. Mirrors test_epub_extract.py's approach.
+# Must happen with a *separate* module identity from the real `project`
+# module we just imported above -- app.py does `from project import
+# ProjectManager`, so we only need that one name to resolve.
+# ---------------------------------------------------------------------------
+_real_project_module = sys.modules.get("project")
+
+
+class _FakeProjectManager:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def load_chunks(self):
+        return []
+
+    def save_chunks(self, chunks):
+        pass
+
+    def __getattr__(self, name):
+        # app.py's module-level startup code may touch other attributes;
+        # turn any of those into harmless no-op callables.
+        def _noop(*args, **kwargs):
+            return None
+        return _noop
+
+
+# Temporarily swap in a fake ProjectManager just for app.py's `from project
+# import ProjectManager` line, then restore the real module so later tests
+# in this file (if any) still see the genuine `project` module.
+_fake_project_for_app = types.ModuleType("project")
+_fake_project_for_app.ProjectManager = _FakeProjectManager
+sys.modules["project"] = _fake_project_for_app
+try:
+    import app as alexandria_app  # noqa: E402
+finally:
+    if _real_project_module is not None:
+        sys.modules["project"] = _real_project_module
+
+_process_completion_message = alexandria_app._process_completion_message
+
+
+# ---------------------------------------------------------------------------
+# Test harness (no external test framework dependency)
+# ---------------------------------------------------------------------------
+_failures = []
+
+
+def check(name, condition, detail=""):
+    if condition:
+        print(f"  PASS: {name}")
+    else:
+        msg = f"  FAIL: {name}" + (f" -- {detail}" if detail else "")
+        print(msg)
+        _failures.append(name)
+
+
+def check_eq(name, actual, expected):
+    check(name, actual == expected, f"expected {expected!r}, got {actual!r}")
+
+
+# ---------------------------------------------------------------------------
+# resolve_voice tests
+# ---------------------------------------------------------------------------
+def test_resolve_voice_raw_hit():
+    voice_config = {"MARK": {"type": "custom", "voice": "Ryan"}}
+    check_eq("raw exact key hit", resolve_voice(voice_config, "MARK"), "MARK")
+
+
+def test_resolve_voice_canonical_hit_narrator():
+    # Single-speaker scripts historically wrote raw "Narrator" (mixed case)
+    # into chunks.json; voice_config is now keyed by canonical "NARRATOR".
+    voice_config = {"NARRATOR": {"type": "custom", "voice": "Ryan"}}
+    check_eq(
+        "canonical hit: raw 'Narrator' resolves config under 'NARRATOR'",
+        resolve_voice(voice_config, "Narrator"),
+        "NARRATOR",
+    )
+    check_eq(
+        "canonical hit: raw 'narrator' (lowercase) also resolves",
+        resolve_voice(voice_config, "narrator"),
+        "NARRATOR",
+    )
+
+
+def test_resolve_voice_canonicalized_key_scan():
+    # Legacy voice_config keyed by a raw, non-canonical label ("Mr. Mark"),
+    # while the script/UI now uses the canonical speaker "MARK".
+    voice_config = {"Mr. Mark": {"type": "custom", "voice": "Ryan"}}
+    check_eq(
+        "canonicalized-key scan: canonical speaker 'MARK' resolves 'Mr. Mark' config",
+        resolve_voice(voice_config, "MARK"),
+        "Mr. Mark",
+    )
+    # And the reverse direction: config already keyed canonically, raw
+    # honorific-prefixed speaker label should still resolve to it.
+    voice_config2 = {"MARK": {"type": "custom", "voice": "Ryan"}}
+    check_eq(
+        "canonicalized-key scan (reverse): raw 'Mr. Mark' resolves 'MARK' config",
+        resolve_voice(voice_config2, "Mr. Mark"),
+        "MARK",
+    )
+
+
+def test_resolve_voice_miss_returns_none():
+    voice_config = {"NARRATOR": {"type": "custom"}}
+    check("miss returns None", resolve_voice(voice_config, "ELLA") is None)
+    check("empty speaker returns None", resolve_voice(voice_config, "") is None)
+    check("empty voice_config returns None", resolve_voice({}, "NARRATOR") is None)
+
+
+def test_resolve_voice_alias_chain():
+    voice_config = {
+        "JON": {"alias_of": "JOHN"},
+        "JOHN": {"type": "custom", "voice": "Ryan"},
+    }
+    check_eq("alias chain follows alias_of", resolve_voice(voice_config, "JON"), "JOHN")
+    # Alias chain should also be canonical-aware at the raw-speaker hop.
+    check_eq(
+        "alias chain resolves from a raw (non-canonical) speaker label",
+        resolve_voice(voice_config, "Jon"),
+        "JOHN",
+    )
+
+
+def test_resolve_voice_alias_cycle_safe():
+    voice_config = {
+        "A": {"alias_of": "B"},
+        "B": {"alias_of": "A"},
+    }
+    # Must not infinite-loop; some deterministic name is returned.
+    result = resolve_voice(voice_config, "A")
+    check("alias cycle terminates", result in ("A", "B"))
+
+
+# ---------------------------------------------------------------------------
+# _prepare_batch_chunks tests (audit re-finding N3: generate_batch's entry
+# loop must never mutate the caller's chunk dicts in place -- a future
+# caller passing persisted load_chunks() dicts would otherwise get
+# normalized text + rewritten speakers silently written back into
+# chunks.json, causing double-normalization on the next run).
+# ---------------------------------------------------------------------------
+import copy  # noqa: E402
+
+
+class _RecordingNormalizer:
+    """Minimal stand-in for TTSNormalizer: uppercases text so a change is
+    visually obvious, and records every string it was asked to normalize."""
+
+    def __init__(self):
+        self.calls = []
+
+    def normalize(self, text):
+        self.calls.append(text)
+        return text.upper()
+
+
+class _IdentityNormalizer:
+    """Stand-in for a disabled TTSNormalizer: returns the exact same string
+    object, unchanged -- this is the real TTSNormalizer's flag-off contract."""
+
+    def normalize(self, text):
+        return text
+
+
+def test_prepare_batch_chunks_does_not_mutate_input():
+    voice_config = {"NARRATOR": {"type": "custom", "voice": "Ryan"}}
+    original = [
+        {"index": 0, "speaker": "Narrator", "text": "hello there", "instruct": "neutral"},
+        {"index": 1, "speaker": "Narrator", "text": "second line", "instruct": ""},
+    ]
+    snapshot = copy.deepcopy(original)
+
+    _ = tts._prepare_batch_chunks(original, voice_config, _RecordingNormalizer())
+
+    check_eq("input chunk list unchanged after call (deep-equality)", original, snapshot)
+
+
+def test_prepare_batch_chunks_output_normalized_and_resolved():
+    voice_config = {"NARRATOR": {"type": "custom", "voice": "Ryan"}}
+    original = [
+        {"index": 0, "speaker": "Narrator", "text": "hello there", "instruct": "neutral"},
+    ]
+
+    prepared = tts._prepare_batch_chunks(original, voice_config, _RecordingNormalizer())
+
+    check_eq("prepared list has one entry", len(prepared), 1)
+    check_eq("prepared text is normalized", prepared[0]["text"], "HELLO THERE")
+    check_eq(
+        "prepared speaker resolved to canonical voice_config key",
+        prepared[0]["speaker"],
+        "NARRATOR",
+    )
+    check_eq("prepared entry keeps unrelated fields (index)", prepared[0]["index"], 0)
+    check_eq("prepared entry keeps instruct untouched", prepared[0]["instruct"], "neutral")
+    check(
+        "prepared dict is a distinct object from the input dict",
+        prepared[0] is not original[0],
+    )
+
+
+def test_prepare_batch_chunks_instruct_never_normalized():
+    voice_config = {"NARRATOR": {"type": "custom"}}
+    original = [{"index": 0, "speaker": "NARRATOR", "text": "hi", "instruct": "hi"}]
+    normalizer = _RecordingNormalizer()
+
+    prepared = tts._prepare_batch_chunks(original, voice_config, normalizer)
+
+    check_eq("only 'text' passed to normalizer, never 'instruct'", normalizer.calls, ["hi"])
+    check_eq("instruct field left exactly as-is", prepared[0]["instruct"], "hi")
+
+
+def test_prepare_batch_chunks_flag_off_is_byte_identical():
+    voice_config = {"NARRATOR": {"type": "custom"}}
+    original = [{"index": 0, "speaker": "NARRATOR", "text": "St. Peter's arrived.", "instruct": ""}]
+
+    prepared = tts._prepare_batch_chunks(original, voice_config, _IdentityNormalizer())
+
+    check_eq(
+        "flag-off (identity normalizer): text is byte-identical",
+        prepared[0]["text"],
+        original[0]["text"],
+    )
+    check(
+        "flag-off (identity normalizer): text is the SAME string object (no copy)",
+        prepared[0]["text"] is original[0]["text"],
+    )
+
+
+def test_prepare_batch_chunks_unresolvable_speaker_kept_raw():
+    # No canonical-aware match anywhere -- speaker is left as the original
+    # raw value (so the caller's later raw .get(speaker) lookup, and the
+    # printed warning, both still make sense) rather than becoming None.
+    voice_config = {"NARRATOR": {"type": "custom"}}
+    original = [{"index": 0, "speaker": "SOMEONE_ELSE", "text": "hi", "instruct": ""}]
+
+    prepared = tts._prepare_batch_chunks(original, voice_config, _IdentityNormalizer())
+
+    check_eq(
+        "unresolvable speaker is left unchanged, not set to None",
+        prepared[0]["speaker"],
+        "SOMEONE_ELSE",
+    )
+
+
+# ---------------------------------------------------------------------------
+# group_into_chunks whitespace-aware join tests
+# ---------------------------------------------------------------------------
+def test_join_verbatim_no_injected_space():
+    # Both entries already carry their own boundary whitespace (trailing
+    # space on the first, none needed on the second) -- verbatim join must
+    # NOT inject an extra character that was never in the source.
+    entries = [
+        {"speaker": "NARRATOR", "text": "Hello there. ", "instruct": ""},
+        {"speaker": "NARRATOR", "text": "The next sentence.", "instruct": ""},
+    ]
+    chunks = group_into_chunks(entries)
+    check_eq("verbatim join count", len(chunks), 1)
+    check_eq(
+        "verbatim join produces no injected space",
+        chunks[0]["text"],
+        "Hello there. The next sentence.",
+    )
+
+
+def test_join_verbatim_leading_space_on_second():
+    entries = [
+        {"speaker": "NARRATOR", "text": "Hello there.", "instruct": ""},
+        {"speaker": "NARRATOR", "text": " The next sentence.", "instruct": ""},
+    ]
+    chunks = group_into_chunks(entries)
+    check_eq(
+        "verbatim join: leading space on second entry is respected, not doubled",
+        chunks[0]["text"],
+        "Hello there. The next sentence.",
+    )
+
+
+def test_join_legacy_stripped_entries_get_readable_join():
+    # Legacy/stripped entries with no boundary whitespace on either side
+    # still get a readable space injected (old behavior preserved).
+    entries = [
+        {"speaker": "NARRATOR", "text": "Hello there.", "instruct": ""},
+        {"speaker": "NARRATOR", "text": "The next sentence.", "instruct": ""},
+    ]
+    chunks = group_into_chunks(entries)
+    check_eq(
+        "legacy stripped join still inserts one readable space",
+        chunks[0]["text"],
+        "Hello there. The next sentence.",
+    )
+
+
+def test_join_newline_boundary_not_doubled():
+    entries = [
+        {"speaker": "NARRATOR", "text": "Hello there.\n", "instruct": ""},
+        {"speaker": "NARRATOR", "text": "The next sentence.", "instruct": ""},
+    ]
+    chunks = group_into_chunks(entries)
+    check_eq(
+        "newline boundary counts as whitespace; no extra space injected",
+        chunks[0]["text"],
+        "Hello there.\nThe next sentence.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# app._process_completion_message tests
+# ---------------------------------------------------------------------------
+def test_process_completion_message_success():
+    check_eq(
+        "success message unchanged",
+        _process_completion_message("script", 0),
+        "Task script completed successfully.",
+    )
+
+
+def test_process_completion_message_exit3_script_task():
+    msg = _process_completion_message("script", 3)
+    check("exit-3 script message mentions degradations, not 'failed'", "degradations" in msg and "failed" not in msg)
+    check("exit-3 script message mentions NARRATOR fallback", "NARRATOR" in msg)
+
+
+def test_process_completion_message_other_nonzero_unchanged():
+    check_eq(
+        "generic nonzero code still says failed",
+        _process_completion_message("script", 1),
+        "Task script failed with return code 1.",
+    )
+    check_eq(
+        "exit code 3 for an unrelated task family is still a generic failure",
+        _process_completion_message("audio", 3),
+        "Task audio failed with return code 3.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Normalization flag-off passthrough (structural check, not a live import of
+# TTSEngine which needs a real torch/model stack). This asserts the actual
+# TTSNormalizer contract used by generate_batch/generate_voice: disabled ->
+# returns the exact same string object, unchanged.
+# ---------------------------------------------------------------------------
+def test_normalizer_disabled_is_identity_passthrough():
+    from tts_normalizer import TTSNormalizer
+
+    normalizer = TTSNormalizer(enabled=False)
+    text = "St. Peter's arrived at 3pm."
+    result = normalizer.normalize(text)
+    check("disabled normalizer returns same object (no copy/mutation)", result is text)
+
+
+def run():
+    tests = [
+        test_resolve_voice_raw_hit,
+        test_resolve_voice_canonical_hit_narrator,
+        test_resolve_voice_canonicalized_key_scan,
+        test_resolve_voice_miss_returns_none,
+        test_resolve_voice_alias_chain,
+        test_resolve_voice_alias_cycle_safe,
+        test_prepare_batch_chunks_does_not_mutate_input,
+        test_prepare_batch_chunks_output_normalized_and_resolved,
+        test_prepare_batch_chunks_instruct_never_normalized,
+        test_prepare_batch_chunks_flag_off_is_byte_identical,
+        test_prepare_batch_chunks_unresolvable_speaker_kept_raw,
+        test_join_verbatim_no_injected_space,
+        test_join_verbatim_leading_space_on_second,
+        test_join_legacy_stripped_entries_get_readable_join,
+        test_join_newline_boundary_not_doubled,
+        test_process_completion_message_success,
+        test_process_completion_message_exit3_script_task,
+        test_process_completion_message_other_nonzero_unchanged,
+        test_normalizer_disabled_is_identity_passthrough,
+    ]
+
+    for t in tests:
+        print(f"{t.__name__}:")
+        try:
+            t()
+        except Exception:
+            print(f"  ERROR: {t.__name__} raised an exception:")
+            traceback.print_exc()
+            _failures.append(t.__name__)
+
+    print()
+    if _failures:
+        print(f"FAILED: {len(_failures)} check(s): {_failures}")
+        return 1
+    print("All checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/app/test_persona_aliasing.py
+++ b/app/test_persona_aliasing.py
@@ -70,11 +70,38 @@ def test_merging_is_symmetric():
               merges(a, b) == merges(b, a))
 
 
+
+def test_narrator_default_is_not_an_alias():
+    """A speaker with no persona defaults to the NARRATOR's voice settings but
+    KEEPS its own entry. An alias_of would fold it into NARRATOR, and nothing
+    in this pipeline can split a merged entry back apart."""
+    from generate_personas import _entry_has_voice
+
+    narrator = {"type": "clone", "voice": "Ryan", "ref_audio": "designed_voices/n.wav"}
+    check("default: narrator entry counts as having a voice", _entry_has_voice(narrator))
+    check("default: missing entry has no voice", not _entry_has_voice(None))
+    check("default: empty entry has no voice", not _entry_has_voice({}))
+    check("default: entry with only blank fields has no voice",
+          not _entry_has_voice({"voice": "  ", "ref_audio": ""}))
+    check("default: an aliased entry is not a usable voice",
+          not _entry_has_voice({"alias_of": "NARRATOR", "voice": "Ryan"}))
+
+    # The defaulting step copies settings, so the speaker still has its own key
+    # and can be overridden; it must not gain an alias_of.
+    entry = dict(narrator)
+    entry["defaulted_from_narrator"] = True
+    check("default: defaulted entry carries no alias_of", "alias_of" not in entry)
+    check("default: defaulted entry is usable for synthesis", _entry_has_voice(entry))
+    check("default: defaulted entry is marked for the operator",
+          entry.get("defaulted_from_narrator") is True)
+
+
 for fn in [test_relation_is_not_the_person,
            test_shared_surname_is_not_the_same_person,
            test_similar_but_distinct_names_stay_apart,
            test_exact_after_normalization_still_merges,
-           test_merging_is_symmetric]:
+           test_merging_is_symmetric,
+           test_narrator_default_is_not_an_alias]:
     fn()
 
 print(f"\n{'FAILED: ' + ', '.join(failures) if failures else 'All persona-aliasing checks passed'}")

--- a/app/test_persona_aliasing.py
+++ b/app/test_persona_aliasing.py
@@ -1,0 +1,81 @@
+"""Standalone test: persona generation must not auto-merge speakers on similarity.
+
+A fuzzy pre-pass (rapidfuzz at 0.8) used to decide that two roster entries were
+the same character and SKIP the loser, leaving it with no voice. Measured on one
+book it merged 31 pairs -- a person against a possessive relation naming them
+(X vs X'S FATHER), and cyclically in both directions -- and 28 of 65 speakers
+came out of persona generation with no voice at all.
+
+Only exact equality after normalization may merge two speakers here, which is
+the rule the rest of the pipeline uses. Anything looser is a human decision.
+
+Run directly:
+    python app/test_persona_aliasing.py
+Exits 0 if all tests pass, non-zero otherwise.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from generate_personas import normalize_speaker_name  # noqa: E402
+
+failures = []
+
+
+def check(name, condition, detail=""):
+    print(f"[{'PASS' if condition else 'FAIL'}] {name}" + (f" -- {detail}" if detail and not condition else ""))
+    if not condition:
+        failures.append(name)
+
+
+def merges(a, b):
+    """The rule Step 1 of generate_personas.main() now applies."""
+    na, nb = normalize_speaker_name(a), normalize_speaker_name(b)
+    return bool(na) and na == nb
+
+
+def test_relation_is_not_the_person():
+    # The defect: a possessive relation scores high against the person it
+    # names, but a parent is not their child. Synthesized names only.
+    for person, relation in [("ARLO", "ARLO'S DAD"),
+                             ("BRENNA", "BRENNA'S MOTHER"),
+                             ("CIRO", "CIRO'S FATHER")]:
+        check(f"aliasing: {person} is not {relation}",
+              not merges(person, relation))
+
+
+def test_shared_surname_is_not_the_same_person():
+    check("aliasing: a bare surname is not the full name",
+          not merges("DELACROIX", "MAREN DELACROIX"))
+
+
+def test_similar_but_distinct_names_stay_apart():
+    # The JON/JOHN class the banned-approaches list exists for.
+    for a, b in [("JON", "JOHN"), ("ELLA", "BELLA"), ("MARIA", "MARIE")]:
+        check(f"aliasing: {a} and {b} stay distinct", not merges(a, b))
+
+
+def test_exact_after_normalization_still_merges():
+    # The one merge that is still allowed: same name, different formatting.
+    for a, b in [("MAREN", "maren"), ("MAREN", "  MAREN  ")]:
+        check(f"aliasing: {a!r} and {b!r} are the same speaker", merges(a, b))
+
+
+def test_merging_is_symmetric():
+    # The old fuzzy pass was cyclic, so the winner depended on iteration
+    # order. Equality cannot be.
+    for a, b in [("ARLO", "ARLO'S DAD"), ("MAREN", "maren")]:
+        check(f"aliasing: {a}/{b} decision is order-independent",
+              merges(a, b) == merges(b, a))
+
+
+for fn in [test_relation_is_not_the_person,
+           test_shared_surname_is_not_the_same_person,
+           test_similar_but_distinct_names_stay_apart,
+           test_exact_after_normalization_still_merges,
+           test_merging_is_symmetric]:
+    fn()
+
+print(f"\n{'FAILED: ' + ', '.join(failures) if failures else 'All persona-aliasing checks passed'}")
+sys.exit(1 if failures else 0)

--- a/app/test_review_verbatim.py
+++ b/app/test_review_verbatim.py
@@ -11,7 +11,10 @@ discouraged:
     entry, never from the LLM's response. Only "speaker" (canonicalized)
     and "instruct" are taken from the LLM, matched positionally. A count
     mismatch between batch and corrected returns None -- the caller must
-    treat that as a failed batch and keep the originals.
+    treat that as a failed batch and keep the originals. So does a
+    same-length but MISALIGNED response (the model duplicated one entry and
+    dropped another): count is not alignment, and a shift files correct
+    labels against the wrong entries.
   - _join_narrator_texts()/merge_consecutive_narrators(): the narrator-merge
     join no longer unconditionally inserts a space -- it only does so when
     neither side already carries boundary whitespace, so verbatim entries
@@ -27,6 +30,7 @@ Exits 0 if all tests pass, non-zero otherwise.
 """
 import inspect
 import io
+import json
 import os
 import sys
 import traceback
@@ -67,11 +71,15 @@ def test_overlay_preserves_text_applies_speaker_and_instruct():
         {"speaker": "narrator", "text": "  He lit a cigarette. ", "instruct": "Neutral, even narration."},
         {"speaker": "HOLMES", "text": "Quite so, he answered.", "instruct": "flat"},
     ]
-    # The LLM tries to rewrite text (attribution-strip / rephrase) -- must
-    # be discarded entirely. It also fixes a speaker and an instruct.
+    # The LLM echoes the text back with whitespace drift (a leading space,
+    # a collapsed run) -- still the same entries, so the corrections apply,
+    # and the accepted text must come byte-for-byte from the ORIGINAL batch.
+    # A materially REWRITTEN echo is no longer merely ignored: it is
+    # indistinguishable from a dropped/duplicated entry, so it now fails the
+    # whole batch (see test_overlay_shifted_same_length_response_rejected).
     corrected = [
-        {"speaker": "NARRATOR", "text": "He lit a cigarette and threw himself into an armchair.", "instruct": "Neutral, even narration."},
-        {"speaker": "holmes", "text": "Quite so.", "instruct": "Quietly analytical, dry amusement."},
+        {"speaker": "NARRATOR", "text": "He lit a  cigarette.", "instruct": "Neutral, even narration."},
+        {"speaker": "holmes", "text": " Quite so, he answered. ", "instruct": "Quietly analytical, dry amusement."},
     ]
 
     accepted = apply_positional_overlay(batch, corrected)
@@ -129,7 +137,7 @@ def test_overlay_empty_corrected_speaker_keeps_original():
     ]
     for label, bad_speaker in cases:
         batch = [{"speaker": "mark", "text": "Stop right there.", "instruct": "Firm, commanding."}]
-        corrected = [{"speaker": bad_speaker, "text": "irrelevant", "instruct": "Firm, commanding."}]
+        corrected = [{"speaker": bad_speaker, "instruct": "Firm, commanding."}]
         accepted = apply_positional_overlay(batch, corrected)
         check(
             f"overlay: corrected speaker ({label}) -> original speaker retained (canonical)",
@@ -164,7 +172,7 @@ def test_overlay_invalid_corrected_instruct_keeps_original():
     ]
     for label, bad_instruct in cases:
         batch = [{"speaker": "NARRATOR", "text": "It was raining.", "instruct": "Neutral, even narration."}]
-        corrected = [{"speaker": "NARRATOR", "text": "irrelevant", "instruct": bad_instruct}]
+        corrected = [{"speaker": "NARRATOR", "instruct": bad_instruct}]
         accepted = apply_positional_overlay(batch, corrected)
         check(
             f"overlay: corrected instruct ({label}) -> original instruct retained",
@@ -177,7 +185,7 @@ def test_overlay_valid_string_instruct_still_applied():
     """Sanity check that the N2 fix didn't overcorrect: a genuine non-empty
     string instruct from the LLM must still be applied."""
     batch = [{"speaker": "NARRATOR", "text": "It was raining.", "instruct": "Neutral, even narration."}]
-    corrected = [{"speaker": "NARRATOR", "text": "irrelevant", "instruct": "Tense, clipped narration."}]
+    corrected = [{"speaker": "NARRATOR", "instruct": "Tense, clipped narration."}]
     accepted = apply_positional_overlay(batch, corrected)
     check(
         "overlay: valid string instruct is still applied",
@@ -291,7 +299,7 @@ def test_narrator_casing_canonicalized_by_overlay():
     canonicalize() call must normalize it so downstream `!= "NARRATOR"`
     comparisons (e.g. in merge_consecutive_narrators) stay reliable."""
     batch = [{"speaker": "Narrator", "text": "Once upon a time.", "instruct": "calm"}]
-    corrected = [{"speaker": "NaRrAtOr", "text": "irrelevant, discarded", "instruct": "Neutral, even narration."}]
+    corrected = [{"speaker": "NaRrAtOr", "instruct": "Neutral, even narration."}]
     accepted = apply_positional_overlay(batch, corrected)
     check(
         "overlay: odd-cased NARRATOR from the LLM is canonicalized",
@@ -622,7 +630,7 @@ def test_overlay_target_batch_text_unaffected_by_context_truncation():
     routes through the context-truncation helper."""
     long_text = "Y" * 500
     batch = [{"speaker": "NARRATOR", "text": long_text, "instruct": "Neutral, even narration."}]
-    corrected = [{"speaker": "NARRATOR", "text": "irrelevant, discarded", "instruct": "Tense, clipped narration."}]
+    corrected = [{"speaker": "NARRATOR", "instruct": "Tense, clipped narration."}]
     accepted = apply_positional_overlay(batch, corrected)
     check(
         "overlay: target batch text stays full-length/byte-identical (never context-truncated)",
@@ -763,8 +771,172 @@ def test_build_script_roster_shape():
 
 
 
+# ---------------------------------------------------------------------------
+# Alignment: same length is not the same as same entries
+# ---------------------------------------------------------------------------
+
+def test_overlay_shifted_same_length_response_rejected():
+    """The regression that matters: the model duplicates one entry and drops
+    another, so the count still matches but every later label is filed one
+    slot early. Text stays verbatim either way, so only the echoed-text
+    check can catch it."""
+    batch = [
+        {"speaker": "NARRATOR", "text": "He crossed the yard.", "instruct": "neutral"},
+        {"speaker": "A", "text": "\"Wait,\" she said.", "instruct": "urgent"},
+        {"speaker": "B", "text": "\"For what?\" he asked.", "instruct": "flat"},
+    ]
+    # slot 0 echoed twice, slot 2's text never echoed -> slots 1,2 shifted.
+    corrected = [
+        {"speaker": "NARRATOR", "text": "He crossed the yard.", "instruct": "neutral"},
+        {"speaker": "NARRATOR", "text": "He crossed the yard.", "instruct": "neutral"},
+        {"speaker": "A", "text": "\"Wait,\" she said.", "instruct": "urgent"},
+    ]
+    accepted = apply_positional_overlay(batch, corrected)
+    check(
+        "overlay: same-length but shifted response is rejected (returns None)",
+        accepted is None,
+        detail=repr(accepted),
+    )
+
+
+def test_overlay_whitespace_differing_echo_still_applied():
+    """Guard against over-tightening: models routinely echo the text with a
+    leading space or collapsed newlines. That is still the same entry and
+    its correction must be applied."""
+    batch = [
+        {"speaker": "NARRATOR", "text": "  He crossed\n the yard. ", "instruct": "neutral"},
+        {"speaker": "NARRATOR", "text": "\"Wait,\" she said.", "instruct": "flat"},
+    ]
+    corrected = [
+        {"speaker": "NARRATOR", "text": " He crossed the yard.", "instruct": "wry"},
+        {"speaker": "MARA", "text": "\"Wait,\" she said. ", "instruct": "urgent"},
+    ]
+    accepted = apply_positional_overlay(batch, corrected)
+    check(
+        "overlay: whitespace-only differing echo is still accepted",
+        accepted is not None,
+        detail=repr(accepted),
+    )
+    if accepted:
+        check(
+            "overlay: whitespace-echo corrections applied, text byte-identical",
+            accepted[0]["instruct"] == "wry"
+            and accepted[1]["speaker"] == "MARA"
+            and accepted[0]["text"] == "  He crossed\n the yard. "
+            and accepted[1]["text"] == "\"Wait,\" she said.",
+            detail=repr(accepted),
+        )
+
+
+def test_overlay_absent_or_blank_echo_still_applied():
+    """A response that omits "text" carries no alignment evidence -- the
+    reviewer is asked for labels only. Those have always been accepted
+    positionally and must stay accepted."""
+    batch = [{"speaker": "NARRATOR", "text": "He crossed the yard.", "instruct": "neutral"}]
+    for corrected in ([{"speaker": "MARA"}], [{"speaker": "MARA", "text": ""}],
+                      [{"speaker": "MARA", "text": None}]):
+        accepted = apply_positional_overlay(batch, corrected)
+        check(
+            f"overlay: missing/blank echo does not discard the correction ({corrected!r})",
+            accepted is not None and accepted[0]["speaker"] == "MARA",
+            detail=repr(accepted),
+        )
+
+
+# ---------------------------------------------------------------------------
+# review_batch(): a wrong-length response must consume its retries
+# ---------------------------------------------------------------------------
+
+class _FakeLLMClient:
+    """Minimal stand-in for the OpenAI client: replays canned response
+    bodies, one per attempt, and records how many calls it received."""
+
+    def __init__(self, bodies):
+        self._bodies = list(bodies)
+        self.calls = 0
+        self.chat = self
+
+    @property
+    def completions(self):
+        return self
+
+    def create(self, **kwargs):
+        body = self._bodies[min(self.calls, len(self._bodies) - 1)]
+        self.calls += 1
+        message = type("M", (), {"content": body})()
+        choice = type("C", (), {"message": message, "finish_reason": "stop"})()
+        return type("R", (), {"choices": [choice], "usage": None})()
+
+
+def _review_batch_with(bodies, batch):
+    """Run review_batch against a fake client, with logging redirected into
+    a temp dir (review_script logs relative to its own __file__)."""
+    import tempfile
+    client = _FakeLLMClient(bodies)
+    original_file = review_script_module.__file__
+    with tempfile.TemporaryDirectory() as tmp:
+        review_script_module.__file__ = os.path.join(tmp, "review_script.py")
+        try:
+            with redirect_stdout(io.StringIO()) as buffer:
+                result = review_script_module.review_batch(
+                    client, "fake-model", batch, 1, 1)
+        finally:
+            review_script_module.__file__ = original_file
+    return result, client.calls, buffer.getvalue()
+
+
+_RB_BATCH = [
+    {"speaker": "NARRATOR", "text": "He crossed the yard.", "instruct": "neutral"},
+    {"speaker": "A", "text": "\"Wait,\" she said.", "instruct": "urgent"},
+]
+_RB_SHORT = json.dumps([{"speaker": "NARRATOR", "instruct": "neutral"}])
+_RB_FULL = json.dumps([{"speaker": "NARRATOR", "instruct": "neutral"},
+                       {"speaker": "MARA", "instruct": "urgent"}])
+
+
+def test_review_batch_retries_wrong_length_and_succeeds():
+    result, calls, output = _review_batch_with([_RB_SHORT, _RB_FULL], _RB_BATCH)
+    check(
+        "review_batch: a wrong-length response retries instead of returning",
+        calls == 2, detail=f"calls={calls}\n{output}",
+    )
+    check(
+        "review_batch: the retry's correct-length response is returned",
+        result is not None and len(result) == len(_RB_BATCH),
+        detail=repr(result),
+    )
+
+
+def test_review_batch_wrong_length_every_attempt_fails_as_before():
+    result, calls, output = _review_batch_with([_RB_SHORT], _RB_BATCH)
+    check(
+        "review_batch: exhausts all attempts (1 + max_retries) on repeated wrong length",
+        calls == 3, detail=f"calls={calls}\n{output}",
+    )
+    check(
+        "review_batch: on exhaustion still returns the mismatched array for the caller's count check",
+        result is not None and len(result) != len(_RB_BATCH),
+        detail=repr(result),
+    )
+
+
+def test_review_batch_correct_length_does_not_retry():
+    result, calls, _ = _review_batch_with([_RB_FULL], _RB_BATCH)
+    check(
+        "review_batch: a correct-length response is returned on the first attempt",
+        calls == 1 and result is not None and len(result) == 2,
+        detail=f"calls={calls} result={result!r}",
+    )
+
+
 def main():
     tests = [
+        test_overlay_shifted_same_length_response_rejected,
+        test_overlay_whitespace_differing_echo_still_applied,
+        test_overlay_absent_or_blank_echo_still_applied,
+        test_review_batch_retries_wrong_length_and_succeeds,
+        test_review_batch_wrong_length_every_attempt_fails_as_before,
+        test_review_batch_correct_length_does_not_retry,
         test_review_roster_snaps_drifted_spelling,
         test_review_roster_is_built_order_independently,
         test_review_overlay_conforms_to_the_established_spelling,

--- a/app/test_review_verbatim.py
+++ b/app/test_review_verbatim.py
@@ -25,6 +25,7 @@ Run directly:
     python app/test_review_verbatim.py
 Exits 0 if all tests pass, non-zero otherwise.
 """
+import inspect
 import io
 import os
 import sys
@@ -33,6 +34,7 @@ from contextlib import redirect_stdout
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+import review_script as review_script_module  # noqa: E402
 from review_script import (  # noqa: E402
     apply_positional_overlay,
     merge_consecutive_narrators,
@@ -43,6 +45,10 @@ from review_script import (  # noqa: E402
     REVIEW_USER_PROMPT,
     normalize_text,
     check_text_loss,
+    build_review_batches,
+    _rendered_len,
+    _truncate_context_entry,
+    _maybe_print_truncation_hint,
 )
 
 
@@ -452,6 +458,201 @@ def test_check_text_loss_whole_vs_entry_split_agree_on_fused_quote_fixture():
     )
 
 
+# --- F12: dual-budget batching (count + rendered-JSON-size) --------------
+#
+# Production evidence: a fixed entry-count batch (25 entries) rendered to
+# 26,001 chars (~6.5k tokens) when a batch happened to contain huge
+# Gutenberg front-matter entries. The Ollama server was configured with a
+# small serving context window and silently truncated the prompt instead
+# of erroring -- the model never saw its instructions/entries and returned
+# garbage (screenplay-format prose, or a 15-for-25 entry-count mismatch).
+# The overlay kept annotated_script.json safe either way, but review
+# silently became a no-op on exactly the batches with the longest entries.
+# build_review_batches() bounds batches by BOTH count and rendered size so
+# this can't happen regardless of the serving window in use.
+
+def test_build_review_batches_splits_on_char_budget():
+    entry = {"speaker": "NARRATOR", "text": "word " * 40, "instruct": "Neutral, even narration."}
+    entries = [dict(entry) for _ in range(5)]
+
+    size_2 = _rendered_len(entries[:2])
+    size_3 = _rendered_len(entries[:3])
+    check(
+        "fixture sanity: rendered size strictly grows as entries are added",
+        size_2 < size_3,
+        detail=f"size_2={size_2} size_3={size_3}",
+    )
+    # Budget that fits exactly 2 of these identical entries but not a 3rd.
+    budget = size_2
+
+    batches = build_review_batches(entries, batch_size=100, char_budget=budget)
+
+    check(
+        "build_review_batches: no batch's rendered size exceeds the char budget "
+        "(except an unavoidable singleton, not applicable here since entries are small)",
+        all(_rendered_len(b) <= budget for b in batches),
+        detail=repr([len(b) for b in batches]),
+    )
+    check(
+        "build_review_batches: all entries preserved across batches, in order",
+        [e for b in batches for e in b] == entries,
+        detail=repr([len(b) for b in batches]),
+    )
+    check(
+        "build_review_batches: char budget actually constrained batch sizes (more than 1 batch)",
+        len(batches) > 1,
+        detail=repr([len(b) for b in batches]),
+    )
+
+
+def test_build_review_batches_singleton_oversized_entry():
+    huge_entry = {"speaker": "NARRATOR", "text": "Z" * 5000, "instruct": "Neutral, even narration."}
+    small_entry = {"speaker": "NARRATOR", "text": "Short.", "instruct": "Neutral, even narration."}
+    entries = [small_entry, huge_entry, small_entry]
+
+    # Budget far too small for huge_entry alone -- it must still become its
+    # own batch (never split, never silently dropped or merged away).
+    tiny_budget = _rendered_len([small_entry]) + 50
+    batches = build_review_batches(entries, batch_size=100, char_budget=tiny_budget)
+
+    check(
+        "build_review_batches: oversized entry becomes its own singleton batch (not split)",
+        any(len(b) == 1 and b[0] is huge_entry for b in batches),
+        detail=repr([len(b) for b in batches]),
+    )
+    check(
+        "build_review_batches: all entries preserved, in order, none dropped",
+        [e for b in batches for e in b] == entries,
+        detail=repr(batches),
+    )
+
+
+def test_build_review_batches_count_budget_still_respected():
+    """Even when the rendered size is well under the char budget, the
+    entry-COUNT cap (review_batch_size) must still apply."""
+    entries = [{"speaker": "NARRATOR", "text": "Hi.", "instruct": "Neutral, even narration."} for _ in range(10)]
+    batches = build_review_batches(entries, batch_size=3, char_budget=1_000_000)
+    check(
+        "build_review_batches: count cap respected when char budget is not the constraint",
+        [len(b) for b in batches] == [3, 3, 3, 1],
+        detail=repr([len(b) for b in batches]),
+    )
+
+
+def test_build_review_batches_empty_and_single_entry():
+    check(
+        "build_review_batches: empty input -> empty list",
+        build_review_batches([], 25, 12000) == [],
+    )
+    one = [{"speaker": "NARRATOR", "text": "Hi.", "instruct": "Neutral, even narration."}]
+    check(
+        "build_review_batches: single small entry -> one singleton batch",
+        build_review_batches(one, 25, 12000) == [one],
+    )
+
+
+def test_truncate_context_entry_only_affects_context_copy():
+    long_text = "X" * 500
+    entry = {"speaker": "NARRATOR", "text": long_text, "instruct": "Neutral, even narration."}
+    truncated = _truncate_context_entry(entry, max_text_chars=300)
+
+    check(
+        "_truncate_context_entry: long text truncated to 300 chars + ellipsis",
+        truncated["text"] == ("X" * 300) + "...",
+        detail=repr(truncated["text"][:40] + "..."),
+    )
+    check(
+        "_truncate_context_entry: original entry dict is NOT mutated",
+        entry["text"] == long_text,
+        detail=repr(entry["text"][:40]),
+    )
+    check(
+        "_truncate_context_entry: returns a different object than the original when truncating",
+        truncated is not entry,
+    )
+
+    short_entry = {"speaker": "NARRATOR", "text": "Short.", "instruct": "Neutral, even narration."}
+    unchanged = _truncate_context_entry(short_entry, max_text_chars=300)
+    check(
+        "_truncate_context_entry: text under the cap is left untouched",
+        unchanged["text"] == "Short.",
+    )
+
+
+def test_overlay_target_batch_text_unaffected_by_context_truncation():
+    """Extends the existing overlay tests: even for an entry long enough
+    that _truncate_context_entry WOULD truncate it if used as neighbor
+    context, apply_positional_overlay (which only ever sees TARGET BATCH
+    entries, never context) must still produce byte-identical full-length
+    text. These are two entirely separate code paths -- context truncation
+    is applied in main() only to the +/-N neighbor windows passed via
+    source_context, never to the batch passed to review_batch()/
+    apply_positional_overlay -- this test pins that the overlay never
+    routes through the context-truncation helper."""
+    long_text = "Y" * 500
+    batch = [{"speaker": "NARRATOR", "text": long_text, "instruct": "Neutral, even narration."}]
+    corrected = [{"speaker": "NARRATOR", "text": "irrelevant, discarded", "instruct": "Tense, clipped narration."}]
+    accepted = apply_positional_overlay(batch, corrected)
+    check(
+        "overlay: target batch text stays full-length/byte-identical (never context-truncated)",
+        accepted[0]["text"] == long_text and len(accepted[0]["text"]) == 500,
+        detail=f"len={len(accepted[0]['text'])}",
+    )
+
+
+def test_maybe_print_truncation_hint_fires_when_ratio_far_above_baseline():
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        _maybe_print_truncation_hint(prompt_chars=32000, prompt_tokens=2050)  # ratio ~15.6, far above ~4
+    output = buffer.getvalue()
+    check(
+        "truncation hint: fires when chars/tokens ratio is far above the ~4 baseline",
+        "HINT" in output and "2050" in output and "32000" in output,
+        detail=repr(output),
+    )
+
+
+def test_maybe_print_truncation_hint_silent_for_normal_ratio():
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        _maybe_print_truncation_hint(prompt_chars=8000, prompt_tokens=2000)  # ratio 4.0, normal
+    check(
+        "truncation hint: silent for a normal chars/tokens ratio (no false positive)",
+        buffer.getvalue() == "",
+        detail=repr(buffer.getvalue()),
+    )
+
+
+def test_maybe_print_truncation_hint_silent_when_tokens_unknown():
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        _maybe_print_truncation_hint(prompt_chars=32000, prompt_tokens=None)
+        _maybe_print_truncation_hint(prompt_chars=32000, prompt_tokens=0)
+    check(
+        "truncation hint: silent when prompt_tokens is unknown/zero (no false positives, best-effort only)",
+        buffer.getvalue() == "",
+        detail=repr(buffer.getvalue()),
+    )
+
+
+def test_review_batch_char_budget_config_key_and_default():
+    """F12: `generation.review_batch_char_budget` config key must be read
+    with a default of 12000. Inspect main()'s actual source (rather than
+    reimplementing the lookup separately) so this test tracks the real
+    shipped default and config key name, not a copy that could drift."""
+    source = inspect.getsource(review_script_module.main)
+    check(
+        'main(): reads generation_config.get("review_batch_char_budget", 12000)',
+        'generation_config.get("review_batch_char_budget", 12000)' in source,
+        detail=source[:600],
+    )
+    check(
+        "main(): uses build_review_batches() (not raw fixed-count slicing) in both modes",
+        source.count("build_review_batches(entries, batch_size, batch_char_budget)") == 2,
+        detail=str(source.count("build_review_batches(entries, batch_size, batch_char_budget)")),
+    )
+
+
 def main():
     tests = [
         test_overlay_preserves_text_applies_speaker_and_instruct,
@@ -472,6 +673,16 @@ def main():
         test_shipped_review_prompts_pass_their_own_guard,
         test_normalize_text_no_fusion_at_punctuation_quote_boundary,
         test_check_text_loss_whole_vs_entry_split_agree_on_fused_quote_fixture,
+        test_build_review_batches_splits_on_char_budget,
+        test_build_review_batches_singleton_oversized_entry,
+        test_build_review_batches_count_budget_still_respected,
+        test_build_review_batches_empty_and_single_entry,
+        test_truncate_context_entry_only_affects_context_copy,
+        test_overlay_target_batch_text_unaffected_by_context_truncation,
+        test_maybe_print_truncation_hint_fires_when_ratio_far_above_baseline,
+        test_maybe_print_truncation_hint_silent_for_normal_ratio,
+        test_maybe_print_truncation_hint_silent_when_tokens_unknown,
+        test_review_batch_char_budget_config_key_and_default,
     ]
     for t in tests:
         try:

--- a/app/test_review_verbatim.py
+++ b/app/test_review_verbatim.py
@@ -49,6 +49,7 @@ from review_script import (  # noqa: E402
     _rendered_len,
     _truncate_context_entry,
     _maybe_print_truncation_hint,
+    build_script_roster,
 )
 
 
@@ -653,8 +654,94 @@ def test_review_batch_char_budget_config_key_and_default():
     )
 
 
+
+# ---------------------------------------------------------------------------
+# F15: roster-aware spelling resolution at the review seam
+# ---------------------------------------------------------------------------
+
+def _overlay_speaker(original, correction, roster=None):
+    batch = [{"speaker": original, "text": "  Verbatim text. ", "instruct": "i"}]
+    corrected = [{"speaker": correction, "instruct": "i"}]
+    accepted = apply_positional_overlay(batch, corrected, roster=roster)
+    return accepted[0]
+
+
+def test_review_roster_snaps_drifted_spelling():
+    roster = build_script_roster([
+        {"speaker": "ABBE MARIGNAN"}, {"speaker": "NARRATOR"}])
+    entry = _overlay_speaker("NARRATOR", "ABBEMARIGNAN", roster)
+    check("review overlay snaps ABBEMARIGNAN onto ABBE MARIGNAN",
+          entry["speaker"] == "ABBE MARIGNAN", detail=repr(entry["speaker"]))
+    check("review overlay leaves text byte-identical",
+          entry["text"] == "  Verbatim text. ", detail=repr(entry["text"]))
+
+
+def test_review_roster_is_built_order_independently():
+    # build_script_roster() sees the whole script, so which spelling it
+    # establishes does not depend on the order the two variants appear in.
+    forward = build_script_roster([{"speaker": "ABBE MARIGNAN"}, {"speaker": "ABBEMARIGNAN"}])
+    backward = build_script_roster([{"speaker": "ABBEMARIGNAN"}, {"speaker": "ABBE MARIGNAN"}])
+    check("review roster establishes the more-punctuated spelling either way",
+          list(forward.values()) == list(backward.values()) == ["ABBE MARIGNAN"],
+          detail=f"{forward!r} vs {backward!r}")
+
+
+def test_review_overlay_conforms_to_the_established_spelling():
+    # The overlay is read-only against the roster: a correction is snapped
+    # onto whatever the SCRIPT established, so one review pass cannot emit
+    # two spellings of one character into the same file.
+    roster = build_script_roster([{"speaker": "ABBEMARIGNAN"}])
+    entry = _overlay_speaker("NARRATOR", "ABBE MARIGNAN", roster)
+    check("review overlay conforms a correction to the script's spelling",
+          entry["speaker"] == "ABBEMARIGNAN", detail=repr(entry["speaker"]))
+
+
+def test_review_roster_unifies_punctuation_drift():
+    roster = build_script_roster([{"speaker": "O'BRIEN"}])
+    entry = _overlay_speaker("NARRATOR", "OBRIEN", roster)
+    check("review overlay snaps OBRIEN onto O'BRIEN",
+          entry["speaker"] == "O'BRIEN", detail=repr(entry["speaker"]))
+
+
+def test_review_roster_never_merges_similar_names():
+    roster = build_script_roster([{"speaker": "JON"}, {"speaker": "ELLA"}])
+    john = _overlay_speaker("NARRATOR", "JOHN", roster)
+    bella = _overlay_speaker("NARRATOR", "BELLA", roster)
+    check("JOHN stays distinct from JON in review", john["speaker"] == "JOHN",
+          detail=repr(john["speaker"]))
+    check("BELLA stays distinct from ELLA in review", bella["speaker"] == "BELLA",
+          detail=repr(bella["speaker"]))
+
+
+def test_review_roster_optional_and_fallback_intact():
+    plain = _overlay_speaker("NARRATOR", "ABBEMARIGNAN")
+    check("no roster -> plain canonicalization (back-compat)",
+          plain["speaker"] == "ABBEMARIGNAN", detail=repr(plain["speaker"]))
+    roster = build_script_roster([{"speaker": "ABBE MARIGNAN"}])
+    fallback = _overlay_speaker("abbemarignan", "", roster)
+    check("empty correction falls back to the roster-resolved original",
+          fallback["speaker"] == "ABBE MARIGNAN", detail=repr(fallback["speaker"]))
+
+
+def test_build_script_roster_shape():
+    roster = build_script_roster([
+        {"speaker": "ABBE MARIGNAN"}, {"speaker": "ABBEMARIGNAN"},
+        {"speaker": "JON"}, {"speaker": ""}, "not a dict",
+    ])
+    check("roster index collapses the whitespace variant only",
+          sorted(roster.values()) == ["ABBE MARIGNAN", "JON"], detail=repr(roster))
+
+
+
 def main():
     tests = [
+        test_review_roster_snaps_drifted_spelling,
+        test_review_roster_is_built_order_independently,
+        test_review_overlay_conforms_to_the_established_spelling,
+        test_review_roster_unifies_punctuation_drift,
+        test_review_roster_never_merges_similar_names,
+        test_review_roster_optional_and_fallback_intact,
+        test_build_script_roster_shape,
         test_overlay_preserves_text_applies_speaker_and_instruct,
         test_overlay_keeps_unspecified_fields_from_original,
         test_overlay_empty_corrected_speaker_keeps_original,

--- a/app/test_review_verbatim.py
+++ b/app/test_review_verbatim.py
@@ -25,9 +25,11 @@ Run directly:
     python app/test_review_verbatim.py
 Exits 0 if all tests pass, non-zero otherwise.
 """
+import io
 import os
 import sys
 import traceback
+from contextlib import redirect_stdout
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
@@ -35,6 +37,10 @@ from review_script import (  # noqa: E402
     apply_positional_overlay,
     merge_consecutive_narrators,
     _join_narrator_texts,
+    select_review_prompt,
+    REVIEW_PROMPT_SCHEMA_MARKER,
+    REVIEW_SYSTEM_PROMPT,
+    REVIEW_USER_PROMPT,
 )
 
 
@@ -289,6 +295,99 @@ def test_narrator_casing_canonicalized_by_overlay():
     )
 
 
+def test_select_review_prompt_stale_custom_falls_back_with_warning():
+    """F8: a saved custom prompt from before the verbatim-review refactor
+    (no REVIEW_PROMPT_SCHEMA_MARKER) must NOT be used as-is -- it still
+    carries the retired "strip attribution tags / rewrite" methodology,
+    which causes entry-count mismatches (failed batches) and degraded
+    speaker/instruct fixes under the new positional-overlay contract. It
+    must fall back to the built-in default and print a warning naming the
+    offending config key."""
+    stale_prompt = "You are a script reviewer. STRIP ATTRIBUTION TAGS FROM DIALOGUE. Rephrase as needed."
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        result = select_review_prompt(stale_prompt, REVIEW_SYSTEM_PROMPT, "review_system_prompt")
+    output = buffer.getvalue()
+    check(
+        "select_review_prompt: stale custom (no marker) falls back to the default",
+        result == REVIEW_SYSTEM_PROMPT,
+        detail=repr(result[:80]),
+    )
+    check(
+        "select_review_prompt: warning names the offending config key",
+        "review_system_prompt" in output and "WARNING" in output,
+        detail=repr(output),
+    )
+
+
+def test_select_review_prompt_marker_bearing_custom_used_as_is():
+    """A custom prompt that DOES carry the marker is the operator's own,
+    intentional, up-to-date customization -- it must be used byte-identically,
+    not silently altered."""
+    custom_prompt = "My own custom review prompt (prompt schema: verbatim-review-v1) with extra house rules."
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        result = select_review_prompt(custom_prompt, REVIEW_SYSTEM_PROMPT, "review_system_prompt")
+    output = buffer.getvalue()
+    check(
+        "select_review_prompt: marker-bearing custom prompt used byte-identically",
+        result == custom_prompt,
+        detail=repr(result),
+    )
+    check(
+        "select_review_prompt: no warning printed for a valid custom prompt",
+        output == "",
+        detail=repr(output),
+    )
+
+
+def test_select_review_prompt_absent_or_blank_uses_default_silently():
+    """No saved custom prompt (None, missing) or a blank one -- both are the
+    common/unconfigured case and must silently use the built-in default,
+    with no warning noise."""
+    for label, value in [("None", None), ("empty string", ""), ("whitespace-only", "   ")]:
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            result = select_review_prompt(value, REVIEW_USER_PROMPT, "review_user_prompt")
+        output = buffer.getvalue()
+        check(
+            f"select_review_prompt: absent/blank custom ({label}) -> default, silently",
+            result == REVIEW_USER_PROMPT and output == "",
+            detail=repr(output),
+        )
+
+
+def test_shipped_review_prompts_pass_their_own_guard():
+    """The review_prompts.txt shipped with the repo must carry the marker in
+    BOTH halves (system prompt and user prompt template), so a fresh
+    install's own default prompts pass select_review_prompt's guard exactly
+    like a valid custom prompt would."""
+    check(
+        "shipped prompts: REVIEW_SYSTEM_PROMPT carries the marker",
+        REVIEW_PROMPT_SCHEMA_MARKER in REVIEW_SYSTEM_PROMPT,
+        detail=repr(REVIEW_SYSTEM_PROMPT[:120]),
+    )
+    check(
+        "shipped prompts: REVIEW_USER_PROMPT carries the marker",
+        REVIEW_PROMPT_SCHEMA_MARKER in REVIEW_USER_PROMPT,
+        detail=repr(REVIEW_USER_PROMPT[:200]),
+    )
+    # Also exercise the actual guard function end-to-end with the shipped
+    # prompts, standing in for "prompts_config" being empty (the common
+    # fresh-install case) and for a config that happens to echo the
+    # shipped default back (still must pass, no warning).
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        sys_result = select_review_prompt(REVIEW_SYSTEM_PROMPT, REVIEW_SYSTEM_PROMPT, "review_system_prompt")
+        usr_result = select_review_prompt(REVIEW_USER_PROMPT, REVIEW_USER_PROMPT, "review_user_prompt")
+    output = buffer.getvalue()
+    check(
+        "shipped prompts: both pass select_review_prompt's guard with no warning",
+        sys_result == REVIEW_SYSTEM_PROMPT and usr_result == REVIEW_USER_PROMPT and output == "",
+        detail=repr(output),
+    )
+
+
 def main():
     tests = [
         test_overlay_preserves_text_applies_speaker_and_instruct,
@@ -303,6 +402,10 @@ def main():
         test_merge_consecutive_narrators_byte_exact_for_verbatim_entries,
         test_merge_consecutive_narrators_legacy_stripped_entries_still_readable,
         test_narrator_casing_canonicalized_by_overlay,
+        test_select_review_prompt_stale_custom_falls_back_with_warning,
+        test_select_review_prompt_marker_bearing_custom_used_as_is,
+        test_select_review_prompt_absent_or_blank_uses_default_silently,
+        test_shipped_review_prompts_pass_their_own_guard,
     ]
     for t in tests:
         try:

--- a/app/test_review_verbatim.py
+++ b/app/test_review_verbatim.py
@@ -397,6 +397,36 @@ def test_shipped_review_prompts_pass_their_own_guard():
     )
 
 
+def test_shipped_review_prompt_states_the_attribution_tag_rule():
+    """The reviewer must be told that an attribution tag stays narration.
+
+    Measured cost of its absence: a full-book review made 58 NARRATOR ->
+    character changes, 57 of them on entries containing no quotation mark at
+    all -- "Dairine said.", "Ronan shook his head." and the like handed to
+    character voices. Entries with no quotes voiced by a character nearly
+    doubled (63 -> 119). The model was not malfunctioning; it was reading a
+    tag that names a character as evidence the character speaks it, which is
+    the one rule this fork exists to enforce and the only rule the review
+    prompt did not state. default_prompts.txt carries it as its rule 2; both
+    stages need it, so pin it here rather than relying on prose surviving an
+    edit.
+    """
+    lowered = REVIEW_SYSTEM_PROMPT.lower()
+    check(
+        "review prompt: says attribution tags/action beats stay narration",
+        "attribution tag" in lowered and "action beat" in lowered,
+        detail=repr(REVIEW_SYSTEM_PROMPT[:200]),
+    )
+    check(
+        "review prompt: distinguishes an audiobook from an audio drama",
+        "audio drama" in lowered,
+    )
+    check(
+        "review prompt: says naming a character is not the same as speaking",
+        "he said" in lowered or "said." in lowered,
+    )
+
+
 def test_normalize_text_no_fusion_at_punctuation_quote_boundary():
     """F10: normalize_text() used to delete punctuation outright
     (`re.sub(r'[^\\w\\s]', '', text)`), so a quote/dash mark that directly
@@ -758,6 +788,7 @@ def main():
         test_select_review_prompt_marker_bearing_custom_used_as_is,
         test_select_review_prompt_absent_or_blank_uses_default_silently,
         test_shipped_review_prompts_pass_their_own_guard,
+        test_shipped_review_prompt_states_the_attribution_tag_rule,
         test_normalize_text_no_fusion_at_punctuation_quote_boundary,
         test_check_text_loss_whole_vs_entry_split_agree_on_fused_quote_fixture,
         test_build_review_batches_splits_on_char_budget,

--- a/app/test_review_verbatim.py
+++ b/app/test_review_verbatim.py
@@ -41,6 +41,8 @@ from review_script import (  # noqa: E402
     REVIEW_PROMPT_SCHEMA_MARKER,
     REVIEW_SYSTEM_PROMPT,
     REVIEW_USER_PROMPT,
+    normalize_text,
+    check_text_loss,
 )
 
 
@@ -388,6 +390,68 @@ def test_shipped_review_prompts_pass_their_own_guard():
     )
 
 
+def test_normalize_text_no_fusion_at_punctuation_quote_boundary():
+    """F10: normalize_text() used to delete punctuation outright
+    (`re.sub(r'[^\\w\\s]', '', text)`), so a quote/dash mark that directly
+    abuts a word with no space of its own fused the two words together
+    (`he said:--"Sicut` -> `saidsicut`). That fusion happened differently
+    depending on whether the text was normalized as one long string or as
+    separately-normalized entries split at a span/quote boundary, producing
+    false-alarm coverage-ratio mismatches with zero actual text loss.
+    Replacing punctuation with a space (then collapsing whitespace) fixes
+    this: a punctuation mark always leaves a token separator behind."""
+    check(
+        'normalize_text: \'he said:--"Sicut quercus"\' does not fuse into "saidsicut"',
+        normalize_text('he said:--"Sicut quercus"') == "he said sicut quercus",
+        detail=repr(normalize_text('he said:--"Sicut quercus"')),
+    )
+    check(
+        'normalize_text: \'ex-"spahi"\' does not fuse into "exspahi"',
+        normalize_text('ex-"spahi"') == "ex spahi",
+        detail=repr(normalize_text('ex-"spahi"')),
+    )
+    check(
+        "normalize_text: apostrophe contractions now split into two tokens "
+        "(don't -> 'don t', was 'dont' before -- fine as long as both sides "
+        "of every comparison go through the same function)",
+        normalize_text("don't") == "don t",
+        detail=repr(normalize_text("don't")),
+    )
+
+
+def test_check_text_loss_whole_vs_entry_split_agree_on_fused_quote_fixture():
+    """Regression for the false-alarm coverage-ratio bug: a source whose
+    span/entry boundary falls exactly at a quote mark used to normalize
+    differently depending on whether it went through normalize_text() as
+    one long string vs. as separately-normalized entries whose words are
+    then concatenated by check_text_loss. Both paths must now agree
+    exactly, with zero actual characters gained or lost."""
+    source = 'He said:--"Sicut quercus" and left, then said ex-"spahi" once more.'
+    # Mimic a span/entry split landing exactly at the quote boundaries --
+    # concatenating these pieces reproduces `source` exactly (byte-verbatim
+    # by construction, same as the real pipeline).
+    entry_pieces = [
+        'He said:--',
+        '"Sicut quercus" and left, then said ex-',
+        '"spahi" once more.',
+    ]
+    check(
+        "fixture: entry pieces concatenate back to the source exactly (sanity check)",
+        "".join(entry_pieces) == source,
+        detail=repr("".join(entry_pieces)),
+    )
+
+    entries = [{"text": p} for p in entry_pieces]
+    passed, orig_joined, corr_joined, ratio = check_text_loss(
+        [{"text": source}], entries, threshold=1.0, upper_bound=1.0
+    )
+    check(
+        "check_text_loss: whole-source vs per-entry-split normalization now agree exactly (ratio == 1.0)",
+        passed and ratio == 1.0 and orig_joined == corr_joined,
+        detail=f"ratio={ratio!r} orig={orig_joined!r} corr={corr_joined!r}",
+    )
+
+
 def main():
     tests = [
         test_overlay_preserves_text_applies_speaker_and_instruct,
@@ -406,6 +470,8 @@ def main():
         test_select_review_prompt_marker_bearing_custom_used_as_is,
         test_select_review_prompt_absent_or_blank_uses_default_silently,
         test_shipped_review_prompts_pass_their_own_guard,
+        test_normalize_text_no_fusion_at_punctuation_quote_boundary,
+        test_check_text_loss_whole_vs_entry_split_agree_on_fused_quote_fixture,
     ]
     for t in tests:
         try:

--- a/app/test_review_verbatim.py
+++ b/app/test_review_verbatim.py
@@ -1,0 +1,325 @@
+"""Standalone tests for the review-stage verbatim guarantee (app/review_script.py).
+
+Audit finding: the review stage's LLM prompt used to instruct wholesale text
+rewriting (attribution stripping, participle rephrasing, front-matter
+merging) and its safety net (check_text_loss) tolerated up to 5% word loss.
+That is a structural violation of the "audiobooks are verbatim" contract.
+
+The fix makes text damage structurally impossible rather than merely
+discouraged:
+  - apply_positional_overlay(): "text" is ALWAYS taken from the original
+    entry, never from the LLM's response. Only "speaker" (canonicalized)
+    and "instruct" are taken from the LLM, matched positionally. A count
+    mismatch between batch and corrected returns None -- the caller must
+    treat that as a failed batch and keep the originals.
+  - _join_narrator_texts()/merge_consecutive_narrators(): the narrator-merge
+    join no longer unconditionally inserts a space -- it only does so when
+    neither side already carries boundary whitespace, so verbatim entries
+    (which carry their own boundary whitespace) stay byte-exact, while
+    legacy .strip()'d scripts still merge readably.
+
+This test exercises those two functions directly -- no live server, no LLM,
+no subprocess.
+
+Run directly:
+    python app/test_review_verbatim.py
+Exits 0 if all tests pass, non-zero otherwise.
+"""
+import os
+import sys
+import traceback
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from review_script import (  # noqa: E402
+    apply_positional_overlay,
+    merge_consecutive_narrators,
+    _join_narrator_texts,
+)
+
+
+results = []
+
+
+def check(name, condition, detail=""):
+    status = "PASS" if condition else "FAIL"
+    results.append((name, condition, detail))
+    print(f"[{status}] {name}" + (f" -- {detail}" if detail and not condition else ""))
+
+
+def test_overlay_preserves_text_applies_speaker_and_instruct():
+    batch = [
+        {"speaker": "narrator", "text": "  He lit a cigarette. ", "instruct": "Neutral, even narration."},
+        {"speaker": "HOLMES", "text": "Quite so, he answered.", "instruct": "flat"},
+    ]
+    # The LLM tries to rewrite text (attribution-strip / rephrase) -- must
+    # be discarded entirely. It also fixes a speaker and an instruct.
+    corrected = [
+        {"speaker": "NARRATOR", "text": "He lit a cigarette and threw himself into an armchair.", "instruct": "Neutral, even narration."},
+        {"speaker": "holmes", "text": "Quite so.", "instruct": "Quietly analytical, dry amusement."},
+    ]
+
+    accepted = apply_positional_overlay(batch, corrected)
+
+    check(
+        "overlay: text is byte-identical to the ORIGINAL batch, not the LLM's",
+        [e["text"] for e in accepted] == [b["text"] for b in batch],
+        detail=repr([e["text"] for e in accepted]),
+    )
+    check(
+        "overlay: speaker taken from correction, canonicalized",
+        [e["speaker"] for e in accepted] == ["NARRATOR", "HOLMES"],
+        detail=repr([e["speaker"] for e in accepted]),
+    )
+    check(
+        "overlay: instruct taken from correction",
+        accepted[1]["instruct"] == "Quietly analytical, dry amusement.",
+        detail=repr(accepted[1]),
+    )
+    check(
+        "overlay: original batch list/dicts not mutated",
+        batch[0]["text"] == "  He lit a cigarette. " and batch[1]["speaker"] == "HOLMES",
+        detail=repr(batch),
+    )
+
+
+def test_overlay_keeps_unspecified_fields_from_original():
+    batch = [{"speaker": "elena", "text": "Hello.", "instruct": "warm"}]
+    # LLM omits "instruct" entirely (only fixes speaker) -- original instruct
+    # must survive.
+    corrected = [{"speaker": "ELENA"}]
+    accepted = apply_positional_overlay(batch, corrected)
+    check(
+        "overlay: instruct falls back to original when LLM omits it",
+        accepted[0]["instruct"] == "warm",
+        detail=repr(accepted[0]),
+    )
+    check(
+        "overlay: text falls back to original regardless",
+        accepted[0]["text"] == "Hello.",
+    )
+
+
+def test_overlay_empty_corrected_speaker_keeps_original():
+    """N1 regression: a corrected speaker that is empty/None/blank, or that
+    canonicalizes to empty (e.g. a stray parenthetical), must NOT blank out
+    a good original label -- that would silently drop the entry from the
+    voices roster and mute it at render time. The original (canonicalized)
+    speaker must be kept in every such case."""
+    cases = [
+        ("empty string", ""),
+        ("None", None),
+        ("whitespace-only", "   "),
+        ("canonicalizes to empty", "(shouting)"),
+    ]
+    for label, bad_speaker in cases:
+        batch = [{"speaker": "mark", "text": "Stop right there.", "instruct": "Firm, commanding."}]
+        corrected = [{"speaker": bad_speaker, "text": "irrelevant", "instruct": "Firm, commanding."}]
+        accepted = apply_positional_overlay(batch, corrected)
+        check(
+            f"overlay: corrected speaker ({label}) -> original speaker retained (canonical)",
+            accepted[0]["speaker"] == "MARK",
+            detail=repr(accepted[0]),
+        )
+
+
+def test_overlay_absent_speaker_key_keeps_original_existing_behavior():
+    """Existing behavior (unchanged by the N1 fix): an absent "speaker" key
+    in the correction also falls back to the original speaker."""
+    batch = [{"speaker": "elena", "text": "Hello.", "instruct": "warm"}]
+    corrected = [{"instruct": "warm"}]  # no "speaker" key at all
+    accepted = apply_positional_overlay(batch, corrected)
+    check(
+        "overlay: absent speaker key -> original speaker retained",
+        accepted[0]["speaker"] == "ELENA",
+        detail=repr(accepted[0]),
+    )
+
+
+def test_overlay_invalid_corrected_instruct_keeps_original():
+    """N2 regression: a corrected instruct that is None, a list, a dict, or
+    a whitespace-only string must be rejected -- only a non-empty string is
+    accepted -- so malformed values never get written into
+    annotated_script.json."""
+    cases = [
+        ("None", None),
+        ("empty list", []),
+        ("empty dict", {}),
+        ("whitespace-only string", "  "),
+    ]
+    for label, bad_instruct in cases:
+        batch = [{"speaker": "NARRATOR", "text": "It was raining.", "instruct": "Neutral, even narration."}]
+        corrected = [{"speaker": "NARRATOR", "text": "irrelevant", "instruct": bad_instruct}]
+        accepted = apply_positional_overlay(batch, corrected)
+        check(
+            f"overlay: corrected instruct ({label}) -> original instruct retained",
+            accepted[0]["instruct"] == "Neutral, even narration.",
+            detail=repr(accepted[0]),
+        )
+
+
+def test_overlay_valid_string_instruct_still_applied():
+    """Sanity check that the N2 fix didn't overcorrect: a genuine non-empty
+    string instruct from the LLM must still be applied."""
+    batch = [{"speaker": "NARRATOR", "text": "It was raining.", "instruct": "Neutral, even narration."}]
+    corrected = [{"speaker": "NARRATOR", "text": "irrelevant", "instruct": "Tense, clipped narration."}]
+    accepted = apply_positional_overlay(batch, corrected)
+    check(
+        "overlay: valid string instruct is still applied",
+        accepted[0]["instruct"] == "Tense, clipped narration.",
+        detail=repr(accepted[0]),
+    )
+
+
+def test_overlay_count_mismatch_returns_none():
+    batch = [
+        {"speaker": "NARRATOR", "text": "One.", "instruct": "Neutral, even narration."},
+        {"speaker": "NARRATOR", "text": "Two.", "instruct": "Neutral, even narration."},
+    ]
+    # LLM tries to split entry 1 into two -- explicitly forbidden now.
+    corrected_too_many = [
+        {"speaker": "NARRATOR", "text": "One.", "instruct": "Neutral, even narration."},
+        {"speaker": "NARRATOR", "text": "One point five.", "instruct": "Neutral, even narration."},
+        {"speaker": "NARRATOR", "text": "Two.", "instruct": "Neutral, even narration."},
+    ]
+    result = apply_positional_overlay(batch, corrected_too_many)
+    check(
+        "overlay: count mismatch (more entries) returns None",
+        result is None,
+        detail=repr(result),
+    )
+
+    corrected_too_few = [
+        {"speaker": "NARRATOR", "text": "One and two.", "instruct": "Neutral, even narration."},
+    ]
+    result2 = apply_positional_overlay(batch, corrected_too_few)
+    check(
+        "overlay: count mismatch (fewer entries, merge attempt) returns None",
+        result2 is None,
+        detail=repr(result2),
+    )
+
+
+def test_overlay_malformed_correction_entry_falls_back():
+    batch = [{"speaker": "NARRATOR", "text": "Text.", "instruct": "Neutral, even narration."}]
+    corrected = ["not a dict"]
+    accepted = apply_positional_overlay(batch, corrected)
+    check(
+        "overlay: non-dict correction entry falls back to original speaker/instruct",
+        accepted[0]["speaker"] == "NARRATOR" and accepted[0]["instruct"] == "Neutral, even narration.",
+        detail=repr(accepted),
+    )
+    check(
+        "overlay: non-dict correction entry still gets original text",
+        accepted[0]["text"] == "Text.",
+    )
+
+
+def test_join_narrator_texts_whitespace_aware():
+    # Verbatim entries carrying their own boundary whitespace -> join with
+    # "" so no byte is invented.
+    check(
+        "join: trailing space on left -> no extra space inserted",
+        _join_narrator_texts("He left. ", "She stayed.") == "He left. She stayed.",
+    )
+    check(
+        "join: leading space on right -> no extra space inserted",
+        _join_narrator_texts("He left.", " She stayed.") == "He left. She stayed.",
+    )
+    check(
+        "join: newline boundary preserved byte-exact",
+        _join_narrator_texts("He left.\n", "She stayed.") == "He left.\nShe stayed.",
+    )
+    # Legacy stripped-text entries (neither side has boundary whitespace) ->
+    # a space IS inserted so merged text still reads correctly.
+    check(
+        "join: neither side has boundary whitespace -> space inserted",
+        _join_narrator_texts("He left.", "She stayed.") == "He left. She stayed.",
+    )
+
+
+def test_merge_consecutive_narrators_byte_exact_for_verbatim_entries():
+    # Entries as they'd actually appear post-refactor: boundary whitespace
+    # lives INSIDE the text field already (e.g. a trailing space carried
+    # from the source), not stripped off.
+    entries = [
+        {"speaker": "NARRATOR", "text": "He lit a cigarette. ", "instruct": "Neutral, even narration."},
+        {"speaker": "NARRATOR", "text": "Then he sat down.", "instruct": "Neutral, even narration."},
+    ]
+    merged, merges = merge_consecutive_narrators(entries, max_merged_length=800)
+    check(
+        "merge: verbatim entries join byte-exact (no injected space)",
+        merged[0]["text"] == "He lit a cigarette. Then he sat down.",
+        detail=repr(merged),
+    )
+    check("merge: one merge counted", merges == 1)
+
+
+def test_merge_consecutive_narrators_legacy_stripped_entries_still_readable():
+    # Legacy/older scripts whose entries were .strip()'d -- no boundary
+    # whitespace on either side -- must still merge with a readable space.
+    entries = [
+        {"speaker": "NARRATOR", "text": "He lit a cigarette.", "instruct": "Neutral, even narration."},
+        {"speaker": "NARRATOR", "text": "Then he sat down.", "instruct": "Neutral, even narration."},
+    ]
+    merged, merges = merge_consecutive_narrators(entries, max_merged_length=800)
+    check(
+        "merge: legacy stripped entries still get a readable space",
+        merged[0]["text"] == "He lit a cigarette. Then he sat down.",
+        detail=repr(merged),
+    )
+    check("merge: one merge counted (legacy case)", merges == 1)
+
+
+def test_narrator_casing_canonicalized_by_overlay():
+    """The review LLM might emit odd casing for NARRATOR; the overlay's
+    canonicalize() call must normalize it so downstream `!= "NARRATOR"`
+    comparisons (e.g. in merge_consecutive_narrators) stay reliable."""
+    batch = [{"speaker": "Narrator", "text": "Once upon a time.", "instruct": "calm"}]
+    corrected = [{"speaker": "NaRrAtOr", "text": "irrelevant, discarded", "instruct": "Neutral, even narration."}]
+    accepted = apply_positional_overlay(batch, corrected)
+    check(
+        "overlay: odd-cased NARRATOR from the LLM is canonicalized",
+        accepted[0]["speaker"] == "NARRATOR",
+        detail=repr(accepted[0]),
+    )
+    check(
+        "overlay: text still comes from the original, not the LLM",
+        accepted[0]["text"] == "Once upon a time.",
+    )
+
+
+def main():
+    tests = [
+        test_overlay_preserves_text_applies_speaker_and_instruct,
+        test_overlay_keeps_unspecified_fields_from_original,
+        test_overlay_empty_corrected_speaker_keeps_original,
+        test_overlay_absent_speaker_key_keeps_original_existing_behavior,
+        test_overlay_invalid_corrected_instruct_keeps_original,
+        test_overlay_valid_string_instruct_still_applied,
+        test_overlay_count_mismatch_returns_none,
+        test_overlay_malformed_correction_entry_falls_back,
+        test_join_narrator_texts_whitespace_aware,
+        test_merge_consecutive_narrators_byte_exact_for_verbatim_entries,
+        test_merge_consecutive_narrators_legacy_stripped_entries_still_readable,
+        test_narrator_casing_canonicalized_by_overlay,
+    ]
+    for t in tests:
+        try:
+            t()
+        except Exception:
+            check(t.__name__, False, detail=traceback.format_exc())
+
+    failed = [name for name, ok, _ in results if not ok]
+    print()
+    print(f"{len(results) - len(failed)}/{len(results)} checks passed")
+    if failed:
+        print("FAILED:")
+        for name in failed:
+            print(f"  - {name}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/app/test_span_integration.py
+++ b/app/test_span_integration.py
@@ -13,10 +13,13 @@ concatenate back to that chunk BYTE FOR BYTE. Failure costs speaker labels,
 never prose.
 """
 
+import atexit
 import io
 import json
 import os
+import shutil
 import sys
+import tempfile
 import types
 import unittest
 from contextlib import redirect_stdout
@@ -29,6 +32,16 @@ for _stream in (sys.stdout, sys.stderr):
         pass
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# Redirect generate_script's raw-response log to a tempdir for the whole
+# process. Done at IMPORT time, not in setUpModule, so it also covers
+# test_api.py's Section 15, which imports FakeClient/labels_for from here and
+# drives process_chunk itself. Without this the suite appends fixture responses
+# to the production logs/llm_responses.log -- 1200+ records of noise in the file
+# used for live forensics.
+_LOG_TMPDIR = tempfile.mkdtemp(prefix="alexandria_test_llm_log_")
+os.environ["ALEXANDRIA_LLM_LOG_DIR"] = _LOG_TMPDIR
+atexit.register(shutil.rmtree, _LOG_TMPDIR, True)
 
 from default_prompts import DEFAULT_SYSTEM_PROMPT, DEFAULT_USER_PROMPT  # noqa: E402
 from span_tokenizer import tokenize  # noqa: E402
@@ -44,6 +57,8 @@ from generate_script import (  # noqa: E402
     build_entries,
     build_span_payload,
     extract_labels,
+    is_whitespace_span,
+    llm_log_dir,
     labels_from_id_keyed_object,
     parse_label_response,
     process_chunk,
@@ -192,10 +207,12 @@ class _FakeCompletions:
         self.responses = list(responses)
         self.calls = 0
         self.last_kwargs = None
+        self.prompts = []          # user prompt of every call, in order
 
     def create(self, **kwargs):
         self.calls += 1
         self.last_kwargs = kwargs
+        self.prompts.append(kwargs["messages"][1]["content"])
         index = min(self.calls - 1, len(self.responses) - 1)
         item = self.responses[index]
         if isinstance(item, Exception):
@@ -217,6 +234,10 @@ class FakeClient:
     @property
     def last_user_prompt(self):
         return self.completions.last_kwargs["messages"][1]["content"]
+
+    @property
+    def user_prompts(self):
+        return self.completions.prompts
 
 
 # --------------------------------------------------------------------------
@@ -405,8 +426,9 @@ class TestTotalFailure(unittest.TestCase):
         self.assertEqual(entries[0]["speaker"], NARRATOR)
         self.assertEqual(entries[0]["instruct"], DEFAULT_NARRATOR_INSTRUCT)
         self.assertTrue(stats["degraded"])
-        self.assertEqual(stats["labelled"], 0)
-        self.assertEqual(stats["fallback"], stats["spans"])
+        self.assertEqual(stats["labelled"] - stats["whitespace"], 0,
+                         "the model labelled nothing (whitespace spans auto-resolve)")
+        self.assertEqual(stats["fallback"], stats["spans"] - stats["whitespace"])
         self.assertIn("DEGRADED", output)
         self.assertEqual(client.calls, 3, "should exhaust max_retries + 1 attempts")
 
@@ -433,7 +455,8 @@ class TestMalformedJson(unittest.TestCase):
 
         self.assertEqual(joined(entries), chunk)
         self.assertTrue(stats["degraded"])
-        self.assertEqual(stats["fallback"], stats["spans"])
+        self.assertEqual(stats["fallback"], stats["spans"] - stats["whitespace"],
+                         "every VISIBLE span fell back; whitespace auto-resolved")
         self.assertIn("DEGRADED", output)
 
     def test_salvageable_broken_json(self):
@@ -578,6 +601,8 @@ class TestRoleMissingDegrades(unittest.TestCase):
         self.assertTrue(stats["degraded"], "role-less labels must not exit 0 silently")
         self.assertIn("role=dialogue", stats["reason"])
         self.assertIn("DEGRADED", output)
+        self.assertEqual(client.calls, 3,
+                         "role-less labels now trigger retries; the fake repeats them, so all 3 burn")
 
         # The book is fully narrated: that is the damage being surfaced.
         self.assertEqual({entry["speaker"] for entry in entries}, {NARRATOR})
@@ -773,8 +798,8 @@ class TestRealResponseShapes(unittest.TestCase):
 
     def test_markdown_recovery_is_degraded_but_labels_apply(self):
         chunk = self.SIX_SPAN_CHUNK
-        entries, stats, output = run_chunk(
-            FakeClient(FakeResponse(REAL_MARKDOWN_SPAN)), chunk)
+        client = FakeClient(FakeResponse(REAL_MARKDOWN_SPAN))
+        entries, stats, output = run_chunk(client, chunk)
 
         self.assertEqual(joined(entries), chunk, "prose byte-identical either way")
         self.assertEqual(stats["recovery"], LABEL_MODE_MARKDOWN)
@@ -784,6 +809,8 @@ class TestRealResponseShapes(unittest.TestCase):
         self.assertIn("markdown", stats["reason"].lower())
         self.assertIn("markdown blocks", output)
         self.assertIn("BILL", {entry["speaker"] for entry in entries})
+        self.assertEqual(client.calls, 3,
+                         "3 of 6 spans unlabelled -> the retry budget is spent trying to fill them")
 
     def test_markdown_is_last_resort_only(self):
         # A well-formed array that also happens to mention "Span 1" in prose
@@ -843,6 +870,320 @@ class TestRealResponseShapes(unittest.TestCase):
                 self.assertEqual(extract_labels(text)[1], expected)
 
 
+class TestRetryOnIncompleteLabels(unittest.TestCase):
+    """Live evidence: the model closes the array early, dropping a contiguous
+    SUFFIX of span ids at finish_reason=stop (logged: missing [28] of 28, and
+    [27, 28] of 28), and separately invents role values ("thought" on a real
+    spoken line). Both are recoverable by re-asking for the named gaps."""
+
+    CHUNK = '"One." said A. "Two." said B. "Three." he added.'   # 6 spans
+
+    def setUp(self):
+        self.spans = tokenize(self.CHUNK)
+        self.assertEqual(len(self.spans), 6)
+
+    def _labels(self, ids, speaker="ELENA", role=None, instruct="Firm."):
+        out = []
+        for span in self.spans:
+            if span.id not in ids:
+                continue
+            label = {"id": span.id}
+            is_quoted = span.kind == "quoted"
+            label["speaker"] = speaker if is_quoted else "NARRATOR"
+            resolved_role = role if role is not None else ("dialogue" if is_quoted else "narration")
+            if resolved_role:
+                label["role"] = resolved_role
+            label["instruct"] = instruct
+            out.append(label)
+        return out
+
+    def _json(self, ids, **kw):
+        return json.dumps(self._labels(ids, **kw))
+
+    # --- the headline case ------------------------------------------------
+
+    def test_missing_suffix_is_recovered_on_retry(self):
+        client = FakeClient(
+            FakeResponse(self._json([1, 2, 3, 4, 5])),   # id 6 dropped, like the log
+            FakeResponse(self._json([6])),               # retry supplies the gap
+        )
+        entries, stats, output = run_chunk(client, self.CHUNK)
+
+        self.assertEqual(client.calls, 2, "one retry, no more")
+        self.assertEqual(joined(entries), self.CHUNK)
+        self.assertEqual(stats["labelled"], 6)
+        self.assertEqual(stats["fallback"], 0)
+        self.assertFalse(stats["degraded"], "a chunk fully labelled on retry is NOT degraded")
+        self.assertIn("retrying", output.lower())
+        self.assertIn("Retry recovered 1 new label(s)", output)
+
+    def test_retry_prompt_names_the_missing_ids(self):
+        client = FakeClient(
+            FakeResponse(self._json([1, 2, 3, 4, 5])),
+            FakeResponse(self._json([6])),
+        )
+        run_chunk(client, self.CHUNK)
+
+        first, second = client.user_prompts[0], client.user_prompts[1]
+        self.assertNotIn("CORRECTION", first, "attempt 1 must be the plain prompt")
+        self.assertTrue(second.startswith(first),
+                        "the nudge is appended, so the cached prefix is preserved")
+        self.assertIn("CORRECTION", second)
+        self.assertIn("still missing a label: 6", second)
+
+    def test_role_missing_is_fixed_on_retry(self):
+        # Logged live: {"id": 15, "speaker": "BILL", "role": "thought", ...}
+        # on a genuinely spoken quoted span.
+        bad = self._labels([1, 2, 3, 4, 5, 6])
+        bad[0]["role"] = "thought"
+        client = FakeClient(
+            FakeResponse(json.dumps(bad)),
+            FakeResponse(self._json([1])),
+        )
+        entries, stats, output = run_chunk(client, self.CHUNK)
+
+        self.assertEqual(client.calls, 2)
+        self.assertEqual(stats["role_missing"], 0, "the invalid role was filled in")
+        self.assertFalse(stats["degraded"])
+        self.assertEqual(entries[0]["speaker"], "ELENA")
+        self.assertIn("unusable role", output)
+        self.assertIn("neither \"dialogue\" nor \"narration\": 1", client.user_prompts[1])
+
+    # --- monotonicity: a retry can never make things worse ----------------
+
+    def test_worse_retry_cannot_overwrite_good_labels(self):
+        good = self._labels([1, 2, 3, 4, 5], speaker="ELENA", instruct="Firm.")
+        worse = [{"id": 1, "speaker": "WRONG", "instruct": "Sloppy."}]  # no role
+        client = FakeClient(FakeResponse(json.dumps(good)), FakeResponse(json.dumps(worse)))
+        entries, stats, _ = run_chunk(client, self.CHUNK)
+
+        self.assertEqual(joined(entries), self.CHUNK)
+        self.assertEqual(entries[0]["speaker"], "ELENA", "attempt 1's label must survive")
+        self.assertEqual(entries[0]["instruct"], "Firm.")
+        self.assertEqual(stats["fallback"], 1, "only span 6 was never labelled")
+        self.assertTrue(stats["degraded"])
+        self.assertEqual(client.calls, 3, "budget exhausted trying to fill span 6")
+
+    def test_equal_field_from_a_later_attempt_does_not_replace_it(self):
+        first = [{"id": 1, "speaker": "ELENA", "role": "dialogue", "instruct": "Firm."}]
+        second = [{"id": 1, "speaker": "BETA", "role": "dialogue", "instruct": "Soft."}]
+        client = FakeClient(FakeResponse(json.dumps(first)), FakeResponse(json.dumps(second)))
+        entries, _, _ = run_chunk(client, self.CHUNK)
+
+        self.assertEqual(entries[0]["speaker"], "ELENA")
+        self.assertEqual(entries[0]["instruct"], "Firm.")
+
+    def test_blank_fields_are_filled_but_present_ones_are_not(self):
+        first = [{"id": 1, "speaker": "", "role": "dialogue", "instruct": "Firm."}]
+        second = [{"id": 1, "speaker": "BETA", "role": "narration", "instruct": "Soft."}]
+        client = FakeClient(FakeResponse(json.dumps(first)), FakeResponse(json.dumps(second)))
+        entries, _, _ = run_chunk(client, self.CHUNK)
+
+        # speaker was blank -> filled from attempt 2; role/instruct were present -> kept.
+        self.assertEqual(entries[0]["speaker"], "BETA")
+        self.assertEqual(entries[0]["instruct"], "Firm.")
+
+    def test_good_first_attempt_survives_a_garbage_retry(self):
+        client = FakeClient(
+            FakeResponse(self._json([1, 2, 3, 4, 5])),
+            FakeResponse("I'm sorry, I cannot help with that."),
+        )
+        entries, stats, _ = run_chunk(client, self.CHUNK)
+
+        self.assertEqual(joined(entries), self.CHUNK)
+        self.assertEqual(stats["labelled"], 5, "attempt 1's labels must not be dropped")
+        self.assertEqual(stats["fallback"], 1)
+
+    # --- completeness is membership, not a count --------------------------
+
+    def test_hallucinated_ids_do_not_fake_completeness(self):
+        # Logged live: 30 labels for 28 spans, and 137 labels for 41 spans.
+        labels = self._labels([1, 2, 3, 4, 5]) + [
+            {"id": 90, "speaker": "GHOST", "role": "dialogue", "instruct": "x"},
+            {"id": 91, "speaker": "GHOST", "role": "dialogue", "instruct": "x"},
+            {"id": 92, "speaker": "GHOST", "role": "dialogue", "instruct": "x"},
+        ]
+        client = FakeClient(FakeResponse(json.dumps(labels)))
+        entries, stats, _ = run_chunk(client, self.CHUNK)
+
+        self.assertEqual(joined(entries), self.CHUNK)
+        self.assertEqual(client.calls, 3, "8 labels for 6 spans must not count as complete")
+        self.assertEqual(stats["labelled"], 5)
+        self.assertEqual(stats["fallback"], 1)
+        self.assertEqual(stats["discarded"], 3, "distinct phantom ids, counted once each")
+
+    # --- the truncation gate ----------------------------------------------
+
+    def test_truncated_partial_is_accepted_without_retry(self):
+        client = FakeClient(
+            FakeResponse(self._json([1, 2, 3]), finish_reason="length"))
+        entries, stats, _ = run_chunk(client, self.CHUNK)
+
+        self.assertEqual(client.calls, 1, "re-rolling at the same max_tokens is pointless")
+        self.assertEqual(joined(entries), self.CHUNK)
+        self.assertEqual(stats["fallback"], 3)
+        self.assertTrue(stats["degraded"])
+
+    def test_truncated_with_nothing_usable_still_retries(self):
+        # A truncated response we could not parse at all is a different failure
+        # from a truncated response that gave us partial labels.
+        client = FakeClient(FakeResponse("blah blah", finish_reason="length"))
+        _, stats, _ = run_chunk(client, self.CHUNK)
+
+        self.assertEqual(client.calls, 3)
+        self.assertTrue(stats["degraded"])
+
+    # --- budget --------------------------------------------------------------
+
+    def test_never_exceeds_the_existing_budget(self):
+        client = FakeClient(FakeResponse(self._json([1])))
+        run_chunk(client, self.CHUNK, max_retries=2)
+        self.assertEqual(client.calls, 3)
+
+        client = FakeClient(FakeResponse(self._json([1])))
+        run_chunk(client, self.CHUNK, max_retries=0)
+        self.assertEqual(client.calls, 1, "max_retries=0 means exactly one attempt")
+
+    def test_worst_recovery_mode_is_reported_across_attempts(self):
+        # attempt 1 array (partial) + attempt 2 markdown -> markdown must win,
+        # so the contract violation is not hidden behind the array.
+        client = FakeClient(
+            FakeResponse(self._json([1, 2, 3, 4, 5])),
+            FakeResponse(REAL_MARKDOWN_SPAN),
+        )
+        _, stats, _ = run_chunk(client, self.CHUNK)
+        self.assertEqual(stats["recovery"], LABEL_MODE_MARKDOWN)
+        self.assertTrue(stats["degraded"])
+
+
+class TestWhitespaceSpansOutOfTheLoop(unittest.TestCase):
+    """A "\\n\\n" between two quoted paragraphs has no audible content and its
+    label is discarded by _absorb_whitespace_groups regardless. It must never
+    reach the model, never cost a retry, and never degrade a chunk."""
+
+    CHUNK = TWO_DIALOGUE_PARAGRAPHS          # '"Hi."\n\n"Bye."'
+
+    def setUp(self):
+        self.spans = tokenize(self.CHUNK)
+        self.assertEqual(len(self.spans), 3)
+        self.assertEqual([s.id for s in self.spans], [1, 2, 3])
+        self.assertTrue(is_whitespace_span(self.spans[1], self.CHUNK),
+                        "span 2 is the paragraph break")
+
+    def _visible_labels(self):
+        return [
+            {"id": 1, "speaker": "ALPHA", "role": "dialogue", "instruct": "Bright."},
+            {"id": 3, "speaker": "BETA", "role": "dialogue", "instruct": "Flat."},
+        ]
+
+    # --- the payload -------------------------------------------------------
+
+    def test_payload_omits_the_whitespace_span(self):
+        payload = build_span_payload(self.spans, self.CHUNK)
+        lines = payload.split("\n")
+
+        self.assertEqual(len(lines), 2, "3 spans, 1 of them whitespace -> 2 payload lines")
+        ids = [json.loads(line)["id"] for line in lines]
+        self.assertEqual(ids, [1, 3], "ids stay the tokenizer's; the gap is the omission")
+        self.assertNotIn('"id": 2', payload)
+
+    def test_payload_ids_are_stable_not_renumbered(self):
+        # The reassembly contract keys on tokenizer ids; renumbering would
+        # silently misalign every label after a whitespace span.
+        payload = build_span_payload(tokenize(STRAIGHT_QUOTES), STRAIGHT_QUOTES)
+        ids = [json.loads(line)["id"] for line in payload.split("\n")]
+        self.assertEqual(ids, sorted(ids))
+
+    # --- resolution and degradation ---------------------------------------
+
+    def test_labelling_only_visible_spans_is_not_degraded(self):
+        client = FakeClient(FakeResponse(json.dumps(self._visible_labels())))
+        entries, stats, output = run_chunk(client, self.CHUNK)
+
+        self.assertEqual(client.calls, 1, "no retry for the unlabelled whitespace span")
+        self.assertEqual(joined(entries), self.CHUNK, "byte-identity unaffected")
+        self.assertFalse(stats["degraded"])
+        self.assertEqual(stats["fallback"], 0, "whitespace is not a fallback")
+        self.assertEqual(stats["whitespace"], 1)
+        self.assertEqual(stats["labelled"] + stats["fallback"], stats["spans"],
+                         "the accounting invariant test_api.py relies on")
+        self.assertNotIn("DEGRADED", output)
+
+    def test_whitespace_is_still_absorbed_into_the_preceding_entry(self):
+        client = FakeClient(FakeResponse(json.dumps(self._visible_labels())))
+        entries, _, _ = run_chunk(client, self.CHUNK)
+
+        self.assertEqual([e["speaker"] for e in entries], ["ALPHA", "BETA"])
+        self.assertEqual(entries[0]["text"], '"Hi."\n\n')
+        self.assertEqual(entries[1]["text"], '"Bye."')
+        for entry in entries:
+            self.assertTrue(entry["text"].strip())
+
+    def test_a_real_missing_span_still_degrades(self):
+        # Guard against over-suppression: omitting id 3 must still be caught.
+        client = FakeClient(FakeResponse(json.dumps(self._visible_labels()[:1])))
+        _, stats, _ = run_chunk(client, self.CHUNK)
+
+        self.assertEqual(client.calls, 3, "a genuinely missing visible span is retried")
+        self.assertEqual(stats["fallback"], 1)
+        self.assertTrue(stats["degraded"])
+
+    def test_phantom_label_for_a_whitespace_id_is_ignored(self):
+        labels = self._visible_labels() + [
+            {"id": 2, "speaker": "GHOST", "role": "dialogue", "instruct": "x"}]
+        client = FakeClient(FakeResponse(json.dumps(labels)))
+        entries, stats, _ = run_chunk(client, self.CHUNK)
+
+        self.assertEqual(joined(entries), self.CHUNK)
+        self.assertNotIn("GHOST", {e["speaker"] for e in entries})
+        self.assertFalse(stats["degraded"])
+
+    def test_all_whitespace_chunk_skips_the_llm_entirely(self):
+        client = FakeClient(FakeResponse("[]"))
+        entries, stats, _ = run_chunk(client, "\n\n")
+
+        self.assertEqual(client.calls, 0, "nothing audible to classify")
+        self.assertEqual(joined(entries), "\n\n")
+        self.assertFalse(stats["degraded"])
+        self.assertEqual(stats["whitespace"], stats["spans"])
+
+    def test_resolve_span_labels_without_source_is_unchanged(self):
+        # Back-compat: direct callers that pass no source get the old behavior.
+        resolved, stats = resolve_span_labels(self.spans, self._visible_labels())
+        self.assertEqual(stats["whitespace"], 0)
+        self.assertEqual(stats["fallback"], 1, "span 2 counts as fallback without source")
+
+
+class TestLogIsolation(unittest.TestCase):
+    """The suite must not append to the production forensic log."""
+
+    def test_log_dir_honours_the_env_override(self):
+        self.assertEqual(llm_log_dir(), os.environ["ALEXANDRIA_LLM_LOG_DIR"])
+        self.assertEqual(llm_log_dir(), _LOG_TMPDIR)
+
+    def test_process_chunk_writes_to_the_override_dir_only(self):
+        production_log = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "..", "logs", "llm_responses.log")
+        before = os.path.getsize(production_log) if os.path.exists(production_log) else None
+
+        run_chunk(FakeClient(FakeResponse("[]")), '"Hi." he said.')
+
+        override_log = os.path.join(_LOG_TMPDIR, "llm_responses.log")
+        self.assertTrue(os.path.exists(override_log), "log must land in the override dir")
+        self.assertIn("CHUNK", io.open(override_log, encoding="utf-8").read())
+
+        after = os.path.getsize(production_log) if os.path.exists(production_log) else None
+        self.assertEqual(before, after, "production log must not grow during tests")
+
+    def test_default_is_unchanged_without_the_env_var(self):
+        saved = os.environ.pop("ALEXANDRIA_LLM_LOG_DIR")
+        try:
+            self.assertEqual(llm_log_dir(), generate_script.LLM_LOG_DIR)
+            self.assertTrue(llm_log_dir().replace("\\", "/").endswith("/logs"))
+        finally:
+            os.environ["ALEXANDRIA_LLM_LOG_DIR"] = saved
+
+
 class TestSalvageAndPayload(unittest.TestCase):
     def test_salvage_label_entries_is_field_order_agnostic(self):
         text = '[{"role": "dialogue", "instruct": "Calm.", "speaker": "MARCUS", "id": 4}]'
@@ -859,12 +1200,17 @@ class TestSalvageAndPayload(unittest.TestCase):
         self.assertEqual(len(parse_label_response(text)), 1)
 
     def test_span_payload_never_contains_offsets_and_is_one_line_per_span(self):
-        payload = build_span_payload(tokenize(STRAIGHT_QUOTES), STRAIGHT_QUOTES)
+        spans = tokenize(STRAIGHT_QUOTES)
+        visible = [s for s in spans if not is_whitespace_span(s, STRAIGHT_QUOTES)]
+        self.assertLess(len(visible), len(spans), "fixture should have a whitespace span")
+
+        payload = build_span_payload(spans, STRAIGHT_QUOTES)
         lines = payload.split("\n")
-        self.assertEqual(len(lines), len(tokenize(STRAIGHT_QUOTES)))
+        self.assertEqual(len(lines), len(visible), "one line per VISIBLE span")
         for line in lines:
             record = json.loads(line)
             self.assertEqual(set(record.keys()), {"id", "kind", "text"})
+            self.assertTrue(record["text"].strip(), "whitespace spans are never shown")
 
     def test_old_salvage_export_still_present_for_review_script(self):
         # review_script.py imports these three by name.
@@ -960,7 +1306,8 @@ class TestPromptSchemaGuard(unittest.TestCase):
         entries, stats, _ = run_chunk(client, chunk)
 
         self.assertEqual(joined(entries), chunk)
-        self.assertEqual(stats["labelled"], 0)
+        self.assertEqual(stats["labelled"] - stats["whitespace"], 0,
+                         "old-schema output carries no ids, so nothing is labelled")
         self.assertTrue(stats["degraded"])
 
 

--- a/app/test_span_integration.py
+++ b/app/test_span_integration.py
@@ -1859,6 +1859,49 @@ class TestAttestationGate(unittest.TestCase):
                     client, chunk, require_attested=True, attest_window=chunk)
                 self.assertEqual(joined(entries), chunk)
 
+    def test_narrator_with_dialogue_role_is_never_gated(self):
+        # NARRATOR is the narrator sentinel, not a name. The word "Narrator"
+        # appears in no novel, so attesting it rejected the narrator itself and
+        # falsely degraded the chunk. The prompt explicitly tells the model to
+        # use NARRATOR for an unidentifiable speaker, so this fires constantly.
+        chunk = STRAIGHT_QUOTES
+        labels = labels_for(chunk, speaker_of=lambda span, text: "NARRATOR")
+        for label in labels:
+            label["role"] = "dialogue"  # the shape observed live
+        client = FakeClient(FakeResponse(json.dumps(labels)))
+        entries, stats, _ = run_chunk(
+            client, chunk, require_attested=True, attest_window=chunk)
+        check = self.assertEqual
+        check(stats["unattested_rejected"], 0)
+        check(stats["degraded"], False)
+        self.assertEqual(joined(entries), chunk)
+
+    def test_gate_and_retry_predicate_agree_on_every_label(self):
+        # The invariant _incomplete_span_ids' docstring states for roles, held
+        # here for speakers: whatever the gate would REJECT is exactly what the
+        # retry predicate must ASK about. If they diverge, a label is either
+        # silently rejected with no retry (what NARRATOR did) or nagged about
+        # forever without ever being refused.
+        chunk = STRAIGHT_QUOTES
+        spans = tokenize(chunk)
+        for speaker in ("NARRATOR", "MARCUS", "ZZQXAL", "MISTER", "SPEAKER 1"):
+            with self.subTest(speaker=speaker):
+                labels = labels_for(chunk, speaker_of=lambda s, t: speaker)
+                for label in labels:
+                    label["role"] = "dialogue"
+                merged = {generate_script._label_id(l): l for l in labels}
+
+                asked = generate_script._unattested_speaker_ids(
+                    spans, merged, source=chunk, roster=None, attest_window=chunk)
+                _, stats = resolve_span_labels(
+                    spans, labels, source=chunk, roster={},
+                    attest_window=chunk, require_attested=True)
+
+                self.assertEqual(
+                    bool(asked), bool(stats["unattested_rejected"]),
+                    f"retry predicate and gate disagree for {speaker!r}: "
+                    f"asked={len(asked)} rejected={stats['unattested_rejected']}")
+
     def test_no_window_means_no_confirmation(self):
         # Guards against a caller enabling the gate without supplying a window
         # and silently narrating the whole book: with no window, an

--- a/app/test_span_integration.py
+++ b/app/test_span_integration.py
@@ -45,7 +45,7 @@ os.environ["ALEXANDRIA_LLM_LOG_DIR"] = _LOG_TMPDIR
 atexit.register(shutil.rmtree, _LOG_TMPDIR, True)
 
 from default_prompts import DEFAULT_SYSTEM_PROMPT, DEFAULT_USER_PROMPT  # noqa: E402
-from span_tokenizer import tokenize  # noqa: E402
+from span_tokenizer import Span, tokenize  # noqa: E402
 import generate_script  # noqa: E402
 from generate_script import (  # noqa: E402
     DEFAULT_NARRATOR_INSTRUCT,
@@ -573,8 +573,17 @@ class TestLabelResolution(unittest.TestCase):
         labels = [{"id": s.id, "speaker": "ELENA", "role": "dialogue"} for s in spans]
         resolved, _ = resolve_span_labels(spans, labels)
         entries = build_entries(resolved, chunk)
-        self.assertEqual(len(entries), 1)
-        self.assertEqual(entries[0]["instruct"], generate_script.DEFAULT_CHARACTER_INSTRUCT)
+        # The narration between the two quotations is handed back to NARRATOR
+        # (see TestNarrationNeverGetsACharacterVoice), so the chunk is three
+        # entries, each carrying the default instruct for its own speaker.
+        self.assertEqual(joined(entries), chunk)
+        for entry in entries:
+            self.assertEqual(
+                entry["instruct"],
+                generate_script.DEFAULT_NARRATOR_INSTRUCT
+                if entry["speaker"] == NARRATOR
+                else generate_script.DEFAULT_CHARACTER_INSTRUCT,
+            )
 
     def test_entry_schema_has_no_extra_fields(self):
         chunk = STRAIGHT_QUOTES
@@ -762,6 +771,94 @@ class TestMisspelledKeyRecovery(unittest.TestCase):
         self.assertIn("Recovered misspelled key", output)
         for entry in entries:
             self.assertNotEqual(entry["instruct"], "")
+
+
+class TestNarrationNeverGetsACharacterVoice(unittest.TestCase):
+    """A character-voiced entry must never also contain narration.
+
+    The renderer gives one entry one voice, so a quotation merged with the
+    attribution tag beside it means the tag is spoken by the character.
+    """
+
+    @staticmethod
+    def _entries(chunk, speaker_of=lambda span: "ELENA"):
+        # NOT labels_for(): that one forces every unquoted span to narration,
+        # which is precisely the classifier mistake under test here.
+        labels = [
+            {"id": span.id, "speaker": speaker_of(span), "role": "dialogue",
+             "instruct": "Flat."}
+            for span in tokenize(chunk)
+        ]
+        entries, _, _ = run_chunk(FakeClient(FakeResponse(json.dumps(labels))), chunk)
+        return entries
+
+    def test_mislabelled_attribution_tag_is_handed_back_to_narrator(self):
+        chunk = '"Go," he said.'
+        entries = self._entries(chunk)
+
+        self.assertEqual(joined(entries), chunk, "text must stay byte-identical")
+        self.assertEqual([e["speaker"] for e in entries], ["ELENA", NARRATOR])
+        self.assertEqual(entries[0]["text"], '"Go,"')
+        self.assertEqual(entries[1]["text"], " he said.")
+
+    def test_no_entry_mixes_quoted_and_unquoted_under_a_character(self):
+        for name, chunk in FIXTURES.items():
+            with self.subTest(fixture=name):
+                entries = self._entries(chunk)
+                self.assertEqual(joined(entries), chunk)
+                for entry in entries:
+                    if entry["speaker"] == NARRATOR:
+                        continue
+                    kinds = {span.kind for span in tokenize(entry["text"])
+                             if entry["text"][span.start:span.end].strip()}
+                    self.assertLessEqual(len(kinds), 1,
+                                         f"{name}: mixed-kind character entry {entry!r}")
+
+    def test_adjacent_quotations_by_one_speaker_still_merge(self):
+        # Merging same-kind spans is the win worth keeping: one TTS call, not
+        # two. Only the mixed-kind merge was ever the problem.
+        chunk = '"Wait." "Please."'
+        entries = self._entries(chunk)
+
+        self.assertEqual(joined(entries), chunk)
+        self.assertEqual([e["speaker"] for e in entries], ["ELENA"])
+
+    def test_standalone_unquoted_speech_keeps_its_character(self):
+        # Unquoted character speech is real (telepathy, silent speech, an
+        # animal's voice). Nothing beside this span is a quotation by the same
+        # speaker, so no structural rule can call it narration -- and a blanket
+        # "unquoted implies NARRATOR" would silence every such line.
+        chunk = "Come on, the dog said into her mind."
+        entries = self._entries(chunk)
+
+        self.assertEqual(joined(entries), chunk)
+        self.assertEqual([e["speaker"] for e in entries], ["ELENA"])
+
+    def test_merge_refuses_to_bridge_kinds_even_without_the_relabel(self):
+        # build_entries' last line of defence, reached when adjacency did not
+        # apply (a chunk boundary, a whitespace span between the two). Spans
+        # are built by hand because the tokenizer never emits two consecutive
+        # unquoted spans.
+        source = '"Hi."\n\nElena left.'
+        resolved = [
+            (Span(1, 0, 5, "quoted"), "ELENA", None),
+            (Span(2, 5, 7, "unquoted"), NARRATOR, None),      # the break
+            (Span(3, 7, len(source), "unquoted"), "ELENA", None),
+        ]
+        entries = build_entries(resolved, source)
+
+        self.assertEqual(joined(entries), source)
+        self.assertEqual([e["text"] for e in entries], ['"Hi."\n\n', "Elena left."])
+
+    def test_an_absorbed_paragraph_break_is_not_a_bridge(self):
+        # The break between two quotations is absorbed into the preceding
+        # entry; that must not let the narration after them merge back in.
+        chunk = '"Hi."\n\n"Bye."\n\nElena put down the map.'
+        entries = self._entries(chunk)
+
+        self.assertEqual(joined(entries), chunk)
+        self.assertEqual([e["speaker"] for e in entries], ["ELENA", NARRATOR])
+        self.assertEqual(entries[0]["text"], '"Hi."\n\n"Bye."')
 
 
 class TestNoWhitespaceOnlyEntries(unittest.TestCase):
@@ -2080,17 +2177,6 @@ class TestAttestationGate(unittest.TestCase):
         self.assertEqual(stats["unattested_rejected"], 0)
         self.assertEqual(stats["unverifiable_accepted"], 2)
         self.assertIn("MISTER", [e["speaker"] for e in entries])
-
-    def test_gate_never_touches_prose(self):
-        # Contract 2/4 under every gate outcome, including the rejecting one.
-        chunk = CURLY_QUOTES
-        for speaker in ("ZZQXAL", "MARCUS", "MISTER"):
-            with self.subTest(speaker=speaker):
-                client = FakeClient(*[FakeResponse(json.dumps(labels_for(
-                    chunk, speaker_of=lambda span, text: speaker)))] * 3)
-                entries, _, _ = run_chunk(
-                    client, chunk, require_attested=True, attest_window=chunk)
-                self.assertEqual(joined(entries), chunk)
 
     def test_narrator_with_dialogue_role_is_never_gated(self):
         # NARRATOR is the narrator sentinel, not a name. The word "Narrator"

--- a/app/test_span_integration.py
+++ b/app/test_span_integration.py
@@ -78,7 +78,7 @@ from generate_script import (  # noqa: E402
     looks_silently_truncated,
     strip_thinking_tags,
 )
-from speaker_canon import remember_in_roster
+from speaker_canon import remember_in_roster, source_word_index
 
 
 # --------------------------------------------------------------------------
@@ -646,6 +646,51 @@ class TestRoleMissingDegrades(unittest.TestCase):
         self.assertFalse(stats["degraded"])
 
 
+class TestUnknownLabelKeysAreVisible(unittest.TestCase):
+    """A key outside the schema is discarded -- but never silently.
+
+    Observed in production: the model wrote "instituct" instead of "instruct",
+    so the delivery direction vanished with no counter and no warning. Nothing
+    is repaired here (no fuzzy key matching); the discard is only reported.
+    """
+
+    def test_misspelled_key_is_counted_and_logged(self):
+        chunk = STRAIGHT_QUOTES
+        labels = labels_for(chunk)
+        for label in labels:
+            label["instituct"] = label.pop("instruct")
+        _, stats, output = run_chunk(FakeClient(FakeResponse(json.dumps(labels))), chunk)
+
+        self.assertEqual(stats["unknown_key_labels"], len(labels))
+        self.assertEqual(stats["unknown_keys"], ["instituct"])
+        self.assertIn("instituct", output)
+        self.assertIn("Ignored unknown key", output)
+        self.assertEqual(stats["text_key_labels"], 0)
+
+    def test_known_schema_produces_no_warning(self):
+        chunk = STRAIGHT_QUOTES
+        labels = labels_for(chunk)
+        _, stats, output = run_chunk(FakeClient(FakeResponse(json.dumps(labels))), chunk)
+
+        self.assertEqual(stats["unknown_key_labels"], 0)
+        self.assertEqual(stats["unknown_keys"], [])
+        self.assertEqual(stats["text_key_labels"], 0)
+        self.assertNotIn("Ignored unknown key", output)
+
+    def test_text_key_is_not_honoured_and_is_reported_on_its_own(self):
+        chunk = STRAIGHT_QUOTES
+        labels = labels_for(chunk)
+        for label in labels:
+            label["text"] = "MODEL-INVENTED PROSE"
+        entries, stats, output = run_chunk(FakeClient(FakeResponse(json.dumps(labels))), chunk)
+
+        self.assertEqual(joined(entries), chunk, "prose must come from the source only")
+        for entry in entries:
+            self.assertNotIn("MODEL-INVENTED PROSE", entry["text"])
+        self.assertEqual(stats["text_key_labels"], len(labels))
+        self.assertIn('"text" key', output)
+
+
 class TestNoWhitespaceOnlyEntries(unittest.TestCase):
     """A paragraph break between two speakers must not become its own entry."""
 
@@ -964,6 +1009,65 @@ class TestRetryOnIncompleteLabels(unittest.TestCase):
         self.assertIn("unusable role", output)
         self.assertIn("neither \"dialogue\" nor \"narration\": 1", client.user_prompts[1])
 
+    def test_dialogue_without_speaker_is_retried(self):
+        # role is good and says "dialogue", but no name came with it. Before the
+        # predicate had a branch for it this was neither missing, nor bad-role,
+        # nor unattested, so the loop broke on attempt 1 and the span was
+        # narrated in silence -- 26/27 such labels on a live chunk, ZERO retries.
+        bad = self._labels([1, 2, 3, 4, 5, 6])
+        bad[0]["speaker"] = ""
+        client = FakeClient(
+            FakeResponse(json.dumps(bad)),
+            FakeResponse(self._json([1])),
+        )
+        entries, stats, output = run_chunk(client, self.CHUNK)
+
+        self.assertEqual(client.calls, 2, "the gap must be retried, not swallowed")
+        self.assertEqual(stats["dialogue_without_speaker"], 0, "the retry filled it")
+        self.assertFalse(stats["degraded"])
+        self.assertEqual(entries[0]["speaker"], "ELENA")
+        self.assertEqual(joined(entries), self.CHUNK)
+        self.assertIn("no speaker", output)
+        self.assertIn('no usable "speaker"', client.user_prompts[1])
+        self.assertIn("1", client.user_prompts[1])
+
+    def test_narrator_dialogue_label_is_not_retried(self):
+        # NARRATOR is a usable name, so resolve_span_labels does not count it as
+        # dialogue_without_speaker -- the predicate must not nag about it either.
+        labels = self._labels([1, 2, 3, 4, 5, 6], speaker="NARRATOR")
+        for label in labels:
+            label["role"] = "dialogue"
+        client = FakeClient(FakeResponse(json.dumps(labels)))
+        _, stats, _ = run_chunk(client, self.CHUNK)
+        self.assertEqual(client.calls, 1, "nothing to correct")
+        self.assertEqual(stats["dialogue_without_speaker"], 0)
+
+    def test_predicate_and_resolver_agree_on_every_label_shape(self):
+        # The recurring failure mode in this file: _incomplete_span_ids and
+        # resolve_span_labels drift apart, so a label is either nagged about
+        # without ever being counted, or counted without ever being retried.
+        # Property, not fixture: sweep the label shapes and assert agreement.
+        speakers = [None, "", "   ", "ELENA", "NARRATOR", "narrator", 7]
+        roles = [None, "", "dialogue", "DIALOGUE ", "narration", "thought"]
+        for speaker in speakers:
+            for role in roles:
+                label = {"id": 1}
+                if speaker is not None:
+                    label["speaker"] = speaker
+                if role is not None:
+                    label["role"] = role
+                with self.subTest(speaker=speaker, role=role):
+                    _, bad_role, no_speaker = generate_script._incomplete_span_ids(
+                        self.spans, {1: label}, source=self.CHUNK)
+                    _, stats = resolve_span_labels(
+                        self.spans, [label], source=self.CHUNK, roster={})
+                    self.assertEqual(
+                        1 in bad_role, bool(stats["role_missing"]),
+                        "bad_role must mirror role_missing exactly")
+                    self.assertEqual(
+                        1 in no_speaker, bool(stats["dialogue_without_speaker"]),
+                        "no_speaker must mirror dialogue_without_speaker exactly")
+
     # --- monotonicity: a retry can never make things worse ----------------
 
     def test_worse_retry_cannot_overwrite_good_labels(self):
@@ -1209,6 +1313,62 @@ class TestSalvageAndPayload(unittest.TestCase):
         text = '[{"id": 1, "speaker": "A", "role": "dialogue", "instruct": "x"}, {"id": 2, "speaker": "B"'
         labels = salvage_label_entries(text)
         self.assertEqual([label["id"] for label in labels], [1, 2])
+
+    # --- unquoted (bareword) values: complete output, invalid JSON ---------
+    #
+    # Observed live: {"id": 1, "speaker": KIT, "role": dialogue, "instruct": "x"}
+    # at finish_reason=stop. The quoted-only patterns dropped speaker and role in
+    # silence, collapsing whole chunks into a single NARRATOR entry.
+
+    def test_salvage_recovers_bareword_speaker_and_role(self):
+        text = '[{"id": 1, "speaker": KIT, "role": dialogue, "instruct": "Angry."}]'
+        labels = salvage_label_entries(text)
+        self.assertEqual(labels, [{"id": 1, "speaker": "KIT", "role": "dialogue",
+                                   "instruct": "Angry."}])
+
+    def test_bareword_value_does_not_bleed_into_the_next_key(self):
+        # The terminator rules are the whole safety story here: a greedy value
+        # would swallow `, "role": ...` and produce a speaker named after the
+        # rest of the object.
+        cases = [
+            '[{"id": 2, "speaker": ROSHAUN\'S FATHER, "role": dialogue, "instruct": "x"}]',
+            '[{"id": 2, "role": dialogue, "speaker": ROSHAUN\'S FATHER, "instruct": "x"}]',
+            '[{"id": 2, "instruct": "x", "role": dialogue, "speaker": ROSHAUN\'S FATHER}]',
+        ]
+        for text in cases:
+            with self.subTest(text=text):
+                label = salvage_label_entries(text)[0]
+                self.assertEqual(label["speaker"], "ROSHAUN'S FATHER")
+                self.assertEqual(label["role"], "dialogue")
+
+    def test_bareword_fallback_never_preempts_a_quoted_value(self):
+        text = '[{"id": 3, "speaker": "MARCUS", "role": "narration", "instruct": "Calm."}]'
+        self.assertEqual(
+            salvage_label_entries(text),
+            [{"id": 3, "speaker": "MARCUS", "role": "narration", "instruct": "Calm."}])
+
+    def test_bareword_json_literals_are_not_names(self):
+        text = '[{"id": 4, "speaker": null, "role": dialogue, "instruct": "x"}]'
+        label = salvage_label_entries(text)[0]
+        self.assertNotIn("speaker", label, "`null` means no answer, not a character")
+
+    def test_bareword_instruct_is_not_salvaged(self):
+        # Deliberate: instruct was always quoted in the logged failures, and it
+        # is free prose whose commas make an unterminated scan unsafe.
+        text = '[{"id": 5, "speaker": KIT, "role": dialogue, "instruct": Angry, loud.}]'
+        label = salvage_label_entries(text)[0]
+        self.assertEqual(label["speaker"], "KIT")
+        self.assertNotIn("instruct", label)
+
+    def test_bareword_salvage_is_announced(self):
+        chunk = '"One." said A.'
+        text = '[{"id": 1, "speaker": KIT, "role": dialogue, "instruct": "Angry."}]'
+        client = FakeClient(FakeResponse(text))
+        entries, _, output = run_chunk(client, chunk)
+        self.assertEqual(joined(entries), chunk)
+        self.assertEqual(entries[0]["speaker"], "KIT",
+                         "the cast must survive a model that forgot its quotes")
+        self.assertIn("Salvaged unquoted", output)
 
     def test_parse_label_response_handles_clean_json(self):
         text = '[{"id": 1, "speaker": "A", "role": "dialogue", "instruct": "x"}]'
@@ -1901,6 +2061,138 @@ class TestAttestationGate(unittest.TestCase):
                     bool(asked), bool(stats["unattested_rejected"]),
                     f"retry predicate and gate disagree for {speaker!r}: "
                     f"asked={len(asked)} rejected={stats['unattested_rejected']}")
+
+    def test_gate_and_retry_predicate_agree_on_repaired_labels_too(self):
+        # The same invariant with repair in play, which is exactly where it is
+        # easiest to break: a label the gate silently REPAIRS must not be one
+        # the retry predicate keeps nagging about, and vice versa. Both go
+        # through _gate_speaker, and this pins that they still do.
+        chunk = 'Marcus and Marcas leaned over the map. "Then go."\n'
+        spans = tokenize(chunk)
+        source_words = source_word_index(chunk)
+        roster = {}
+        remember_in_roster(roster, "MARCUS")
+        # MARCVS repairs (unique candidate), MARCS is ambiguous (two roster
+        # names one edit away), ZZQXAL has no candidate at all.
+        ambiguous_roster = dict(roster)
+        remember_in_roster(ambiguous_roster, "MARCAS")
+        cases = [
+            ("MARCVS", roster, False),
+            ("MARCS", ambiguous_roster, True),
+            ("ZZQXAL", roster, True),
+            ("MARCUS", roster, False),
+        ]
+        for speaker, book_roster, expect_rejected in cases:
+            with self.subTest(speaker=speaker):
+                labels = labels_for(chunk, speaker_of=lambda s, t: speaker)
+                for label in labels:
+                    label["role"] = "dialogue"
+                merged = {generate_script._label_id(l): l for l in labels}
+
+                asked = generate_script._unattested_speaker_ids(
+                    spans, merged, source=chunk, roster=book_roster,
+                    attest_window=chunk, source_words=source_words)
+                _, stats = resolve_span_labels(
+                    spans, labels, source=chunk, roster=book_roster,
+                    attest_window=chunk, require_attested=True,
+                    source_words=source_words)
+
+                self.assertEqual(
+                    bool(asked), bool(stats["unattested_rejected"]),
+                    f"retry predicate and gate disagree for {speaker!r}: "
+                    f"asked={len(asked)} rejected={stats['unattested_rejected']}")
+                self.assertEqual(bool(stats["unattested_rejected"]), expect_rejected,
+                                 f"unexpected gate outcome for {speaker!r}")
+
+    def test_label_built_on_a_roster_name_is_accepted_as_unverifiable(self):
+        # Change 1: "<established name>'S FATHER" is not positive evidence of a
+        # WRONG label, so it must not be refused. The voice is kept and the
+        # acceptance is counted.
+        chunk = STRAIGHT_QUOTES  # names "Marcus"
+        roster = {}
+        remember_in_roster(roster, "MARCUS")
+        client = FakeClient(FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=lambda span, text: "MARCUS'S FATHER"))))
+        entries, stats, _ = run_chunk(
+            client, chunk, require_attested=True, attest_window=chunk,
+            roster=roster)
+        self.assertEqual(stats["unattested_rejected"], 0)
+        # Counted once: accepting it establishes it, and the second span then
+        # takes the established-roster shortcut.
+        self.assertEqual(stats["unverifiable_accepted"], 1)
+        self.assertIn("MARCUS'S FATHER", [e["speaker"] for e in entries])
+
+    def test_repair_keeps_the_voice_without_spending_a_retry(self):
+        # Change 2, and its whole economic argument: a misread spelling the
+        # book never uses, one edit from an established name that is right
+        # there in the window, is repaired in place -- ONE LLM call, no retry,
+        # and the line keeps a character voice instead of being narrated.
+        chunk = STRAIGHT_QUOTES  # names "Marcus", never "MARCVS"
+        roster = {}
+        remember_in_roster(roster, "MARCUS")
+        client = FakeClient(FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=lambda span, text: "MARCVS"))))
+        entries, stats, output = run_chunk(
+            client, chunk, require_attested=True, attest_window=chunk,
+            roster=roster, source_words=source_word_index(chunk))
+
+        self.assertEqual(len(client.user_prompts), 1,
+                         "repair must not cost a retry")
+        self.assertIn("MARCUS", [e["speaker"] for e in entries])
+        self.assertNotIn("MARCVS", [e["speaker"] for e in entries])
+        self.assertEqual(stats["unattested_rejected"], 0)
+        self.assertEqual(stats["speakers_repaired"], 2)
+        self.assertEqual(stats["repairs"], [("MARCVS", "MARCUS")] * 2)
+        self.assertFalse(stats["degraded"])
+        # Contract 7: a rewritten name is never silent.
+        self.assertIn("REPAIRED", output)
+        self.assertIn("MARCVS", output)
+        # And prose is untouched, as under every other gate outcome.
+        self.assertEqual(joined(entries), chunk)
+
+    def test_repair_is_unavailable_without_a_book_word_index(self):
+        # The default is the old behaviour: no book index, no repair.
+        chunk = STRAIGHT_QUOTES
+        roster = {}
+        remember_in_roster(roster, "MARCUS")
+        client = FakeClient(*[FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=lambda span, text: "MARCVS")))] * 3)
+        _, stats, _ = run_chunk(client, chunk, require_attested=True,
+                                attest_window=chunk, roster=roster)
+        self.assertEqual(stats["speakers_repaired"], 0)
+        self.assertEqual(stats["unattested_rejected"], 2)
+
+    def test_ambiguous_repair_is_refused_and_retried(self):
+        # Two established names one edit away: the evidence does not pick a
+        # winner, so the label is refused and the retry fires as before.
+        chunk = 'Marcus and Marcas leaned over the map. "Then go."\n'
+        roster = {}
+        remember_in_roster(roster, "MARCUS")
+        remember_in_roster(roster, "MARCAS")
+        client = FakeClient(*[FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=lambda span, text: "MARCS")))] * 3)
+        entries, stats, _ = run_chunk(
+            client, chunk, require_attested=True, attest_window=chunk,
+            roster=roster, source_words=source_word_index(chunk))
+        self.assertEqual(stats["speakers_repaired"], 0)
+        self.assertGreater(stats["unattested_rejected"], 0)
+        self.assertGreater(len(client.user_prompts), 1, "a retry should have fired")
+        self.assertEqual(joined(entries), chunk)
+
+    def test_retry_nudge_offers_candidate_spellings_when_repair_declines(self):
+        # A free prompt hint, not a mechanism: the gate still re-checks
+        # whatever comes back.
+        chunk = 'Marcus and Marcas leaned over the map. "Then go."\n'
+        roster = {}
+        remember_in_roster(roster, "MARCUS")
+        remember_in_roster(roster, "MARCAS")
+        client = FakeClient(*[FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=lambda span, text: "MARCS")))] * 3)
+        run_chunk(client, chunk, require_attested=True, attest_window=chunk,
+                  roster=roster, source_words=source_word_index(chunk))
+        retry_prompt = client.user_prompts[1]
+        self.assertIn("did you mean", retry_prompt)
+        self.assertIn("MARCUS", retry_prompt)
 
     def test_no_window_means_no_confirmation(self):
         # Guards against a caller enabling the gate without supplying a window

--- a/app/test_span_integration.py
+++ b/app/test_span_integration.py
@@ -1,0 +1,991 @@
+#!/usr/bin/env python
+"""Standalone integration tests for the span-classifier stage of generate_script.py.
+
+Run directly -- no pytest, no live server, no real LLM:
+
+    python app/test_span_integration.py
+
+Exits 0 when every test passes, nonzero otherwise.
+
+The contract under test: whatever the LLM does -- label everything, label half,
+return garbage, or fall over entirely -- the entries built for a chunk always
+concatenate back to that chunk BYTE FOR BYTE. Failure costs speaker labels,
+never prose.
+"""
+
+import io
+import json
+import os
+import sys
+import types
+import unittest
+from contextlib import redirect_stdout
+
+# Windows consoles default to cp1252; the fixtures contain curly quotes.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from default_prompts import DEFAULT_SYSTEM_PROMPT, DEFAULT_USER_PROMPT  # noqa: E402
+from span_tokenizer import tokenize  # noqa: E402
+import generate_script  # noqa: E402
+from generate_script import (  # noqa: E402
+    DEFAULT_NARRATOR_INSTRUCT,
+    LABEL_MODE_ARRAY,
+    LABEL_MODE_MARKDOWN,
+    LABEL_MODE_OBJECT,
+    LABEL_MODE_SALVAGE,
+    NARRATOR,
+    PROMPT_SCHEMA_MARKER,
+    build_entries,
+    build_span_payload,
+    extract_labels,
+    labels_from_id_keyed_object,
+    parse_label_response,
+    process_chunk,
+    resolve_span_labels,
+    salvage_label_entries,
+    salvage_markdown_labels,
+    select_prompt,
+    strip_thinking_tags,
+)
+
+
+# --------------------------------------------------------------------------
+# Fixtures
+# --------------------------------------------------------------------------
+
+STRAIGHT_QUOTES = (
+    '"I am leaving," he said.\n'
+    '\n'
+    'Marcus did not look up from the map. "Then go."\n'
+)
+
+CURLY_QUOTES = (
+    "“You were never going to tell me,” she said. It wasn’t a question.\n"
+    "\n"
+    "“I was,” Marcus answered. “I was waiting for the right hour.”\n"
+)
+
+ATTRIBUTION_MID_SENTENCE = (
+    '"We should leave," he said, pulling on his coat, "now, before they notice."'
+)
+
+# Two bare dialogue paragraphs: the blank line between them is its own
+# unquoted span, and must never become a whitespace-only entry.
+TWO_DIALOGUE_PARAGRAPHS = '"Hi."\n\n"Bye."'
+
+FIXTURES = {
+    "straight": STRAIGHT_QUOTES,
+    "curly": CURLY_QUOTES,
+    "mid_sentence": ATTRIBUTION_MID_SENTENCE,
+    "two_dialogue_paragraphs": TWO_DIALOGUE_PARAGRAPHS,
+}
+
+
+# --------------------------------------------------------------------------
+# REAL response shapes, excerpted verbatim from logs/llm_responses.log
+# (live runs against Ollama). Trimmed to the first few spans; the trailing
+# double spaces in the markdown fixtures are markdown hard breaks and are
+# present in the originals -- keep them.
+# --------------------------------------------------------------------------
+
+# qwen3:30b-a3b-q4_K_M, CHUNK 1/4 attempt 2: valid JSON, wrong envelope.
+REAL_ID_KEYED_OBJECT = (
+    '{\n'
+    '  "1": {"speaker": "NARRATOR", "role": "narration", "instruct": "Neutral narration"},\n'
+    '  "2": {"speaker": "NARRATOR", "role": "dialogue", "instruct": "Speaking with confidence"},\n'
+    '  "3": {"speaker": "NARRATOR", "role": "narration", "instruct": "Neutral narration"},\n'
+    '  "4": {"speaker": "NARRATOR", "role": "dialogue", "instruct": "Speaking with conviction"},\n'
+    '  "5": {"speaker": "NARRATOR", "role": "narration", "instruct": "Neutral narration"},\n'
+    '  "6": {"speaker": "BILL", "role": "dialogue", "instruct": "Speaking with certainty"}\n'
+    '}'
+)
+
+# qwen3:30b-a3b-q4_K_M, CHUNK 1/4 attempt 3: "**Span N**" markdown blocks.
+REAL_MARKDOWN_SPAN = (
+    "Here is the classification for each span:\n"
+    "\n"
+    "---\n"
+    "\n"
+    "**Span 1**  \n"
+    "- **Speaker**: NARRATOR  \n"
+    "- **Role**: narration  \n"
+    "- **Instruct**: \"Neutral, even narration.\"  \n"
+    "\n"
+    "**Span 2**  \n"
+    "- **Speaker**: NARRATOR  \n"
+    "- **Role**: dialogue  \n"
+    "- **Instruct**: \"Calm, conversational tone.\"  \n"
+    "\n"
+    "**Span 3**  \n"
+    "- **Speaker**: BILL  \n"
+    "- **Role**: dialogue  \n"
+    "- **Instruct**: \"Speaking with certainty.\"  \n"
+)
+
+# qwen3:30b-a3b-q4_K_M, CHUNK 1/4 attempt 1: the "**id N**" header variant.
+REAL_MARKDOWN_ID = (
+    "Here is the classification for each span based on the rules provided:\n"
+    "\n"
+    "---\n"
+    "\n"
+    "**id 1**  \n"
+    "- **Speaker**: NARRATOR  \n"
+    "- **Role**: narration  \n"
+    "- **Instruct**: \"Neutral, descriptive tone.\"  \n"
+    "\n"
+    "**id 2**  \n"
+    "- **Speaker**: NARRATOR  \n"
+    "- **Role**: dialogue  \n"
+    "- **Instruct**: \"Confident, persuasive tone.\"  \n"
+    "\n"
+    "**id 3**  \n"
+    "- **Speaker**: BILL  \n"
+    "- **Role**: dialogue  \n"
+    "- **Instruct**: \"Calm, matter-of-fact.\"  \n"
+)
+
+# A hard truncation (finish_reason=length) preceded by a reasoning block whose
+# id-like fragments a bare regex salvage would mistake for labels. One live run
+# discarded 96 phantom ids this way.
+REAL_THINK_POLLUTED_TRUNCATION = (
+    "<think>\n"
+    "Okay, let me work through this. Span 500 looks like narration, so maybe\n"
+    '{"id": 500, "speaker": "GHOST", "role": "dialogue", "instruct": "x"} and\n'
+    '{"id": 501, "speaker": "PHANTOM", "role": "dialogue", "instruct": "y"}.\n'
+    "Actually no, let me start over and emit the real array.\n"
+    "</think>\n"
+    '[{"id": 1, "speaker": "NARRATOR", "role": "narr'
+)
+
+
+# --------------------------------------------------------------------------
+# Fake OpenAI-shaped client
+# --------------------------------------------------------------------------
+
+class _FakeMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content, finish_reason):
+        self.message = _FakeMessage(content)
+        self.finish_reason = finish_reason
+
+
+class FakeResponse:
+    """Minimal stand-in for an OpenAI ChatCompletion response."""
+
+    def __init__(self, content, finish_reason="stop"):
+        self.choices = [_FakeChoice(content, finish_reason)]
+        self.usage = None
+
+
+class _FakeCompletions:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = 0
+        self.last_kwargs = None
+
+    def create(self, **kwargs):
+        self.calls += 1
+        self.last_kwargs = kwargs
+        index = min(self.calls - 1, len(self.responses) - 1)
+        item = self.responses[index]
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+class FakeClient:
+    """Injectable client: process_chunk only ever calls chat.completions.create."""
+
+    def __init__(self, *responses):
+        self.completions = _FakeCompletions(responses)
+        self.chat = types.SimpleNamespace(completions=self.completions)
+
+    @property
+    def calls(self):
+        return self.completions.calls
+
+    @property
+    def last_user_prompt(self):
+        return self.completions.last_kwargs["messages"][1]["content"]
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+def labels_for(source, speaker_of=None):
+    """Build a well-formed label array covering every span of `source`.
+
+    `speaker_of(span, text)` returns the character name for a quoted span;
+    default is ELENA. Unquoted spans are always narration.
+    """
+    labels = []
+    for span in tokenize(source):
+        if span.kind == "quoted":
+            name = speaker_of(span, span.text(source)) if speaker_of else "ELENA"
+            labels.append({
+                "id": span.id,
+                "speaker": name,
+                "role": "dialogue",
+                "instruct": "Flat, controlled delivery.",
+            })
+        else:
+            labels.append({
+                "id": span.id,
+                "speaker": "NARRATOR",
+                "role": "narration",
+                "instruct": DEFAULT_NARRATOR_INSTRUCT,
+            })
+    return labels
+
+
+def run_chunk(client, chunk, **kwargs):
+    """Call process_chunk with the real default prompts, capturing its output."""
+    buffer = io.StringIO()
+    options = dict(
+        system_prompt=DEFAULT_SYSTEM_PROMPT,
+        user_prompt_template=DEFAULT_USER_PROMPT,
+        max_retries=2,
+    )
+    options.update(kwargs)
+    with redirect_stdout(buffer):
+        entries, stats = process_chunk(client, "fake-model", chunk, 1, 1, **options)
+    return entries, stats, buffer.getvalue()
+
+
+def joined(entries):
+    return "".join(entry["text"] for entry in entries)
+
+
+# --------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------
+
+class TestFullLabelling(unittest.TestCase):
+    """The happy path: the LLM labels every span."""
+
+    def test_dialogue_heavy_chunk_is_verbatim(self):
+        chunk = STRAIGHT_QUOTES
+        client = FakeClient(FakeResponse(json.dumps(labels_for(chunk))))
+        entries, stats, _ = run_chunk(client, chunk)
+
+        self.assertEqual(joined(entries), chunk, "entries must rebuild the chunk byte-for-byte")
+        self.assertFalse(stats["degraded"])
+        self.assertEqual(stats["fallback"], 0)
+        self.assertEqual(stats["labelled"], stats["spans"])
+        self.assertEqual(client.calls, 1)
+
+    def test_quoted_spans_get_characters_and_tags_stay_narrator(self):
+        chunk = STRAIGHT_QUOTES
+        client = FakeClient(FakeResponse(json.dumps(labels_for(chunk))))
+        entries, _, _ = run_chunk(client, chunk)
+
+        speakers = [entry["speaker"] for entry in entries]
+        self.assertIn("ELENA", speakers)
+        self.assertIn(NARRATOR, speakers)
+
+        # The attribution tag is narrated, verbatim, tag included.
+        narrator_text = "".join(e["text"] for e in entries if e["speaker"] == NARRATOR)
+        self.assertIn(" he said.", narrator_text)
+        # ...and the quote keeps its quotation marks.
+        elena_text = "".join(e["text"] for e in entries if e["speaker"] == "ELENA")
+        self.assertIn('"I am leaving,"', elena_text)
+
+    def test_speakers_are_canonicalized_uppercase(self):
+        chunk = STRAIGHT_QUOTES
+        raw_names = iter(["  elena ", "Dr. Vance"])
+        labels = labels_for(chunk, speaker_of=lambda span, text: next(raw_names))
+        client = FakeClient(FakeResponse(json.dumps(labels)))
+        entries, _, _ = run_chunk(client, chunk)
+
+        speakers = {entry["speaker"] for entry in entries}
+        self.assertIn("ELENA", speakers)
+        self.assertIn("VANCE", speakers, "honorific must be stripped by canonicalize()")
+        for speaker in speakers:
+            self.assertEqual(speaker, speaker.upper())
+
+    def test_consecutive_same_speaker_spans_merge(self):
+        # Every span narrated -> exactly one merged entry holding the whole chunk.
+        chunk = STRAIGHT_QUOTES
+        labels = [
+            {"id": span.id, "speaker": "NARRATOR", "role": "narration", "instruct": "x"}
+            for span in tokenize(chunk)
+        ]
+        client = FakeClient(FakeResponse(json.dumps(labels)))
+        entries, _, _ = run_chunk(client, chunk)
+
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["text"], chunk)
+        self.assertEqual(entries[0]["speaker"], NARRATOR)
+
+    def test_curly_quotes_fixture(self):
+        chunk = CURLY_QUOTES
+        client = FakeClient(FakeResponse(json.dumps(labels_for(chunk))))
+        entries, stats, _ = run_chunk(client, chunk)
+
+        self.assertEqual(joined(entries), chunk)
+        self.assertFalse(stats["degraded"])
+        elena_text = "".join(e["text"] for e in entries if e["speaker"] == "ELENA")
+        self.assertIn("“You were never going to tell me,”", elena_text)
+        narrator_text = "".join(e["text"] for e in entries if e["speaker"] == NARRATOR)
+        self.assertIn("It wasn’t a question.", narrator_text)
+
+    def test_attribution_tag_mid_sentence(self):
+        chunk = ATTRIBUTION_MID_SENTENCE
+        client = FakeClient(FakeResponse(json.dumps(labels_for(chunk))))
+        entries, stats, _ = run_chunk(client, chunk)
+
+        self.assertEqual(joined(entries), chunk)
+        self.assertFalse(stats["degraded"])
+        narrator_text = "".join(e["text"] for e in entries if e["speaker"] == NARRATOR)
+        self.assertIn(" he said, pulling on his coat, ", narrator_text)
+        # Both halves of the split quotation are dialogue.
+        self.assertEqual(len([e for e in entries if e["speaker"] == "ELENA"]), 2)
+
+
+class TestTruncation(unittest.TestCase):
+    """finish_reason='length' with only part of the labels present."""
+
+    def test_half_labels_lose_no_prose(self):
+        chunk = STRAIGHT_QUOTES
+        full = labels_for(chunk)
+        half = full[:max(1, len(full) // 2)]
+        # Simulate a hard cut mid-array: no closing bracket.
+        body = json.dumps(half)[:-1].rstrip()
+        client = FakeClient(FakeResponse(body, finish_reason="length"))
+
+        entries, stats, output = run_chunk(client, chunk)
+
+        self.assertEqual(joined(entries), chunk, "truncation must not lose a single character")
+        self.assertTrue(stats["degraded"])
+        self.assertGreater(stats["fallback"], 0)
+        self.assertEqual(stats["labelled"] + stats["fallback"], stats["spans"])
+        self.assertIn("DEGRADED", output)
+        self.assertIn("truncated", output.lower())
+
+        # Every span the LLM did not label is narrated.
+        labelled_ids = {label["id"] for label in half}
+        for span in tokenize(chunk):
+            if span.id not in labelled_ids:
+                owner = [e for e in entries if span.text(chunk) in e["text"]]
+                self.assertTrue(owner, f"span {span.id} vanished from the entries")
+
+    def test_truncation_is_a_single_degradation_event(self):
+        chunk = STRAIGHT_QUOTES
+        full = labels_for(chunk)
+        body = json.dumps(full[:1])[:-1]
+        client = FakeClient(FakeResponse(body, finish_reason="length"))
+        _, stats, _ = run_chunk(client, chunk)
+
+        self.assertTrue(stats["degraded"])
+        self.assertIsNotNone(stats["reason"])
+        self.assertEqual(client.calls, 1, "a partial-but-usable response must not be retried")
+
+
+class TestTotalFailure(unittest.TestCase):
+    """Every LLM attempt raises."""
+
+    def test_chunk_becomes_narrator_entries(self):
+        chunk = CURLY_QUOTES
+        client = FakeClient(RuntimeError("connection refused"))
+        entries, stats, output = run_chunk(client, chunk)
+
+        self.assertEqual(joined(entries), chunk)
+        self.assertEqual(len(entries), 1, "all-NARRATOR spans merge into one entry")
+        self.assertEqual(entries[0]["speaker"], NARRATOR)
+        self.assertEqual(entries[0]["instruct"], DEFAULT_NARRATOR_INSTRUCT)
+        self.assertTrue(stats["degraded"])
+        self.assertEqual(stats["labelled"], 0)
+        self.assertEqual(stats["fallback"], stats["spans"])
+        self.assertIn("DEGRADED", output)
+        self.assertEqual(client.calls, 3, "should exhaust max_retries + 1 attempts")
+
+    def test_recovers_on_retry(self):
+        chunk = STRAIGHT_QUOTES
+        client = FakeClient(
+            RuntimeError("timeout"),
+            FakeResponse(json.dumps(labels_for(chunk))),
+        )
+        entries, stats, _ = run_chunk(client, chunk)
+
+        self.assertEqual(joined(entries), chunk)
+        self.assertFalse(stats["degraded"])
+        self.assertEqual(client.calls, 2)
+
+
+class TestMalformedJson(unittest.TestCase):
+    """Broken output: salvage what is there, narrate the rest."""
+
+    def test_unparseable_garbage_falls_back(self):
+        chunk = STRAIGHT_QUOTES
+        client = FakeClient(FakeResponse("I'm sorry, I cannot help with that."))
+        entries, stats, output = run_chunk(client, chunk)
+
+        self.assertEqual(joined(entries), chunk)
+        self.assertTrue(stats["degraded"])
+        self.assertEqual(stats["fallback"], stats["spans"])
+        self.assertIn("DEGRADED", output)
+
+    def test_salvageable_broken_json(self):
+        chunk = STRAIGHT_QUOTES
+        spans = tokenize(chunk)
+        # Missing commas between objects, a stray trailing comma, no final bracket.
+        broken = (
+            "Here you go:\n```json\n["
+            + "\n".join(
+                '{"id": %d, "role": "%s", "speaker": "%s", "instruct": "Tense."}'
+                % (
+                    span.id,
+                    "dialogue" if span.kind == "quoted" else "narration",
+                    "ELENA" if span.kind == "quoted" else "NARRATOR",
+                )
+                for span in spans
+            )
+            + ","
+        )
+        client = FakeClient(FakeResponse(broken))
+        entries, stats, _ = run_chunk(client, chunk)
+
+        self.assertEqual(joined(entries), chunk)
+        self.assertGreater(stats["labelled"], 0, "regex salvage should recover labels")
+        self.assertIn("ELENA", {entry["speaker"] for entry in entries})
+
+    def test_llm_echoing_text_is_ignored(self):
+        # The one thing the LLM must never do. If it does it anyway, the text
+        # field is dropped on the floor -- code owns the prose.
+        chunk = STRAIGHT_QUOTES
+        labels = labels_for(chunk)
+        for label in labels:
+            label["text"] = "COMPLETELY WRONG TEXT THE MODEL MADE UP"
+        client = FakeClient(FakeResponse(json.dumps(labels)))
+        entries, _, _ = run_chunk(client, chunk)
+
+        self.assertEqual(joined(entries), chunk)
+        self.assertNotIn("MADE UP", joined(entries))
+
+
+class TestLabelResolution(unittest.TestCase):
+    """Unit-level rules around label -> speaker resolution."""
+
+    def test_unknown_ids_are_discarded(self):
+        chunk = STRAIGHT_QUOTES
+        spans = tokenize(chunk)
+        labels = [{"id": 9999, "speaker": "GHOST", "role": "dialogue", "instruct": "x"}]
+        resolved, stats = resolve_span_labels(spans, labels)
+
+        self.assertEqual(stats["discarded"], 1)
+        self.assertEqual(stats["labelled"], 0)
+        self.assertTrue(all(speaker == NARRATOR for _, speaker, _ in resolved))
+
+    def test_empty_speaker_becomes_narrator(self):
+        chunk = STRAIGHT_QUOTES
+        spans = tokenize(chunk)
+        labels = [{"id": s.id, "speaker": "", "role": "dialogue", "instruct": "x"} for s in spans]
+        resolved, stats = resolve_span_labels(spans, labels)
+
+        self.assertEqual(stats["labelled"], len(spans))
+        self.assertTrue(all(speaker == NARRATOR for _, speaker, _ in resolved))
+
+    def test_role_narration_overrides_a_character_name(self):
+        chunk = STRAIGHT_QUOTES
+        spans = tokenize(chunk)
+        labels = [{"id": s.id, "speaker": "ELENA", "role": "narration", "instruct": "x"} for s in spans]
+        resolved, _ = resolve_span_labels(spans, labels)
+        self.assertTrue(all(speaker == NARRATOR for _, speaker, _ in resolved))
+
+    def test_complete_label_beats_a_truncated_duplicate(self):
+        # salvage_label_entries() can recover a tail fragment for an id that
+        # already parsed cleanly; the fragment must not overwrite it.
+        spans = tokenize(STRAIGHT_QUOTES)
+        first = spans[0]
+        complete = {"id": first.id, "speaker": "ELENA", "role": "dialogue", "instruct": "Firm."}
+        fragment = {"id": first.id, "speaker": "ELENA"}  # no role: truncated tail
+
+        for order in ([complete, fragment], [fragment, complete]):
+            with self.subTest(order=[("complete" if l is complete else "fragment") for l in order]):
+                resolved, _ = resolve_span_labels(spans, order)
+                speaker = resolved[0][1]
+                instruct = resolved[0][2]
+                self.assertEqual(speaker, "ELENA", "the complete label must win")
+                self.assertEqual(instruct, "Firm.")
+
+    def test_equal_completeness_keeps_last_write_wins(self):
+        spans = tokenize(STRAIGHT_QUOTES)
+        first = spans[0]
+        labels = [
+            {"id": first.id, "speaker": "ALPHA", "role": "dialogue", "instruct": "One."},
+            {"id": first.id, "speaker": "BETA", "role": "dialogue", "instruct": "Two."},
+        ]
+        resolved, _ = resolve_span_labels(spans, labels)
+        self.assertEqual(resolved[0][1], "BETA")
+
+    def test_instruct_defaults(self):
+        chunk = STRAIGHT_QUOTES
+        spans = tokenize(chunk)
+        labels = [{"id": s.id, "speaker": "ELENA", "role": "dialogue"} for s in spans]
+        resolved, _ = resolve_span_labels(spans, labels)
+        entries = build_entries(resolved, chunk)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["instruct"], generate_script.DEFAULT_CHARACTER_INSTRUCT)
+
+    def test_entry_schema_has_no_extra_fields(self):
+        chunk = STRAIGHT_QUOTES
+        client = FakeClient(FakeResponse(json.dumps(labels_for(chunk))))
+        entries, _, _ = run_chunk(client, chunk)
+        for entry in entries:
+            self.assertEqual(set(entry.keys()), {"speaker", "text", "instruct"},
+                             "role must not leak into the output schema")
+
+    def test_verbatim_assertion_raises_on_corruption(self):
+        with self.assertRaises(AssertionError):
+            generate_script._assert_chunk_verbatim(
+                [{"speaker": NARRATOR, "text": "not the chunk", "instruct": "x"}],
+                STRAIGHT_QUOTES,
+                1,
+            )
+
+
+class TestRoleMissingDegrades(unittest.TestCase):
+    """A model that names speakers but omits "role" narrates the whole book."""
+
+    @staticmethod
+    def _labels_without_role(chunk):
+        return [
+            {"id": span.id,
+             "speaker": "ELENA" if span.kind == "quoted" else "NARRATOR",
+             "instruct": "Tense."}
+            for span in tokenize(chunk)
+        ]
+
+    def test_speaker_without_role_marks_chunk_degraded(self):
+        chunk = STRAIGHT_QUOTES
+        client = FakeClient(FakeResponse(json.dumps(self._labels_without_role(chunk))))
+        entries, stats, output = run_chunk(client, chunk)
+
+        self.assertEqual(joined(entries), chunk, "prose must still be byte-identical")
+        self.assertGreater(stats["role_missing"], 0)
+        self.assertEqual(stats["fallback"], 0, "every span WAS labelled -- only role is missing")
+        self.assertTrue(stats["degraded"], "role-less labels must not exit 0 silently")
+        self.assertIn("role=dialogue", stats["reason"])
+        self.assertIn("DEGRADED", output)
+
+        # The book is fully narrated: that is the damage being surfaced.
+        self.assertEqual({entry["speaker"] for entry in entries}, {NARRATOR})
+
+    def test_degraded_reason_reaches_the_exit_3_summary(self):
+        # main() adds a chunk to degraded_chunks iff stats["degraded"], and
+        # exits EXIT_DEGRADED iff that list is non-empty. Assert the linkage.
+        chunk = STRAIGHT_QUOTES
+        client = FakeClient(FakeResponse(json.dumps(self._labels_without_role(chunk))))
+        _, stats, _ = run_chunk(client, chunk)
+
+        self.assertTrue(stats["degraded"])
+        self.assertIsNotNone(stats["reason"])
+        self.assertEqual(generate_script.EXIT_DEGRADED, 3)
+
+    def test_explicit_narration_role_is_not_a_degradation(self):
+        # role="narration" on a NARRATOR span is correct, not a schema violation.
+        chunk = STRAIGHT_QUOTES
+        labels = [
+            {"id": span.id, "speaker": "NARRATOR", "role": "narration", "instruct": "Even."}
+            for span in tokenize(chunk)
+        ]
+        _, stats, _ = run_chunk(FakeClient(FakeResponse(json.dumps(labels))), chunk)
+
+        self.assertEqual(stats["role_missing"], 0)
+        self.assertFalse(stats["degraded"])
+
+
+class TestNoWhitespaceOnlyEntries(unittest.TestCase):
+    """A paragraph break between two speakers must not become its own entry."""
+
+    def test_two_dialogue_paragraphs_produce_no_blank_entry(self):
+        chunk = TWO_DIALOGUE_PARAGRAPHS
+        speakers = iter(["ALPHA", "BETA"])
+        labels = labels_for(chunk, speaker_of=lambda span, text: next(speakers))
+        entries, _, _ = run_chunk(FakeClient(FakeResponse(json.dumps(labels))), chunk)
+
+        self.assertEqual(joined(entries), chunk, "absorbing whitespace must change no bytes")
+        for entry in entries:
+            self.assertTrue(entry["text"].strip(), f"whitespace-only entry: {entry!r}")
+
+        # The break lands on the PRECEDING entry.
+        self.assertEqual([e["speaker"] for e in entries], ["ALPHA", "BETA"])
+        self.assertEqual(entries[0]["text"], '"Hi."\n\n')
+        self.assertEqual(entries[1]["text"], '"Bye."')
+
+    def test_leading_whitespace_folds_into_the_following_entry(self):
+        chunk = '\n\n"Hi."'
+        entries, _, _ = run_chunk(
+            FakeClient(FakeResponse(json.dumps(labels_for(chunk)))), chunk)
+
+        self.assertEqual(joined(entries), chunk)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["speaker"], "ELENA")
+        self.assertEqual(entries[0]["text"], chunk)
+
+    def test_all_whitespace_chunk_is_preserved(self):
+        # Degenerate but must not lose bytes or crash.
+        chunk = "\n\n"
+        entries, _, _ = run_chunk(FakeClient(FakeResponse("[]")), chunk)
+        self.assertEqual(joined(entries), chunk)
+
+    def test_no_whitespace_only_entries_across_every_fixture(self):
+        for name, chunk in FIXTURES.items():
+            for mode, response in (
+                ("full", FakeResponse(json.dumps(labels_for(chunk)))),
+                ("failure", RuntimeError("down")),
+            ):
+                with self.subTest(fixture=name, mode=mode):
+                    entries, _, _ = run_chunk(FakeClient(response), chunk)
+                    self.assertEqual(joined(entries), chunk)
+                    for entry in entries:
+                        self.assertTrue(entry["text"].strip(), f"{name}/{mode}: {entry!r}")
+
+
+class TestSingleSpeakerCanonicalization(unittest.TestCase):
+    """run_single_speaker must emit a canonical, comparison-safe speaker."""
+
+    def _run(self, speaker_name, text="Line one.\n\nLine two."):
+        captured = {}
+
+        def fake_write(entries):
+            captured["entries"] = entries
+
+        original = generate_script._write_script_output
+        generate_script._write_script_output = fake_write
+        buffer = io.StringIO()
+        try:
+            with redirect_stdout(buffer):
+                generate_script.run_single_speaker(text, speaker_name, "Neutral narration.")
+        finally:
+            generate_script._write_script_output = original
+        return captured["entries"], buffer.getvalue()
+
+    def test_default_narrator_is_uppercased(self):
+        entries, output = self._run("Narrator")
+
+        self.assertTrue(entries)
+        for entry in entries:
+            self.assertEqual(entry["speaker"], NARRATOR,
+                             'must match the literal "NARRATOR" comparisons downstream')
+        self.assertIn("Canonicalized", output)
+
+    def test_custom_name_is_canonicalized(self):
+        entries, _ = self._run("Dr. Vance")
+        self.assertEqual({e["speaker"] for e in entries}, {"VANCE"})
+
+    def test_already_canonical_name_is_untouched(self):
+        entries, output = self._run("MARCUS")
+        self.assertEqual({e["speaker"] for e in entries}, {"MARCUS"})
+        self.assertNotIn("Canonicalized", output)
+
+    def test_empty_name_falls_back_to_narrator(self):
+        entries, _ = self._run("   ")
+        self.assertEqual({e["speaker"] for e in entries}, {NARRATOR})
+
+    def test_text_is_not_canonicalized(self):
+        entries, _ = self._run("Narrator", text="Dr. Smith met Mr. Jones.")
+        self.assertEqual(entries[0]["text"], "Dr. Smith met Mr. Jones.",
+                         "canonicalization applies to LABELS only, never body text")
+
+
+class TestRealResponseShapes(unittest.TestCase):
+    """Shapes captured from live Ollama runs that the parser must recover."""
+
+    # A 6-span chunk, so the 6-label real fixtures line up 1:1 with the spans.
+    SIX_SPAN_CHUNK = '"One." said A. "Two." said B. "Three." he added.'
+
+    def setUp(self):
+        self.assertEqual(len(tokenize(self.SIX_SPAN_CHUNK)), 6,
+                         "fixture chunk must tokenize to 6 spans")
+
+    # --- shape (a): id-keyed JSON object ---------------------------------
+
+    def test_id_keyed_object_parses_to_labels(self):
+        labels = labels_from_id_keyed_object(REAL_ID_KEYED_OBJECT)
+
+        self.assertEqual([label["id"] for label in labels], [1, 2, 3, 4, 5, 6])
+        self.assertEqual(labels[5], {"id": 6, "speaker": "BILL", "role": "dialogue",
+                                     "instruct": "Speaking with certainty"})
+
+    def test_id_keyed_object_is_reported_as_the_object_mode(self):
+        labels, mode = extract_labels(REAL_ID_KEYED_OBJECT)
+        self.assertEqual(mode, LABEL_MODE_OBJECT)
+        self.assertEqual(len(labels), 6)
+
+    def test_object_key_wins_over_a_conflicting_inner_id(self):
+        labels = labels_from_id_keyed_object(
+            '{"7": {"id": 99, "speaker": "BILL", "role": "dialogue", "instruct": "x"}}')
+        self.assertEqual(labels[0]["id"], 7)
+
+    def test_id_keyed_object_recovery_is_not_degraded(self):
+        chunk = self.SIX_SPAN_CHUNK
+        entries, stats, output = run_chunk(
+            FakeClient(FakeResponse(REAL_ID_KEYED_OBJECT)), chunk)
+
+        self.assertEqual(joined(entries), chunk)
+        self.assertEqual(stats["labelled"], 6, "all six spans labelled")
+        self.assertEqual(stats["discarded"], 0)
+        self.assertFalse(stats["degraded"],
+                         "valid JSON with complete labels is a wrong envelope, not a degradation")
+        self.assertEqual(stats["recovery"], LABEL_MODE_OBJECT)
+        self.assertIn("id-keyed JSON object", output, "must print a one-line notice")
+        self.assertIn("BILL", {entry["speaker"] for entry in entries})
+
+    def test_ordinary_objects_are_not_mistaken_for_id_maps(self):
+        for text in (
+            '{"id": 1, "speaker": "BILL", "role": "dialogue", "instruct": "x"}',
+            '{"labels": [{"id": 1}]}',
+            '{"1": "NARRATOR", "2": "BILL"}',   # values not dicts
+            '{}',
+        ):
+            with self.subTest(text=text[:40]):
+                self.assertIsNone(labels_from_id_keyed_object(text))
+
+    # --- shape (b): markdown label blocks --------------------------------
+
+    def test_markdown_span_header_variant(self):
+        labels = salvage_markdown_labels(REAL_MARKDOWN_SPAN)
+
+        self.assertEqual([label["id"] for label in labels], [1, 2, 3])
+        self.assertEqual(labels[0], {"id": 1, "speaker": "NARRATOR", "role": "narration",
+                                     "instruct": "Neutral, even narration."})
+        self.assertEqual(labels[2]["speaker"], "BILL")
+
+    def test_markdown_id_header_variant(self):
+        labels = salvage_markdown_labels(REAL_MARKDOWN_ID)
+
+        self.assertEqual([label["id"] for label in labels], [1, 2, 3])
+        self.assertEqual(labels[1]["role"], "dialogue")
+        self.assertEqual(labels[1]["instruct"], "Confident, persuasive tone.",
+                         "surrounding quotes and markdown hard-break spaces must be trimmed")
+
+    def test_markdown_recovery_is_degraded_but_labels_apply(self):
+        chunk = self.SIX_SPAN_CHUNK
+        entries, stats, output = run_chunk(
+            FakeClient(FakeResponse(REAL_MARKDOWN_SPAN)), chunk)
+
+        self.assertEqual(joined(entries), chunk, "prose byte-identical either way")
+        self.assertEqual(stats["recovery"], LABEL_MODE_MARKDOWN)
+        self.assertEqual(stats["labelled"], 3, "3 of 6 spans were labelled")
+        self.assertEqual(stats["fallback"], 3)
+        self.assertTrue(stats["degraded"], "ignoring the output contract must not exit 0")
+        self.assertIn("markdown", stats["reason"].lower())
+        self.assertIn("markdown blocks", output)
+        self.assertIn("BILL", {entry["speaker"] for entry in entries})
+
+    def test_markdown_is_last_resort_only(self):
+        # A well-formed array that also happens to mention "Span 1" in prose
+        # must still be read as an array.
+        labels = json.dumps(labels_for(self.SIX_SPAN_CHUNK))
+        text = "**Span 1** is tricky. Anyway:\n" + labels
+        recovered, mode = extract_labels(text)
+        self.assertEqual(mode, LABEL_MODE_ARRAY)
+        self.assertEqual(len(recovered), 6)
+
+    def test_prose_without_labels_recovers_nothing(self):
+        self.assertEqual(extract_labels("I'm sorry, I cannot help with that."), (None, None))
+        self.assertIsNone(salvage_markdown_labels("Here is a nice **bold** paragraph."))
+
+    # --- item 3: think-tag pollution -------------------------------------
+
+    def test_think_tags_are_stripped_before_salvage(self):
+        labels = salvage_label_entries(REAL_THINK_POLLUTED_TRUNCATION)
+
+        ids = [label["id"] for label in labels]
+        self.assertEqual(ids, [1], "only the real truncated label survives")
+        self.assertNotIn(500, ids, "phantom id from <think> reasoning was salvaged")
+        self.assertNotIn(501, ids)
+
+    def test_think_polluted_truncation_discards_no_phantom_ids(self):
+        chunk = self.SIX_SPAN_CHUNK
+        entries, stats, _ = run_chunk(
+            FakeClient(FakeResponse(REAL_THINK_POLLUTED_TRUNCATION, finish_reason="length")),
+            chunk)
+
+        self.assertEqual(joined(entries), chunk)
+        self.assertEqual(stats["discarded"], 0,
+                         "phantom ids from reasoning text must never reach resolution")
+        self.assertEqual(stats["labelled"], 1)
+        self.assertEqual(stats["fallback"], 5)
+        self.assertTrue(stats["degraded"])
+
+    def test_unclosed_think_tag_is_stripped(self):
+        self.assertEqual(strip_thinking_tags('ok<think>{"id": 9}').strip(), "ok")
+
+    def test_extract_labels_modes_are_distinct(self):
+        chunk = self.SIX_SPAN_CHUNK
+        array_text = json.dumps(labels_for(chunk))
+        cases = [
+            (array_text, LABEL_MODE_ARRAY),
+            # An array cut mid-object still repairs to an array when a complete
+            # earlier object exists -- repair beats salvage, by design.
+            (array_text[:-1].rstrip(), LABEL_MODE_ARRAY),
+            (REAL_ID_KEYED_OBJECT, LABEL_MODE_OBJECT),
+            # Real hard truncation from the log: nothing complete to repair.
+            ('[{"id": 1, "speaker": "NARRATOR", "role": "narr', LABEL_MODE_SALVAGE),
+            (REAL_MARKDOWN_ID, LABEL_MODE_MARKDOWN),
+            ("nothing here", None),
+        ]
+        for text, expected in cases:
+            with self.subTest(mode=expected):
+                self.assertEqual(extract_labels(text)[1], expected)
+
+
+class TestSalvageAndPayload(unittest.TestCase):
+    def test_salvage_label_entries_is_field_order_agnostic(self):
+        text = '[{"role": "dialogue", "instruct": "Calm.", "speaker": "MARCUS", "id": 4}]'
+        labels = salvage_label_entries(text)
+        self.assertEqual(labels, [{"id": 4, "speaker": "MARCUS", "role": "dialogue", "instruct": "Calm."}])
+
+    def test_salvage_recovers_truncated_tail_object(self):
+        text = '[{"id": 1, "speaker": "A", "role": "dialogue", "instruct": "x"}, {"id": 2, "speaker": "B"'
+        labels = salvage_label_entries(text)
+        self.assertEqual([label["id"] for label in labels], [1, 2])
+
+    def test_parse_label_response_handles_clean_json(self):
+        text = '[{"id": 1, "speaker": "A", "role": "dialogue", "instruct": "x"}]'
+        self.assertEqual(len(parse_label_response(text)), 1)
+
+    def test_span_payload_never_contains_offsets_and_is_one_line_per_span(self):
+        payload = build_span_payload(tokenize(STRAIGHT_QUOTES), STRAIGHT_QUOTES)
+        lines = payload.split("\n")
+        self.assertEqual(len(lines), len(tokenize(STRAIGHT_QUOTES)))
+        for line in lines:
+            record = json.loads(line)
+            self.assertEqual(set(record.keys()), {"id", "kind", "text"})
+
+    def test_old_salvage_export_still_present_for_review_script(self):
+        # review_script.py imports these three by name.
+        for name in ("clean_json_string", "repair_json_array", "salvage_json_entries"):
+            self.assertTrue(callable(getattr(generate_script, name)), name)
+
+
+class TestPromptTemplate(unittest.TestCase):
+    def test_user_template_formats_without_brace_errors(self):
+        rendered = DEFAULT_USER_PROMPT.format(context="CTX", chunk="SPANS")
+        self.assertIn("CTX", rendered)
+        self.assertIn("SPANS", rendered)
+        # Doubled braces in the template collapse to a literal JSON-ish hint.
+        self.assertIn('{"id", "speaker", "role", "instruct"}', rendered)
+
+    def test_system_prompt_forbids_emitting_text(self):
+        self.assertIn('"role"', DEFAULT_SYSTEM_PROMPT)
+        self.assertIn("NEVER output a \"text\" field", DEFAULT_SYSTEM_PROMPT)
+
+    def test_both_halves_carry_the_schema_marker(self):
+        self.assertIn(PROMPT_SCHEMA_MARKER, DEFAULT_SYSTEM_PROMPT)
+        self.assertIn(PROMPT_SCHEMA_MARKER, DEFAULT_USER_PROMPT)
+
+
+class TestPromptSchemaGuard(unittest.TestCase):
+    """Saved config.json prompts written for the retired schema must not be used."""
+
+    # A verbatim shape of the OLD generation prompt: no span-labels-v1 marker.
+    STALE_PROMPT = (
+        "You are a script writer converting books into audiobook scripts.\n"
+        'Output [{"speaker": "NARRATOR", "text": "...", "instruct": "..."}]\n'
+        "Drop attribution tags. Convert \"Dr.\" to \"Doctor\".\n"
+    )
+
+    def _select(self, custom, default, key):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            chosen = select_prompt(custom, default, key)
+        return chosen, buffer.getvalue()
+
+    def test_stale_custom_prompt_falls_back_to_default_with_warning(self):
+        chosen, output = self._select(
+            self.STALE_PROMPT, DEFAULT_SYSTEM_PROMPT, "prompts.system_prompt")
+
+        self.assertEqual(chosen, DEFAULT_SYSTEM_PROMPT, "must fall back to the built-in default")
+        self.assertNotIn("script writer", chosen)
+        self.assertIn("WARNING", output)
+        self.assertIn("prompts.system_prompt", output, "warning must name the config key")
+        self.assertIn(PROMPT_SCHEMA_MARKER, output)
+
+    def test_stale_user_template_names_its_own_config_key(self):
+        chosen, output = self._select(
+            "{context}\n\nSOURCE TEXT:\n{chunk}", DEFAULT_USER_PROMPT, "prompts.user_prompt")
+
+        self.assertEqual(chosen, DEFAULT_USER_PROMPT)
+        self.assertIn("prompts.user_prompt", output)
+        self.assertNotIn("prompts.system_prompt", output)
+
+    def test_marker_bearing_custom_prompt_is_used_as_is(self):
+        custom = (
+            "Custom classifier prompt (prompt schema: span-labels-v1).\n"
+            "Return only labels.\n"
+        )
+        chosen, output = self._select(custom, DEFAULT_SYSTEM_PROMPT, "prompts.system_prompt")
+
+        self.assertEqual(chosen, custom, "a marker-bearing custom prompt must be honoured verbatim")
+        self.assertEqual(output, "", "no warning for a current-schema custom prompt")
+
+    def test_absent_or_blank_custom_prompt_uses_default_silently(self):
+        for value in (None, "", "   "):
+            with self.subTest(value=repr(value)):
+                chosen, output = self._select(value, DEFAULT_SYSTEM_PROMPT, "prompts.system_prompt")
+                self.assertEqual(chosen, DEFAULT_SYSTEM_PROMPT)
+                self.assertEqual(output, "", "an unset prompt is not a misconfiguration")
+
+    def test_defaults_pass_their_own_guard(self):
+        # The shipped defaults must never be rejected by the guard.
+        for prompt, key in ((DEFAULT_SYSTEM_PROMPT, "prompts.system_prompt"),
+                            (DEFAULT_USER_PROMPT, "prompts.user_prompt")):
+            chosen, output = self._select(prompt, prompt, key)
+            self.assertEqual(chosen, prompt)
+            self.assertEqual(output, "")
+
+    def test_stale_prompt_would_have_degraded_the_chunk(self):
+        # Why the guard exists: old-schema output carries no ids, so every
+        # span falls back to NARRATOR. Prose survives; all voices are lost.
+        chunk = STRAIGHT_QUOTES
+        old_style = json.dumps([
+            {"speaker": "ELENA", "text": "I am leaving.", "instruct": "Firm."},
+            {"speaker": "NARRATOR", "text": "Marcus did not look up.", "instruct": "Even."},
+        ])
+        client = FakeClient(FakeResponse(old_style))
+        entries, stats, _ = run_chunk(client, chunk)
+
+        self.assertEqual(joined(entries), chunk)
+        self.assertEqual(stats["labelled"], 0)
+        self.assertTrue(stats["degraded"])
+
+
+class TestVerbatimAcrossAllFixtures(unittest.TestCase):
+    """Property test: every fixture x every failure mode is byte-identical."""
+
+    def _responses_for(self, chunk):
+        full = json.dumps(labels_for(chunk))
+        return {
+            "full": FakeResponse(full),
+            "truncated": FakeResponse(full[: len(full) // 2], finish_reason="length"),
+            "empty_array": FakeResponse("[]"),
+            "prose": FakeResponse("Sure! Here is the script."),
+            "wrong_ids": FakeResponse('[{"id": 500, "speaker": "X", "role": "dialogue", "instruct": "y"}]'),
+        }
+
+    def test_all_fixtures_all_modes(self):
+        for fixture_name, chunk in FIXTURES.items():
+            for mode, response in self._responses_for(chunk).items():
+                with self.subTest(fixture=fixture_name, mode=mode):
+                    client = FakeClient(response)
+                    entries, stats, _ = run_chunk(client, chunk)
+                    self.assertEqual(joined(entries), chunk)
+                    self.assertEqual(stats["labelled"] + stats["fallback"], stats["spans"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/app/test_span_integration.py
+++ b/app/test_span_integration.py
@@ -14,6 +14,7 @@ never prose.
 """
 
 import atexit
+import inspect
 import io
 import json
 import os
@@ -68,6 +69,9 @@ from generate_script import (  # noqa: E402
     select_prompt,
     build_context,
     MAX_CONTEXT_ROSTER_NAMES,
+    MOJIBAKE_REPLACEMENTS,
+    clean_json_string,
+    fix_mojibake,
     detect_flatlined_prompt_tokens,
     estimate_prompt_tokens,
     is_placeholder_speaker,
@@ -1606,6 +1610,106 @@ class TestPlaceholderLabelRejection(unittest.TestCase):
             labels_for(chunk, speaker_of=lambda span, text: "SPEAKER 2"))))
         run_chunk(client, chunk, roster=roster)
         self.assertEqual(roster, {})
+
+
+
+
+class TestBracketedPreambleRecovery(unittest.TestCase):
+    """A ``[`` in prose must not cost the chunk its labels.
+
+    clean_json_string() used to take the FIRST ``[`` anywhere in the response.
+    A model prefacing its array with prose containing brackets handed back a
+    truthy-but-wrong slice, which then displaced the raw text in
+    extract_labels' salvage step -- total label loss for the chunk, with the
+    real array sitting intact a few characters later.
+    """
+
+    REAL_ARRAY = '[{"id": 1, "speaker": "NARRATOR", "role": "narration", "instruct": "Neutral."}]'
+
+    def test_prose_preamble_with_brackets(self):
+        resp = "Sure! Here are the labels [see list below]:\n" + self.REAL_ARRAY
+        self.assertEqual(clean_json_string(resp), self.REAL_ARRAY)
+        labels, mode = extract_labels(resp)
+        self.assertEqual(mode, LABEL_MODE_ARRAY)
+        self.assertEqual([label["id"] for label in labels], [1])
+
+    def test_markdown_preamble_with_bracketed_span_ids(self):
+        resp = ("- span [1] is narration\n"
+                "- span [2] is dialogue\n\n" + self.REAL_ARRAY)
+        labels, _ = extract_labels(resp)
+        self.assertEqual([label["id"] for label in labels], [1])
+
+    def test_nested_array_inside_an_object_is_not_truncated(self):
+        resp = ('[{"id": 1, "speaker": "A", "role": "dialogue", "instruct": "x", '
+                '"tags": [1, 2]}, '
+                '{"id": 2, "speaker": "NARRATOR", "role": "narration", "instruct": "y"}]')
+        labels, mode = extract_labels(resp)
+        self.assertEqual(mode, LABEL_MODE_ARRAY)
+        self.assertEqual([label["id"] for label in labels], [1, 2])
+
+    def test_truncated_array_after_a_prose_bracket_still_salvages(self):
+        resp = ('Here goes [note] :\n[{"id": 1, "speaker": "A", "role": "dialogue", '
+                '"instruct": "x"}, {"id": 2, "speaker": "B", "role": "dialogue"')
+        labels, _ = extract_labels(resp)
+        self.assertEqual([label["id"] for label in labels], [1, 2])
+
+    def test_response_with_no_array_at_all_is_unchanged(self):
+        self.assertIsNone(clean_json_string("Sure! Here is the script."))
+        self.assertEqual(extract_labels("Sure! Here is the script."), (None, None))
+
+    def test_bracketed_preamble_through_process_chunk_keeps_the_speaker(self):
+        chunk = STRAIGHT_QUOTES
+        resp = ("Certainly [as requested]:\n" +
+                json.dumps(labels_for(chunk, speaker_of=lambda span, text: "MARCUS")))
+        entries, stats, _ = run_chunk(chunk=chunk, client=FakeClient(FakeResponse(resp)))
+        self.assertEqual(joined(entries), chunk)
+        self.assertIn("MARCUS", [e["speaker"] for e in entries])
+        self.assertFalse(stats["degraded"])
+
+
+class TestMojibakeTable(unittest.TestCase):
+    """The repair table's literals are themselves mojibake and had decayed.
+
+    Two entries were lost: the right-single-quote VALUE became three ASCII
+    apostrophes (a triple-quote that swallowed the next entry), and the em-
+    and en-dash KEYS collapsed to the same byte, so 7 literals became 6 dict
+    entries and em-dash mojibake was never repaired.
+    """
+
+    @staticmethod
+    def _literal_count():
+        """Count key literals in the dict's SOURCE, independent of the dict."""
+        source = inspect.getsource(generate_script)
+        body = source.split("MOJIBAKE_REPLACEMENTS = {", 1)[1].split("}", 1)[0]
+        return len([line for line in body.splitlines() if ":" in line])
+
+    def test_no_duplicate_keys_collapsed(self):
+        self.assertEqual(len(MOJIBAKE_REPLACEMENTS), self._literal_count())
+
+    def test_all_keys_and_values_are_distinct_where_expected(self):
+        self.assertEqual(len(set(MOJIBAKE_REPLACEMENTS)), len(MOJIBAKE_REPLACEMENTS))
+
+    def test_both_dashes_are_repaired(self):
+        em_mojibake = "\u00e2\u20ac\u201d"
+        en_mojibake = "\u00e2\u20ac\u201c"
+        self.assertEqual(fix_mojibake(em_mojibake), "\u2014")
+        self.assertEqual(fix_mojibake(en_mojibake), "\u2013")
+
+    def test_quotes_and_ellipsis_are_repaired(self):
+        cases = {
+            "\u00e2\u20ac\u2122": "\u2019",
+            "\u00e2\u20ac\u02dc": "\u2018",
+            "\u00e2\u20ac\u0153": "\u201c",
+            "\u00e2\u20ac\u009d": "\u201d",
+            "\u00e2\u20ac\u00a6": "\u2026",
+        }
+        for bad, good in cases.items():
+            with self.subTest(bad=bad):
+                self.assertEqual(fix_mojibake(bad), good)
+
+    def test_clean_text_is_untouched(self):
+        clean = 'She said, "it\u2019s fine" \u2014 and left\u2026'
+        self.assertEqual(fix_mojibake(clean), clean)
 
 
 

--- a/app/test_span_integration.py
+++ b/app/test_span_integration.py
@@ -649,21 +649,22 @@ class TestRoleMissingDegrades(unittest.TestCase):
 class TestUnknownLabelKeysAreVisible(unittest.TestCase):
     """A key outside the schema is discarded -- but never silently.
 
-    Observed in production: the model wrote "instituct" instead of "instruct",
-    so the delivery direction vanished with no counter and no warning. Nothing
-    is repaired here (no fuzzy key matching); the discard is only reported.
+    What reaches this path is the residue _recover_label_keys could not place:
+    a key too far from every schema key, or near two of them. Nothing is
+    repaired here; the discard is only reported, so that residue stays
+    measurable rather than becoming invisible once recovery exists.
     """
 
-    def test_misspelled_key_is_counted_and_logged(self):
+    def test_unplaceable_key_is_counted_and_logged(self):
         chunk = STRAIGHT_QUOTES
         labels = labels_for(chunk)
         for label in labels:
-            label["instituct"] = label.pop("instruct")
+            label["subtext"] = label.pop("instruct")
         _, stats, output = run_chunk(FakeClient(FakeResponse(json.dumps(labels))), chunk)
 
         self.assertEqual(stats["unknown_key_labels"], len(labels))
-        self.assertEqual(stats["unknown_keys"], ["instituct"])
-        self.assertIn("instituct", output)
+        self.assertEqual(stats["unknown_keys"], ["subtext"])
+        self.assertIn("subtext", output)
         self.assertIn("Ignored unknown key", output)
         self.assertEqual(stats["text_key_labels"], 0)
 
@@ -689,6 +690,78 @@ class TestUnknownLabelKeysAreVisible(unittest.TestCase):
             self.assertNotIn("MODEL-INVENTED PROSE", entry["text"])
         self.assertEqual(stats["text_key_labels"], len(labels))
         self.assertIn('"text" key', output)
+
+
+class TestMisspelledKeyRecovery(unittest.TestCase):
+    """A misspelled schema key is folded back onto the key it can only mean.
+
+    Properties, not a table of observed spellings: the rule must hold for any
+    misspelling within the budget, and must never reach "text" or "id".
+    """
+
+    @staticmethod
+    def _recovered(key):
+        label = {"id": 1, key: "value"}
+        with redirect_stdout(io.StringIO()):
+            generate_script._recover_label_keys([label])
+        return {k for k in label if k != "id"}
+
+    def test_every_single_edit_of_a_long_key_is_recovered(self):
+        # Exhaustive over one edit, so this cannot be fitted to any one book's
+        # model output. Substitutions, deletions and insertions all count.
+        target = "instruct"
+        variants = {target[:i] + target[i + 1:] for i in range(len(target))}
+        variants |= {target[:i] + "x" + target[i + 1:] for i in range(len(target))}
+        variants |= {target[:i] + "x" + target[i:] for i in range(len(target) + 1)}
+        for variant in sorted(variants - {target}):
+            with self.subTest(variant=variant):
+                self.assertEqual(self._recovered(variant), {target})
+
+    def test_separators_and_case_are_not_misspellings(self):
+        for variant in ("Instruct", "IN_STRUCT", "in instruct", " instruct "):
+            with self.subTest(variant=variant):
+                self.assertEqual(self._recovered(variant), {"instruct"})
+
+    def test_nothing_ever_becomes_text(self):
+        # Contract 1: the model never supplies prose. "text" is not a recovery
+        # target, so no spelling of it -- however close -- can be honoured.
+        for variant in ("text", "texts", "tex", "txt", "Text", "te xt", "textt"):
+            with self.subTest(variant=variant):
+                # Left exactly as sent: still unknown, still discarded, still
+                # reported. Never turned INTO the schema's "text".
+                self.assertEqual(self._recovered(variant), {variant})
+
+    def test_short_keys_stay_strict(self):
+        # "id" has a budget of zero: near-misses are common English words and
+        # recovering them would invent span ids.
+        for variant in ("in", "is", "if", "idx", "od"):
+            with self.subTest(variant=variant):
+                self.assertEqual(self._recovered(variant), {variant})
+
+    def test_ambiguity_and_distance_leave_the_key_alone(self):
+        for variant in ("inquest", "infty", "commentary"):
+            with self.subTest(variant=variant):
+                self.assertEqual(self._recovered(variant), {variant})
+
+    def test_a_correct_key_is_never_overwritten(self):
+        label = {"id": 1, "instruct": "real", "instructor": "guess"}
+        with redirect_stdout(io.StringIO()):
+            generate_script._recover_label_keys([label])
+        self.assertEqual(label["instruct"], "real")
+
+    def test_recovery_reaches_the_pipeline_and_is_logged(self):
+        chunk = STRAIGHT_QUOTES
+        labels = labels_for(chunk)
+        for label in labels:
+            label["instructor"] = label.pop("instruct")
+        entries, stats, output = run_chunk(
+            FakeClient(FakeResponse(json.dumps(labels))), chunk)
+
+        self.assertEqual(joined(entries), chunk)
+        self.assertEqual(stats["unknown_key_labels"], 0)
+        self.assertIn("Recovered misspelled key", output)
+        for entry in entries:
+            self.assertNotEqual(entry["instruct"], "")
 
 
 class TestNoWhitespaceOnlyEntries(unittest.TestCase):

--- a/app/test_span_integration.py
+++ b/app/test_span_integration.py
@@ -78,6 +78,7 @@ from generate_script import (  # noqa: E402
     looks_silently_truncated,
     strip_thinking_tags,
 )
+from speaker_canon import remember_in_roster
 
 
 # --------------------------------------------------------------------------
@@ -1710,6 +1711,138 @@ class TestMojibakeTable(unittest.TestCase):
     def test_clean_text_is_untouched(self):
         clean = 'She said, "it\u2019s fine" \u2014 and left\u2026'
         self.assertEqual(fix_mojibake(clean), clean)
+
+
+class TestAttestationGate(unittest.TestCase):
+    """A speaker name the source does not support is refused, loudly.
+
+    Properties only -- every fixture here is built in the test, and the
+    assertions hold for any text. The gate is OFF by default, so the first
+    test is the one that protects existing users.
+    """
+
+    def test_gate_is_off_by_default(self):
+        # An unattested name is accepted when the gate is not requested, so
+        # this change cannot alter any existing run.
+        chunk = STRAIGHT_QUOTES
+        client = FakeClient(FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=lambda span, text: "ZZQXAL"))))
+        entries, stats, _ = run_chunk(client, chunk)
+        self.assertIn("ZZQXAL", [e["speaker"] for e in entries])
+        self.assertEqual(stats["unattested_rejected"], 0)
+
+    def test_unattested_speaker_is_narrated_and_counted(self):
+        chunk = STRAIGHT_QUOTES  # names "Marcus", never "ZZQXAL"
+        client = FakeClient(*[FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=lambda span, text: "ZZQXAL")))] * 3)
+        entries, stats, _ = run_chunk(
+            client, chunk, require_attested=True, attest_window=chunk)
+        # Prose is never the price of a rejected label.
+        self.assertEqual(joined(entries), chunk)
+        self.assertEqual({e["speaker"] for e in entries}, {NARRATOR})
+        self.assertEqual(stats["unattested_rejected"], 2)
+        # Contract 7: this must not pass silently.
+        self.assertTrue(stats["degraded"])
+        self.assertIn("source text does not support", stats["reason"])
+
+    def test_attested_speaker_passes_the_gate(self):
+        chunk = STRAIGHT_QUOTES  # "Marcus" appears in the narration
+        client = FakeClient(FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=lambda span, text: "MARCUS"))))
+        entries, stats, _ = run_chunk(
+            client, chunk, require_attested=True, attest_window=chunk)
+        self.assertIn("MARCUS", [e["speaker"] for e in entries])
+        self.assertEqual(stats["unattested_rejected"], 0)
+        self.assertFalse(stats["degraded"])
+
+    def test_established_roster_name_needs_no_local_attestation(self):
+        # THE long-range property: a character named pages ago is accepted in a
+        # chunk that never names them, at zero token cost. Without this clause
+        # every unattributed line would be narrated.
+        chunk = STRAIGHT_QUOTES
+        roster = {}
+        remember_in_roster(roster, "DAIRINE")  # established by an earlier chunk
+        client = FakeClient(FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=lambda span, text: "DAIRINE"))))
+        entries, stats, _ = run_chunk(
+            client, chunk, require_attested=True, attest_window=chunk,
+            roster=roster)
+        self.assertIn("DAIRINE", [e["speaker"] for e in entries])
+        self.assertEqual(stats["unattested_rejected"], 0)
+
+    def test_rejected_speaker_never_enters_the_roster(self):
+        # A refused spelling must not become established -- otherwise the
+        # roster clause above would launder it into every later chunk.
+        chunk = STRAIGHT_QUOTES
+        roster = {}
+        client = FakeClient(*[FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=lambda span, text: "ZZQXAL")))] * 3)
+        run_chunk(client, chunk, require_attested=True, attest_window=chunk,
+                  roster=roster)
+        self.assertEqual(roster, {})
+
+    def test_retry_nudge_names_the_offending_label(self):
+        # Rejection is the fallback; re-asking is the fix. The retry prompt has
+        # to say WHICH name failed and what to do instead, or the model just
+        # re-rolls the same judgement.
+        chunk = STRAIGHT_QUOTES
+        bad = json.dumps(labels_for(chunk, speaker_of=lambda span, text: "ZZQXAL"))
+        client = FakeClient(*[FakeResponse(bad)] * 3)
+        run_chunk(client, chunk, require_attested=True, attest_window=chunk)
+        self.assertGreater(len(client.user_prompts), 1, "a retry should have fired")
+        retry_prompt = client.user_prompts[1]
+        self.assertIn("ZZQXAL", retry_prompt)
+        self.assertIn("do not appear anywhere in the text", retry_prompt)
+
+    def test_nudge_recovers_the_correct_spelling(self):
+        # The whole point: a corrected retry keeps the voice instead of losing
+        # it to the narrator.
+        chunk = STRAIGHT_QUOTES
+        bad = json.dumps(labels_for(chunk, speaker_of=lambda span, text: "MARCVS"))
+        good = json.dumps(labels_for(chunk, speaker_of=lambda span, text: "MARCUS"))
+        client = FakeClient(FakeResponse(bad), FakeResponse(good))
+        entries, stats, _ = run_chunk(
+            client, chunk, require_attested=True, attest_window=chunk)
+        self.assertIn("MARCUS", [e["speaker"] for e in entries])
+        self.assertNotIn("MARCVS", [e["speaker"] for e in entries])
+        self.assertEqual(stats["unattested_rejected"], 0)
+        self.assertFalse(stats["degraded"])
+
+    def test_unverifiable_label_is_accepted_not_rejected(self):
+        # A title-only label yields no core tokens: nothing to confirm, so
+        # nothing to refuse. Rejecting here would destroy scripts this module
+        # cannot tokenize.
+        chunk = STRAIGHT_QUOTES
+        client = FakeClient(FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=lambda span, text: "MISTER"))))
+        entries, stats, _ = run_chunk(
+            client, chunk, require_attested=True, attest_window=chunk)
+        self.assertEqual(stats["unattested_rejected"], 0)
+        self.assertEqual(stats["unverifiable_accepted"], 2)
+        self.assertIn("MISTER", [e["speaker"] for e in entries])
+
+    def test_gate_never_touches_prose(self):
+        # Contract 2/4 under every gate outcome, including the rejecting one.
+        chunk = CURLY_QUOTES
+        for speaker in ("ZZQXAL", "MARCUS", "MISTER"):
+            with self.subTest(speaker=speaker):
+                client = FakeClient(*[FakeResponse(json.dumps(labels_for(
+                    chunk, speaker_of=lambda span, text: speaker)))] * 3)
+                entries, _, _ = run_chunk(
+                    client, chunk, require_attested=True, attest_window=chunk)
+                self.assertEqual(joined(entries), chunk)
+
+    def test_no_window_means_no_confirmation(self):
+        # Guards against a caller enabling the gate without supplying a window
+        # and silently narrating the whole book: with no window, an
+        # unestablished name cannot attest, and the run degrades loudly rather
+        # than quietly.
+        chunk = STRAIGHT_QUOTES
+        client = FakeClient(*[FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=lambda span, text: "MARCUS")))] * 3)
+        entries, stats, _ = run_chunk(client, chunk, require_attested=True)
+        self.assertEqual(joined(entries), chunk)
+        self.assertTrue(stats["degraded"])
 
 
 

--- a/app/test_span_integration.py
+++ b/app/test_span_integration.py
@@ -1713,6 +1713,33 @@ class TestMojibakeTable(unittest.TestCase):
         self.assertEqual(fix_mojibake(clean), clean)
 
 
+class TestLLMTimeoutConfig(unittest.TestCase):
+    """main() must honour llm.timeout, and must not send it when unset.
+
+    Source assertions, because the client is constructed inside main() around a
+    network call. The property that matters is the CONDITIONAL: passing a
+    timeout unconditionally would replace the SDK default for every existing
+    install, which is the kind of silent behaviour change this repo avoids.
+    """
+
+    def setUp(self):
+        self.source = inspect.getsource(generate_script)
+
+    def test_main_reads_the_timeout_key(self):
+        self.assertIn('llm_config.get("timeout")', self.source,
+                      "main() must read llm.timeout from the llm config section")
+
+    def test_timeout_is_only_passed_when_set(self):
+        # The guard is what keeps the unset case byte-identical to before.
+        self.assertIn('if timeout:', self.source)
+        self.assertIn('client_kwargs["timeout"] = timeout', self.source)
+
+    def test_client_is_built_from_kwargs_not_a_literal_call(self):
+        # Guards against a refactor that reinstates a hardcoded OpenAI(...)
+        # call and silently drops the timeout.
+        self.assertIn("OpenAI(**client_kwargs)", self.source)
+
+
 class TestAttestationGate(unittest.TestCase):
     """A speaker name the source does not support is refused, loudly.
 

--- a/app/test_span_integration.py
+++ b/app/test_span_integration.py
@@ -2280,6 +2280,126 @@ class TestAttestationGate(unittest.TestCase):
         self.assertTrue(stats["degraded"])
 
 
+# Two lines, each closed by its own attribution tag. Synthesized: no book's
+# names, no book's phrasing -- only the shape English narration always uses.
+TAGGED_DIALOGUE = (
+    '"Yeah," Annika said.\n'
+    '\n'
+    '"No," Borel said.\n'
+)
+
+
+def _tagged_roster():
+    roster = {}
+    remember_in_roster(roster, "ANNIKA")
+    remember_in_roster(roster, "BOREL")
+    return roster
+
+
+def _label_first_quote(name):
+    """Label the first quoted span `name` and the second one BOREL."""
+    seen = []
+
+    def speaker_of(span, text):
+        seen.append(span.id)
+        return name if len(seen) == 1 else "BOREL"
+
+    return speaker_of
+
+
+class TestAttributionTagCheck(unittest.TestCase):
+    """A speaker label that contradicts the attribution tag beside it is
+    retried, then reported -- and never rewritten.
+
+    Properties only; the fixtures are built here. The check is OFF by default,
+    so the first test is the one that protects existing users.
+    """
+
+    def test_check_is_off_by_default(self):
+        chunk = TAGGED_DIALOGUE
+        client = FakeClient(FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=_label_first_quote("BOREL")))))
+        entries, stats, _ = run_chunk(client, chunk, roster=_tagged_roster())
+        self.assertEqual(stats.get("tag_contradictions", 0), 0)
+        self.assertEqual(len(client.user_prompts), 1, "no retry when off")
+        self.assertEqual(joined(entries), chunk)
+
+    def test_contradiction_becomes_a_retry_offender(self):
+        chunk = TAGGED_DIALOGUE  # line one is tagged "Annika said"
+        bad = json.dumps(labels_for(chunk, speaker_of=_label_first_quote("BOREL")))
+        client = FakeClient(*[FakeResponse(bad)] * 3)
+        run_chunk(client, chunk, check_tags=True, roster=_tagged_roster())
+        self.assertGreater(len(client.user_prompts), 1, "a retry should have fired")
+        retry_prompt = client.user_prompts[1]
+        self.assertIn("attribution tag", retry_prompt)
+        self.assertIn("ANNIKA", retry_prompt)
+
+    def test_a_corrected_retry_clears_it(self):
+        chunk = TAGGED_DIALOGUE
+        bad = json.dumps(labels_for(chunk, speaker_of=_label_first_quote("BOREL")))
+        good = json.dumps(labels_for(chunk, speaker_of=_label_first_quote("ANNIKA")))
+        client = FakeClient(FakeResponse(bad), FakeResponse(good))
+        entries, stats, _ = run_chunk(chunk=chunk, client=client, check_tags=True,
+                                      roster=_tagged_roster())
+        self.assertEqual(stats["tag_contradictions"], 0)
+        self.assertFalse(stats["degraded"])
+        self.assertIn("ANNIKA", [e["speaker"] for e in entries])
+
+    def test_unresolved_contradiction_degrades_but_never_rewrites(self):
+        # DETECT, DO NOT AUTO-REWRITE: the model's label survives verbatim and
+        # the operator is told where to look (contract 7).
+        chunk = TAGGED_DIALOGUE
+        bad = json.dumps(labels_for(chunk, speaker_of=_label_first_quote("BOREL")))
+        client = FakeClient(*[FakeResponse(bad)] * 3)
+        entries, stats, output = run_chunk(client, chunk, check_tags=True,
+                                           roster=_tagged_roster())
+        self.assertEqual(joined(entries), chunk, "prose is never the price")
+        self.assertEqual(stats["tag_contradictions"], 1)
+        self.assertTrue(stats["degraded"])
+        self.assertIn("contradicted by the attribution tag", stats["reason"])
+        self.assertIn("BOREL", [e["speaker"] for e in entries])
+        self.assertNotIn("ANNIKA", [e["speaker"] for e in entries],
+                         "the tag's name must NOT be imposed on the label")
+        self.assertIn("CONTRADICTED", output)
+
+    def test_agreeing_labels_are_never_flagged(self):
+        chunk = TAGGED_DIALOGUE
+        client = FakeClient(FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=_label_first_quote("ANNIKA")))))
+        entries, stats, _ = run_chunk(client, chunk, check_tags=True,
+                                      roster=_tagged_roster())
+        self.assertEqual(stats["tag_contradictions"], 0)
+        self.assertFalse(stats["degraded"])
+
+    def test_a_non_english_book_produces_no_detections(self):
+        # The lexicon is English-only and DEGRADES TO DOING NOTHING: with a
+        # deliberately wrong label on every line, a French chunk still yields
+        # zero detections, zero retries and no degradation.
+        chunk = (
+            '"Oui," dit Annika.\n'
+            '\n'
+            '"Non," dit Borel.\n'
+        )
+        client = FakeClient(FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=_label_first_quote("BOREL")))))
+        entries, stats, _ = run_chunk(client, chunk, check_tags=True,
+                                      roster=_tagged_roster())
+        self.assertEqual(stats["tag_contradictions"], 0)
+        self.assertEqual(len(client.user_prompts), 1, "no retry on a French book")
+        self.assertEqual(joined(entries), chunk)
+
+    def test_possessive_tag_is_not_flagged_end_to_end(self):
+        # The false-positive class that a naive name-grab gets wrong: the label
+        # naming a person via another character is CORRECT.
+        chunk = '"Sit down," said Annika\'s father.\n'
+        roster = _tagged_roster()
+        remember_in_roster(roster, "ANNIKA'S FATHER")
+        client = FakeClient(FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=lambda span, text: "ANNIKA'S FATHER"))))
+        entries, stats, _ = run_chunk(client, chunk, check_tags=True, roster=roster)
+        self.assertEqual(stats["tag_contradictions"], 0)
+        self.assertEqual(joined(entries), chunk)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/app/test_span_integration.py
+++ b/app/test_span_integration.py
@@ -66,6 +66,12 @@ from generate_script import (  # noqa: E402
     salvage_label_entries,
     salvage_markdown_labels,
     select_prompt,
+    build_context,
+    MAX_CONTEXT_ROSTER_NAMES,
+    detect_flatlined_prompt_tokens,
+    estimate_prompt_tokens,
+    is_placeholder_speaker,
+    looks_silently_truncated,
     strip_thinking_tags,
 )
 
@@ -197,9 +203,13 @@ class _FakeChoice:
 class FakeResponse:
     """Minimal stand-in for an OpenAI ChatCompletion response."""
 
-    def __init__(self, content, finish_reason="stop"):
+    def __init__(self, content, finish_reason="stop", prompt_tokens=None):
         self.choices = [_FakeChoice(content, finish_reason)]
-        self.usage = None
+        # usage is None unless a test cares: the silent-truncation tripwire
+        # reads usage.prompt_tokens and must stay quiet when it is absent.
+        self.usage = (types.SimpleNamespace(prompt_tokens=prompt_tokens,
+                                            completion_tokens=0)
+                      if prompt_tokens is not None else None)
 
 
 class _FakeCompletions:
@@ -1332,6 +1342,271 @@ class TestVerbatimAcrossAllFixtures(unittest.TestCase):
                     entries, stats, _ = run_chunk(client, chunk)
                     self.assertEqual(joined(entries), chunk)
                     self.assertEqual(stats["labelled"] + stats["fallback"], stats["spans"])
+
+
+
+# --------------------------------------------------------------------------
+# F15: roster-aware spelling resolution + bounded roster context
+# --------------------------------------------------------------------------
+
+class TestRosterAwareSpellingAtGenerationSeam(unittest.TestCase):
+    """process_chunk/resolve_span_labels accept labels THROUGH the roster.
+
+    Exact whitespace-stripped key equality only; never fuzzy merging.
+    """
+
+    def _chunk_with_speaker(self, name):
+        chunk = '"I am leaving," he said.'
+        client = FakeClient(FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=lambda span, text: name))))
+        return chunk, client
+
+    def test_drifted_spelling_snaps_onto_established_name(self):
+        chunk, client = self._chunk_with_speaker("ABBEMARIGNAN")
+        roster = {"ABBEMARIGNAN": "ABBE MARIGNAN"}
+        entries, _, _ = run_chunk(client, chunk, roster=roster)
+        self.assertEqual(joined(entries), chunk)
+        self.assertIn("ABBE MARIGNAN", [e["speaker"] for e in entries])
+        # Caller's roster index must not be mutated by the chunk.
+        self.assertEqual(roster, {"ABBEMARIGNAN": "ABBE MARIGNAN"})
+
+    def test_more_segmented_spelling_wins_even_if_seen_second(self):
+        # Order-independence: the roster already holds the malformed form, and
+        # the well-formed one arriving later still wins (and is promoted).
+        chunk, client = self._chunk_with_speaker("ABBE MARIGNAN")
+        roster = {"ABBEMARIGNAN": "ABBEMARIGNAN"}
+        entries, _, _ = run_chunk(client, chunk, roster=roster)
+        self.assertIn("ABBE MARIGNAN", [e["speaker"] for e in entries])
+        # ... without mutating the caller's index.
+        self.assertEqual(roster, {"ABBEMARIGNAN": "ABBEMARIGNAN"})
+
+    def test_similar_names_are_never_merged(self):
+        for established, incoming in (("JON", "JOHN"), ("ELLA", "BELLA")):
+            with self.subTest(established=established):
+                chunk, client = self._chunk_with_speaker(incoming)
+                entries, _, _ = run_chunk(
+                    client, chunk, roster={established: established})
+                self.assertIn(incoming, [e["speaker"] for e in entries])
+
+    def test_no_roster_is_backward_compatible(self):
+        chunk, client = self._chunk_with_speaker("ABBEMARIGNAN")
+        entries, _, _ = run_chunk(client, chunk)
+        self.assertEqual(joined(entries), chunk)
+        self.assertIn("ABBEMARIGNAN", [e["speaker"] for e in entries])
+
+
+class TestBoundedRosterContext(unittest.TestCase):
+    """build_context()'s roster block is capped, configurable and honest."""
+
+    @staticmethod
+    def _entries(count):
+        return [{"speaker": f"CHAR{i:03d}", "text": "x", "instruct": "y"}
+                for i in range(count)]
+
+    @staticmethod
+    def _roster_line(context):
+        for line in context.splitlines():
+            if line.startswith("Characters in this book"):
+                return line
+        return None
+
+    def _names(self, context):
+        line = self._roster_line(context)
+        return [n.strip() for n in line.split(":", 1)[1].split(",")]
+
+    def test_small_roster_is_unchanged_and_unannotated(self):
+        context = build_context(2, 10, self._entries(3))
+        line = self._roster_line(context)
+        self.assertEqual(line, "Characters in this book: CHAR000, CHAR001, CHAR002")
+
+    def test_roster_is_capped_at_the_default_limit(self):
+        entries = self._entries(600)
+        names = self._names(build_context(2, 10, entries))
+        self.assertEqual(len(names), MAX_CONTEXT_ROSTER_NAMES)
+
+    def test_cap_keeps_the_most_recent_names(self):
+        entries = self._entries(600)
+        names = self._names(build_context(2, 10, entries))
+        # Most recently spoken = the highest-numbered CHARs.
+        self.assertEqual(sorted(names), sorted(
+            [f"CHAR{i:03d}" for i in range(600 - MAX_CONTEXT_ROSTER_NAMES, 600)]))
+
+    def test_truncation_is_announced_only_when_it_happened(self):
+        truncated = self._roster_line(build_context(2, 10, self._entries(600)))
+        self.assertIn(f"most recent {MAX_CONTEXT_ROSTER_NAMES}", truncated)
+        # No "of M": computing the total would mean scanning every entry.
+        self.assertNotIn("of 600", truncated)
+        untouched = self._roster_line(build_context(2, 10, self._entries(5)))
+        self.assertNotIn("most recent", untouched)
+
+    def test_cap_is_configurable(self):
+        entries = self._entries(600)
+        self.assertEqual(len(self._names(build_context(2, 10, entries,
+                                                       max_roster_names=5))), 5)
+        self.assertEqual(len(self._names(build_context(2, 10, entries,
+                                                       max_roster_names=200))), 200)
+
+    def test_deterministic_across_runs(self):
+        entries = self._entries(600)
+        first = build_context(2, 10, entries)
+        for _ in range(3):
+            self.assertEqual(build_context(2, 10, entries), first)
+
+    def test_narrator_excluded_and_prompt_stays_bounded(self):
+        entries = self._entries(600) + [{"speaker": NARRATOR, "text": "x", "instruct": "y"}]
+        line = self._roster_line(build_context(2, 10, entries))
+        self.assertNotIn(NARRATOR, line)
+        self.assertLess(len(line), 1500)
+
+
+
+
+class TestSilentPromptTruncationTripwire(unittest.TestCase):
+    """A server that silently truncates the prompt must not go unnoticed.
+
+    Production: prompt_tokens pinned at exactly 2050 for 640 of 1,294 records
+    (Ollama's default num_ctx=2048), with a green summary throughout.
+    """
+
+    def test_ratio_check_fires_when_tokens_are_implausibly_low(self):
+        # 40,000 chars is ~10,000 tokens of English; 2,050 reported means the
+        # server kept about a fifth of it.
+        self.assertTrue(looks_silently_truncated(40000, 2050))
+
+    def test_ratio_check_silent_for_a_normal_ratio(self):
+        self.assertFalse(looks_silently_truncated(8000, 2000))
+        self.assertFalse(looks_silently_truncated(8000, 1300))
+
+    def test_no_false_alarm_on_high_token_density_text(self):
+        # CJK source text tokenizes to far MORE tokens per char, which can only
+        # push prompt_tokens up relative to the chars/4 estimate.
+        cjk_chars = 4000
+        for prompt_tokens in (cjk_chars, cjk_chars * 2, cjk_chars // 2):
+            with self.subTest(prompt_tokens=prompt_tokens):
+                self.assertFalse(looks_silently_truncated(cjk_chars, prompt_tokens))
+
+    def test_missing_or_zero_usage_is_never_a_warning(self):
+        self.assertFalse(looks_silently_truncated(40000, None))
+        self.assertFalse(looks_silently_truncated(40000, 0))
+        self.assertFalse(looks_silently_truncated(0, 10))
+
+    def test_estimate_is_chars_over_four(self):
+        self.assertEqual(estimate_prompt_tokens("x" * 4000), 1000)
+        self.assertEqual(estimate_prompt_tokens(""), 0)
+        self.assertEqual(estimate_prompt_tokens(None), 0)
+
+    def test_warning_fires_through_process_chunk_and_is_counted(self):
+        chunk = STRAIGHT_QUOTES
+        client = FakeClient(FakeResponse(json.dumps(labels_for(chunk)), prompt_tokens=1))
+        entries, stats, output = run_chunk(client, chunk)
+        self.assertEqual(joined(entries), chunk)          # prose still intact
+        self.assertIn("PROMPT LIKELY TRUNCATED", output)
+        self.assertIn("OLLAMA_CONTEXT_LENGTH", output)
+        self.assertEqual(stats["prompt_truncation_events"], 1)
+        self.assertGreater(stats["prompt_chars"], 0)
+        # Diagnostic only -- it must not by itself degrade the chunk.
+        self.assertFalse(stats["degraded"])
+
+    def test_no_warning_for_a_healthy_call(self):
+        chunk = STRAIGHT_QUOTES
+        client = FakeClient(FakeResponse(json.dumps(labels_for(chunk)), prompt_tokens=100000))
+        _, stats, output = run_chunk(client, chunk)
+        self.assertNotIn("PROMPT LIKELY TRUNCATED", output)
+        self.assertEqual(stats["prompt_truncation_events"], 0)
+
+    def test_no_warning_when_the_server_reports_no_usage(self):
+        chunk = STRAIGHT_QUOTES
+        client = FakeClient(FakeResponse(json.dumps(labels_for(chunk))))
+        _, stats, output = run_chunk(client, chunk)
+        self.assertNotIn("PROMPT LIKELY TRUNCATED", output)
+        self.assertEqual(stats["prompt_truncation_events"], 0)
+        self.assertIsNone(stats["prompt_tokens"])
+
+
+class TestFlatlineDetection(unittest.TestCase):
+    """The run-level detector for the exact production signature."""
+
+    def test_flatline_detected_when_tokens_pin_despite_varying_prompts(self):
+        samples = [(5000 + 200 * i, 2050) for i in range(30)]
+        result = detect_flatlined_prompt_tokens(samples)
+        self.assertIsNotNone(result)
+        value, count, total = result
+        self.assertEqual((value, count, total), (2050, 30, 30))
+
+    def test_no_flatline_when_tokens_track_prompt_size(self):
+        samples = [(4000 + 100 * i, 1000 + 25 * i) for i in range(40)]
+        self.assertIsNone(detect_flatlined_prompt_tokens(samples))
+
+    def test_no_flatline_when_the_prompts_were_all_the_same_size(self):
+        # Identical prompts SHOULD produce identical token counts.
+        samples = [(8000, 2000) for _ in range(40)]
+        self.assertIsNone(detect_flatlined_prompt_tokens(samples))
+
+    def test_too_few_samples_is_never_a_verdict(self):
+        self.assertIsNone(detect_flatlined_prompt_tokens([(5000 + 200 * i, 2050)
+                                                          for i in range(10)]))
+        self.assertIsNone(detect_flatlined_prompt_tokens([]))
+
+
+class TestNumCtxRequest(unittest.TestCase):
+    """Best-effort serving-context-window request."""
+
+    def _extra_body(self, **kwargs):
+        chunk = STRAIGHT_QUOTES
+        client = FakeClient(FakeResponse(json.dumps(labels_for(chunk))))
+        run_chunk(client, chunk, **kwargs)
+        return client.completions.last_kwargs.get("extra_body", {})
+
+    def test_options_omitted_entirely_when_unconfigured(self):
+        # Users who never set generation.num_ctx must send an unchanged request.
+        self.assertNotIn("options", self._extra_body())
+
+    def test_options_present_when_configured(self):
+        self.assertEqual(self._extra_body(num_ctx=8192), {"options": {"num_ctx": 8192}})
+
+
+class TestPlaceholderLabelRejection(unittest.TestCase):
+    """Invented enumerated placeholders are narrated, not voiced.
+
+    A production run emitted 307 such entries. The pattern is deliberately
+    language-neutral (one token + a bare number) and carries no word list.
+    """
+
+    def test_pattern_matches_enumerated_placeholders_only(self):
+        for name in ("SPEAKER 1", "SPEAKER 2", "SPEAKER1", "VOICE 3", "CHARACTER 12"):
+            with self.subTest(name=name):
+                self.assertTrue(is_placeholder_speaker(name))
+        for name in ("MARCUS", "ABBE MARIGNAN", "JEAN-LUC", "O'BRIEN", "NARRATOR",
+                     "HENRY VIII", "MARY ANNE SMITH", "", None):
+            with self.subTest(name=name):
+                self.assertFalse(is_placeholder_speaker(name))
+
+    def test_placeholder_label_is_narrated_and_counted(self):
+        chunk = STRAIGHT_QUOTES
+        client = FakeClient(FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=lambda span, text: "SPEAKER 1"))))
+        entries, stats, _ = run_chunk(client, chunk)
+        self.assertEqual(joined(entries), chunk)
+        self.assertEqual({e["speaker"] for e in entries}, {NARRATOR})
+        # STRAIGHT_QUOTES has two quoted spans; both placeholders are rejected.
+        self.assertEqual(stats["placeholder_rejected"], 2)
+
+    def test_real_name_is_untouched(self):
+        chunk = STRAIGHT_QUOTES
+        client = FakeClient(FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=lambda span, text: "MARCUS"))))
+        entries, stats, _ = run_chunk(client, chunk)
+        self.assertIn("MARCUS", [e["speaker"] for e in entries])
+        self.assertEqual(stats["placeholder_rejected"], 0)
+
+    def test_placeholder_never_enters_the_roster(self):
+        chunk = STRAIGHT_QUOTES
+        roster = {}
+        client = FakeClient(FakeResponse(json.dumps(
+            labels_for(chunk, speaker_of=lambda span, text: "SPEAKER 2"))))
+        run_chunk(client, chunk, roster=roster)
+        self.assertEqual(roster, {})
+
 
 
 if __name__ == "__main__":

--- a/app/test_span_tokenizer.py
+++ b/app/test_span_tokenizer.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python
+"""Standalone unit tests for app/span_tokenizer.py.
+
+Run directly -- no pytest, no live server required:
+
+    python app/test_span_tokenizer.py
+
+Exits 0 when every test passes, nonzero otherwise.
+"""
+
+import os
+import sys
+import time
+import unittest
+
+# Windows consoles default to cp1252; the fixtures contain curly quotes.
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+    except Exception:
+        pass
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from span_tokenizer import (  # noqa: E402
+    MAX_AMBIGUOUS_SINGLE_SPAN,
+    QUOTED,
+    UNQUOTED,
+    Span,
+    reassemble,
+    tokenize,
+    validate_spans,
+)
+
+
+def segments(source):
+    """Return [(kind, text), ...] -- the readable view of a tokenization."""
+    return [(s.kind, source[s.start:s.end]) for s in tokenize(source)]
+
+
+# --------------------------------------------------------------------------
+# The corpus. Every fixture is checked by the property test below.
+# --------------------------------------------------------------------------
+
+PROSE_MIXED = (
+    'Marcus set down the lantern. "We can\'t stay here," he said, and the\n'
+    'words hung between them like smoke. "Not after what the Joneses\' boy\n'
+    'told me."\n'
+    '\n'
+    "Elena did not answer at first. She was thinking of the '90s, of the\n"
+    "summer her father had said, 'Everything ends, and that is the whole of\n"
+    "it.'\n"
+    '\n'
+    '"Don\'t," she said finally. "Don\'t say \'ends\' to me tonight."\n'
+)
+
+PROSE_CURLY = (
+    "“You were never going to tell me,” she said. It wasn’t a "
+    "question.\n"
+    "\n"
+    "“I was,” Marcus answered. “I was waiting for the right "
+    "hour, and then there wasn’t one.” He turned the glass in his "
+    "hand. “She told me ‘go away’ and I went.”\n"
+    "\n"
+    "— Then go again, Elena thought, and said nothing at all.\n"
+)
+
+# The audit probe: a false opener plus a distant possessive used to swallow
+# 1139 characters of narration into one "quoted" span.
+RUNAWAY_PROBE = (
+    "He said 'no more. "
+    + ("Filler narration text here. " * 40)
+    + "The dogs' tails wagged."
+)
+
+# Same shape, but the only candidate closer sits in a later paragraph.
+CLOSER_IN_LATER_PARAGRAPH = (
+    "He said 'no more and walked out into the rain.\n"
+    "\n"
+    "The dogs' tails wagged when he reached the gate.\n"
+)
+
+CORPUS = [
+    # 1-4: the item-3 splitting rule, straight and curly, double and single
+    '"I am leaving," he said.',
+    "“I am leaving,” he said.",
+    "'Hello,' she said.",
+    "‘Hello,’ she said.",
+    # 5-6: nested quotes -- outer quotation is ONE span
+    '"She told me \'go away\' yesterday," he said.',
+    "“She told me ‘go away’ yesterday,” he said.",
+    # 7-9: apostrophes that are not delimiters
+    "Don't touch Jones' hat; 'tis his.",
+    "It doesn’t matter, 'twas Jones’ idea.",
+    "Back in the '90s, things were different, 'round here at least.",
+    # 10-12: unterminated quotations
+    'He said, "I am leaving',
+    "He said, 'I am leaving",
+    "He said, ‘I am leaving",
+    # 13-14: dialogue the tokenizer must NOT try to classify
+    "— I am leaving, he said.",
+    "I am leaving, he said, and then he left.",
+    # 15-17: structural edges
+    '"Yes."',
+    '"A""B"',
+    'Those are the dogs\' and those are the cats\'',
+    # 18-20: whitespace, newlines, mixed glyphs in one document
+    "   ",
+    '"I am leaving,\nand I am not coming back," he said.\n',
+    "“First,” he said. \"Second,\" she replied. ‘Third,’ "
+    "they agreed.",
+    # 21-23: realistic prose
+    PROSE_MIXED,
+    PROSE_CURLY,
+    'The letter read: "To whom it may concern -- I regret nothing." Below it,\n'
+    "unsigned, someone had written 'liar' in pencil. Marcus didn't laugh.\n",
+    # 24-25: the runaway-opener probe and its paragraph-crossing sibling
+    RUNAWAY_PROBE,
+    CLOSER_IN_LATER_PARAGRAPH,
+]
+
+
+class TestProperties(unittest.TestCase):
+    """The invariants every caller depends on, for every fixture."""
+
+    def test_join_equals_source(self):
+        for index, source in enumerate(CORPUS, start=1):
+            spans = tokenize(source)
+            joined = "".join(source[s.start:s.end] for s in spans)
+            self.assertEqual(
+                joined, source, "fixture %d did not reassemble verbatim" % index
+            )
+            self.assertEqual(reassemble(spans, source), source)
+
+    def test_contiguous_covering_and_numbered(self):
+        for index, source in enumerate(CORPUS, start=1):
+            spans = tokenize(source)
+            self.assertTrue(spans, "fixture %d produced no spans" % index)
+            self.assertEqual(spans[0].start, 0, "fixture %d start" % index)
+            self.assertEqual(spans[-1].end, len(source), "fixture %d end" % index)
+            for position, span in enumerate(spans):
+                self.assertEqual(span.id, position + 1, "fixture %d ids" % index)
+                self.assertGreater(span.end, span.start, "fixture %d empty" % index)
+                self.assertIn(span.kind, (QUOTED, UNQUOTED))
+            for first, second in zip(spans, spans[1:]):
+                self.assertEqual(
+                    first.end, second.start, "fixture %d contiguity" % index
+                )
+
+    def test_validate_spans_accepts_every_fixture(self):
+        for index, source in enumerate(CORPUS, start=1):
+            self.assertTrue(
+                validate_spans(tokenize(source), source),
+                "fixture %d failed validation" % index,
+            )
+
+    def test_validate_spans_rejects_a_broken_tiling(self):
+        source = '"Go," he said.'
+        good = tokenize(source)
+        broken = [Span(id=1, start=0, end=5, kind=QUOTED)]
+        with self.assertRaises(ValueError):
+            validate_spans(broken, source)
+        # renumbered out of order
+        scrambled = [
+            Span(id=s.id + 1, start=s.start, end=s.end, kind=s.kind) for s in good
+        ]
+        with self.assertRaises(ValueError):
+            validate_spans(scrambled, source)
+
+    def test_empty_source(self):
+        self.assertEqual(tokenize(""), [])
+        self.assertEqual(reassemble([], ""), "")
+        self.assertTrue(validate_spans([], ""))
+
+    def test_book_sized_input_stays_linear(self):
+        # Regression guard: the opener rule asks "does a closer exist later?".
+        # When that was a rescan of the tail, this input took ~60s. The bound
+        # is deliberately loose so it flags a return to quadratic, not a slow
+        # machine.
+        adversarial = "He said 'x " * 20000
+        start = time.time()
+        spans = tokenize(adversarial)
+        elapsed = time.time() - start
+        self.assertTrue(validate_spans(spans, adversarial))
+        self.assertLess(elapsed, 10.0, "tokenize() went quadratic: %.1fs" % elapsed)
+
+        prose = PROSE_MIXED * 2000
+        start = time.time()
+        spans = tokenize(prose)
+        elapsed = time.time() - start
+        self.assertTrue(validate_spans(spans, prose))
+        self.assertLess(elapsed, 10.0, "tokenize() went quadratic: %.1fs" % elapsed)
+
+
+class TestSplittingRule(unittest.TestCase):
+    """Item 3: quote marks belong to the quoted span; the tag stays unquoted."""
+
+    def test_straight_double(self):
+        self.assertEqual(
+            segments('"I am leaving," he said.'),
+            [(QUOTED, '"I am leaving,"'), (UNQUOTED, " he said.")],
+        )
+
+    def test_curly_double(self):
+        self.assertEqual(
+            segments("“I am leaving,” he said."),
+            [(QUOTED, "“I am leaving,”"), (UNQUOTED, " he said.")],
+        )
+
+    def test_leading_whitespace_belongs_to_the_unquoted_span(self):
+        self.assertEqual(
+            segments('He said, "I am leaving." Then he left.'),
+            [
+                (UNQUOTED, "He said, "),
+                (QUOTED, '"I am leaving."'),
+                (UNQUOTED, " Then he left."),
+            ],
+        )
+
+    def test_span_text_helper(self):
+        source = '"Go," he said.'
+        spans = tokenize(source)
+        self.assertEqual(spans[0].text(source), '"Go,"')
+        self.assertEqual(spans[0].as_dict()["kind"], QUOTED)
+
+
+class TestSingleQuotes(unittest.TestCase):
+    """Item 4: single-quoted dialogue vs. apostrophes."""
+
+    def test_single_quoted_dialogue(self):
+        self.assertEqual(
+            segments("'Hello,' she said."),
+            [(QUOTED, "'Hello,'"), (UNQUOTED, " she said.")],
+        )
+
+    def test_curly_single_quoted_dialogue(self):
+        self.assertEqual(
+            segments("‘Hello,’ she said."),
+            [(QUOTED, "‘Hello,’"), (UNQUOTED, " she said.")],
+        )
+
+    def test_apostrophe_inside_word_is_not_a_delimiter(self):
+        source = "Don't stop; it doesn’t matter."
+        self.assertEqual(segments(source), [(UNQUOTED, source)])
+
+    def test_leading_elision_does_not_open_a_span(self):
+        source = "'tis a fine day, and 'twas a finer night."
+        self.assertEqual(segments(source), [(UNQUOTED, source)])
+
+    def test_trailing_possessive_does_not_open_a_span(self):
+        source = "Those are Jones' boots and the Joneses’ cart."
+        self.assertEqual(segments(source), [(UNQUOTED, source)])
+
+    def test_possessive_at_very_end_of_input(self):
+        source = "Those boots are Jones'"
+        self.assertEqual(segments(source), [(UNQUOTED, source)])
+
+    def test_decade_elision_is_not_an_opener(self):
+        source = "Back in the '90s nobody asked."
+        self.assertEqual(segments(source), [(UNQUOTED, source)])
+
+    def test_apostrophe_survives_inside_single_quoted_dialogue(self):
+        self.assertEqual(
+            segments("'It doesn't matter,' she said."),
+            [(QUOTED, "'It doesn't matter,'"), (UNQUOTED, " she said.")],
+        )
+
+    def test_curly_apostrophe_survives_inside_curly_dialogue(self):
+        self.assertEqual(
+            segments("‘It doesn’t matter,’ she said."),
+            [
+                (QUOTED, "‘It doesn’t matter,’"),
+                (UNQUOTED, " she said."),
+            ],
+        )
+
+    def test_two_single_quoted_phrases(self):
+        self.assertEqual(
+            segments("She said 'yes' and then 'no' and left."),
+            [
+                (UNQUOTED, "She said "),
+                (QUOTED, "'yes'"),
+                (UNQUOTED, " and then "),
+                (QUOTED, "'no'"),
+                (UNQUOTED, " and left."),
+            ],
+        )
+
+
+class TestRunawayOpenerBounds(unittest.TestCase):
+    """Rule 5's two bounds: an ambiguous opener cannot swallow narration."""
+
+    def test_audit_probe_filler_stays_unquoted(self):
+        spans = tokenize(RUNAWAY_PROBE)
+        self.assertEqual(
+            segments(RUNAWAY_PROBE), [(UNQUOTED, RUNAWAY_PROBE)]
+        )
+        # Nothing anywhere may be quoted, and certainly nothing page-sized.
+        for span in spans:
+            self.assertEqual(span.kind, UNQUOTED)
+        self.assertNotIn("Filler narration", "".join(
+            s.text(RUNAWAY_PROBE) for s in spans if s.kind == QUOTED
+        ))
+
+    def test_closer_only_in_a_later_paragraph_does_not_open(self):
+        source = CLOSER_IN_LATER_PARAGRAPH
+        self.assertEqual(segments(source), [(UNQUOTED, source)])
+
+    def test_paragraph_bound_uses_blank_line_not_single_newline(self):
+        # A single newline inside a paragraph must NOT end the search.
+        source = "She said 'Everything ends,\nand that is all.' He nodded."
+        self.assertEqual(
+            segments(source),
+            [
+                (UNQUOTED, "She said "),
+                (QUOTED, "'Everything ends,\nand that is all.'"),
+                (UNQUOTED, " He nodded."),
+            ],
+        )
+
+    def test_blank_line_with_horizontal_whitespace_counts_as_a_break(self):
+        source = "He said 'no more and left.\n   \nThe dogs' tails wagged.\n"
+        self.assertEqual(segments(source), [(UNQUOTED, source)])
+
+    def test_legitimate_dialogue_within_one_paragraph_still_quotes(self):
+        source = (
+            "'I have thought about it for a long time, and I do not think "
+            "there is any way around it,' she said at last."
+        )
+        spans = tokenize(source)
+        self.assertEqual(spans[0].kind, QUOTED)
+        self.assertTrue(spans[0].text(source).endswith("around it,'"))
+        self.assertEqual(spans[1].kind, UNQUOTED)
+
+    def test_span_just_under_the_length_cap_still_quotes(self):
+        body = "word " * 90  # ~450 chars, comfortably under the 500 cap
+        source = "She said '" + body + "end.' He nodded."
+        spans = tokenize(source)
+        self.assertLess(len(body), MAX_AMBIGUOUS_SINGLE_SPAN)
+        self.assertEqual(spans[1].kind, QUOTED)
+
+    def test_span_over_the_length_cap_does_not_open(self):
+        body = "word " * 200  # ~1000 chars, over the cap, single paragraph
+        source = "She said '" + body + "end.' He nodded."
+        self.assertEqual(segments(source), [(UNQUOTED, source)])
+
+    def test_unambiguous_curly_single_is_exempt_from_both_bounds(self):
+        long_body = "word " * 200
+        source = "She said ‘" + long_body + "end.’ He nodded."
+        spans = tokenize(source)
+        self.assertEqual(spans[1].kind, QUOTED)
+        self.assertGreater(spans[1].end - spans[1].start, MAX_AMBIGUOUS_SINGLE_SPAN)
+
+        across = "She said ‘no more and left.\n\nThe rain kept on.’ He nodded."
+        self.assertEqual(tokenize(across)[1].kind, QUOTED)
+
+    def test_double_quotes_are_exempt_from_both_bounds(self):
+        long_body = "word " * 200
+        source = 'She said "' + long_body + 'end." He nodded.'
+        spans = tokenize(source)
+        self.assertEqual(spans[1].kind, QUOTED)
+        self.assertGreater(spans[1].end - spans[1].start, MAX_AMBIGUOUS_SINGLE_SPAN)
+
+
+class TestNestedQuotes(unittest.TestCase):
+    """Item 4: the outer quotation is ONE span; inner quotes stay inside."""
+
+    def test_single_nested_in_double(self):
+        self.assertEqual(
+            segments('"She told me \'go away\' yesterday," he said.'),
+            [
+                (QUOTED, '"She told me \'go away\' yesterday,"'),
+                (UNQUOTED, " he said."),
+            ],
+        )
+
+    def test_curly_single_nested_in_curly_double(self):
+        source = (
+            "“She told me ‘go away’ yesterday,” he said."
+        )
+        self.assertEqual(
+            segments(source),
+            [
+                (QUOTED, "“She told me ‘go away’ yesterday,”"),
+                (UNQUOTED, " he said."),
+            ],
+        )
+
+    def test_double_nested_in_single(self):
+        self.assertEqual(
+            segments("'She said \"go away\" to me,' he noted."),
+            [
+                (QUOTED, "'She said \"go away\" to me,'"),
+                (UNQUOTED, " he noted."),
+            ],
+        )
+
+
+class TestUnterminatedQuotes(unittest.TestCase):
+    """Item 4: no crash, no lost text."""
+
+    def test_unterminated_double_runs_to_end(self):
+        self.assertEqual(
+            segments('He said, "I am leaving'),
+            [(UNQUOTED, "He said, "), (QUOTED, '"I am leaving')],
+        )
+
+    def test_unterminated_curly_double_runs_to_end(self):
+        self.assertEqual(
+            segments("He said, “I am leaving"),
+            [(UNQUOTED, "He said, "), (QUOTED, "“I am leaving")],
+        )
+
+    def test_unterminated_curly_single_runs_to_end(self):
+        self.assertEqual(
+            segments("He said, ‘I am leaving"),
+            [(UNQUOTED, "He said, "), (QUOTED, "‘I am leaving")],
+        )
+
+    def test_unterminated_ambiguous_single_stays_unquoted(self):
+        # Rule 5: with no valid closer, apostrophe is the safer reading and
+        # narrator fallback is the safe failure mode.
+        source = "He said, 'I am leaving"
+        self.assertEqual(segments(source), [(UNQUOTED, source)])
+
+    def test_quote_opening_at_index_zero_has_no_empty_leading_span(self):
+        spans = tokenize('"Yes."')
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(spans[0].kind, QUOTED)
+        self.assertEqual(spans[0].start, 0)
+
+
+class TestUnquotedDialogue(unittest.TestCase):
+    """Item 4: em-dash and unquoted dialogue stay UNQUOTED for the LLM."""
+
+    def test_em_dash_dialogue(self):
+        source = "— I am leaving, he said.\n— Then go."
+        self.assertEqual(segments(source), [(UNQUOTED, source)])
+
+    def test_unquoted_dialogue(self):
+        source = "I am leaving, he said, and she did not stop him."
+        self.assertEqual(segments(source), [(UNQUOTED, source)])
+
+    def test_attribution_tag_is_never_dropped(self):
+        source = '"I am leaving," said John, who never returned.'
+        spans = tokenize(source)
+        self.assertEqual(spans[-1].kind, UNQUOTED)
+        self.assertIn("said John", spans[-1].text(source))
+
+
+class TestStructuralEdges(unittest.TestCase):
+    def test_adjacent_quotes_produce_no_empty_span(self):
+        self.assertEqual(
+            segments('"A""B"'), [(QUOTED, '"A"'), (QUOTED, '"B"')]
+        )
+
+    def test_whitespace_only_input(self):
+        self.assertEqual(segments("   \n\t "), [(UNQUOTED, "   \n\t ")])
+
+    def test_quote_spanning_a_newline(self):
+        source = '"I am leaving,\nand not coming back," he said.\n'
+        self.assertEqual(
+            segments(source),
+            [
+                (QUOTED, '"I am leaving,\nand not coming back,"'),
+                (UNQUOTED, " he said.\n"),
+            ],
+        )
+
+    def test_mixed_straight_and_curly_in_one_document(self):
+        source = (
+            "“First,” he said. \"Second,\" she replied. "
+            "‘Third,’ they agreed."
+        )
+        kinds = [s.kind for s in tokenize(source)]
+        self.assertEqual(
+            kinds,
+            [QUOTED, UNQUOTED, QUOTED, UNQUOTED, QUOTED, UNQUOTED],
+        )
+        quoted = [s.text(source) for s in tokenize(source) if s.kind == QUOTED]
+        self.assertEqual(
+            quoted,
+            ["“First,”", '"Second,"', "‘Third,’"],
+        )
+
+    def test_realistic_prose_quoted_spans(self):
+        quoted = [
+            s.text(PROSE_MIXED)
+            for s in tokenize(PROSE_MIXED)
+            if s.kind == QUOTED
+        ]
+        self.assertEqual(
+            quoted,
+            [
+                '"We can\'t stay here,"',
+                '"Not after what the Joneses\' boy\ntold me."',
+                "'Everything ends, and that is the whole of\nit.'",
+                '"Don\'t,"',
+                '"Don\'t say \'ends\' to me tonight."',
+            ],
+        )
+
+    def test_realistic_curly_prose_quoted_spans(self):
+        quoted = [
+            s.text(PROSE_CURLY)
+            for s in tokenize(PROSE_CURLY)
+            if s.kind == QUOTED
+        ]
+        self.assertEqual(
+            quoted,
+            [
+                "“You were never going to tell me,”",
+                "“I was,”",
+                "“I was waiting for the right hour, and then there "
+                "wasn’t one.”",
+                "“She told me ‘go away’ and I went.”",
+            ],
+        )
+        # The em-dash line must remain narration.
+        tail = tokenize(PROSE_CURLY)[-1].text(PROSE_CURLY)
+        self.assertIn("— Then go again", tail)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/app/test_span_tokenizer.py
+++ b/app/test_span_tokenizer.py
@@ -80,6 +80,25 @@ CLOSER_IN_LATER_PARAGRAPH = (
     "The dogs' tails wagged when he reached the gate.\n"
 )
 
+# --- non-English conventions ------------------------------------------------
+# French typography puts a space INSIDE the guillemets. Real books use U+00A0
+# (no-break) or U+202F (narrow no-break) as often as U+0020; all three are part
+# of the quoted span and must survive byte-exactly.
+NBSP = " "
+NNBSP = " "
+
+FRENCH_NBSP = "«" + NBSP + "Je pars." + NBSP + "»"
+FRENCH_NNBSP = "«" + NNBSP + "Je pars." + NNBSP + "»"
+
+FRENCH_INNER = "«" + NBSP + "Bonjour," + NBSP + "»"
+
+MULTILINGUAL_DOC = (
+    FRENCH_INNER + " dit-il. "
+    "「こんにちは」と彼は言った。"
+    "„Guten Tag,“ sagte sie. "
+    '"Hello," he said.\n'
+)
+
 CORPUS = [
     # 1-4: the item-3 splitting rule, straight and curly, double and single
     '"I am leaving," he said.',
@@ -117,6 +136,30 @@ CORPUS = [
     # 24-25: the runaway-opener probe and its paragraph-crossing sibling
     RUNAWAY_PROBE,
     CLOSER_IN_LATER_PARAGRAPH,
+    # 26-31: guillemets, plain and with French inner spacing
+    "« Je pars. »",
+    "« Je pars, » dit-il.",
+    FRENCH_NBSP,
+    FRENCH_NNBSP,
+    "Il a dit « Je pars » et il est parti.",
+    "Il a dit « Je pars et il n'est jamais revenu.",
+    # 32-35: single guillemets
+    "‹ Oui ›, dit-elle.",
+    "« Elle a dit ‹ va-t'en › hier, » dit-il.",
+    "‹ Oui",
+    # 35-39: CJK corner brackets
+    "「こんにちは」と彼は言った。",
+    "「彼は『さようなら』と言った」と彼女は言った。",
+    "『白い箱』を開けた。",
+    "「終わりだ",
+    # 40-43: German / Polish low-high
+    "„Ich gehe,“ sagte er.",
+    "„Sie sagte ‚geh weg‘ gestern,“ sagte er.",
+    "‚Ja‘, sagte sie.",
+    "„Ich gehe",
+    # 44-45: full-width and a mixed-convention document
+    "＂やあ＂と彼は言った。",
+    MULTILINGUAL_DOC,
 ]
 
 
@@ -519,6 +562,224 @@ class TestStructuralEdges(unittest.TestCase):
         # The em-dash line must remain narration.
         tail = tokenize(PROSE_CURLY)[-1].text(PROSE_CURLY)
         self.assertIn("— Then go again", tail)
+
+
+class TestGuillemets(unittest.TestCase):
+    """French / Russian / Spanish « » and the single ‹ ›."""
+
+    def test_simple_guillemets(self):
+        self.assertEqual(segments("« Je pars. »"), [(QUOTED, "« Je pars. »")])
+
+    def test_attribution_tag_after_guillemets(self):
+        self.assertEqual(
+            segments("« Je pars, » dit-il."),
+            [(QUOTED, "« Je pars, »"), (UNQUOTED, " dit-il.")],
+        )
+
+    def test_leading_narration_before_guillemets(self):
+        self.assertEqual(
+            segments("Il a dit « Je pars » et il est parti."),
+            [
+                (UNQUOTED, "Il a dit "),
+                (QUOTED, "« Je pars »"),
+                (UNQUOTED, " et il est parti."),
+            ],
+        )
+
+    def test_french_inner_nbsp_is_preserved_byte_exactly(self):
+        for source in (FRENCH_NBSP, FRENCH_NNBSP):
+            spans = tokenize(source)
+            self.assertEqual(len(spans), 1)
+            self.assertEqual(spans[0].kind, QUOTED)
+            # byte-exact, including the no-break space glyphs themselves
+            self.assertEqual(spans[0].text(source), source)
+            self.assertEqual(
+                spans[0].text(source).encode("utf-8"), source.encode("utf-8")
+            )
+
+    def test_nbsp_variants_are_distinct_and_not_normalized(self):
+        self.assertNotEqual(FRENCH_NBSP, FRENCH_NNBSP)
+        self.assertIn(" ", tokenize(FRENCH_NBSP)[0].text(FRENCH_NBSP))
+        self.assertIn(" ", tokenize(FRENCH_NNBSP)[0].text(FRENCH_NNBSP))
+
+    def test_unterminated_guillemet_runs_to_end(self):
+        source = "Il a dit « Je pars et il n'est jamais revenu."
+        self.assertEqual(
+            segments(source),
+            [(UNQUOTED, "Il a dit "), (QUOTED, "« Je pars et il n'est jamais revenu.")],
+        )
+
+    def test_single_guillemets(self):
+        self.assertEqual(
+            segments("‹ Oui ›, dit-elle."),
+            [(QUOTED, "‹ Oui ›"), (UNQUOTED, ", dit-elle.")],
+        )
+
+    def test_single_guillemets_nested_in_double(self):
+        source = "« Elle a dit ‹ va-t'en › hier, » dit-il."
+        self.assertEqual(
+            segments(source),
+            [
+                (QUOTED, "« Elle a dit ‹ va-t'en › hier, »"),
+                (UNQUOTED, " dit-il."),
+            ],
+        )
+
+    def test_unterminated_single_guillemet_runs_to_end(self):
+        self.assertEqual(segments("‹ Oui"), [(QUOTED, "‹ Oui")])
+
+    def test_russian_guillemets_with_nested_low_high(self):
+        source = "Он сказал: «Она сказала „уходи“ вчера», и ушёл."
+        self.assertEqual(
+            segments(source),
+            [
+                (UNQUOTED, "Он сказал: "),
+                (QUOTED, "«Она сказала „уходи“ вчера»"),
+                (UNQUOTED, ", и ушёл."),
+            ],
+        )
+
+
+class TestCornerBrackets(unittest.TestCase):
+    """Japanese / Chinese 「」 and 『』."""
+
+    def test_simple_corner_brackets(self):
+        self.assertEqual(
+            segments("「こんにちは」と彼は言った。"),
+            [(QUOTED, "「こんにちは」"), (UNQUOTED, "と彼は言った。")],
+        )
+
+    def test_white_corner_brackets(self):
+        self.assertEqual(
+            segments("彼は『さようなら』と言った。"),
+            [
+                (UNQUOTED, "彼は"),
+                (QUOTED, "『さようなら』"),
+                (UNQUOTED, "と言った。"),
+            ],
+        )
+
+    def test_white_nested_in_plain_corner_brackets(self):
+        source = "「彼は『さようなら』と言った」と彼女は言った。"
+        self.assertEqual(
+            segments(source),
+            [
+                (QUOTED, "「彼は『さようなら』と言った」"),
+                (UNQUOTED, "と彼女は言った。"),
+            ],
+        )
+
+    def test_unterminated_corner_bracket_runs_to_end(self):
+        self.assertEqual(segments("「終わりだ"), [(QUOTED, "「終わりだ")])
+
+    def test_full_width_double_quote(self):
+        self.assertEqual(
+            segments("＂やあ＂と彼は言った。"),
+            [(QUOTED, "＂やあ＂"), (UNQUOTED, "と彼は言った。")],
+        )
+
+
+class TestLowHighQuotes(unittest.TestCase):
+    """German / Polish „ … “ and ‚ … ‘.
+
+    ``“`` is an OPENER in English and a CLOSER here. State decides: in
+    NARRATION it opens; inside a ``„`` span only ``„``'s closers are consulted.
+    """
+
+    def test_simple_low_high(self):
+        self.assertEqual(
+            segments("„Ich gehe,“ sagte er."),
+            [(QUOTED, "„Ich gehe,“"), (UNQUOTED, " sagte er.")],
+        )
+
+    def test_low_high_single(self):
+        self.assertEqual(
+            segments("‚Ja‘, sagte sie."),
+            [(QUOTED, "‚Ja‘"), (UNQUOTED, ", sagte sie.")],
+        )
+
+    def test_single_nested_in_double_low_high(self):
+        source = "„Sie sagte ‚geh weg‘ gestern,“ sagte er."
+        self.assertEqual(
+            segments(source),
+            [
+                (QUOTED, "„Sie sagte ‚geh weg‘ gestern,“"),
+                (UNQUOTED, " sagte er."),
+            ],
+        )
+
+    def test_low_high_also_closes_on_right_curly(self):
+        # Some typesetters close „ with ” rather than “.
+        self.assertEqual(
+            segments("„Ich gehe,” sagte er."),
+            [(QUOTED, "„Ich gehe,”"), (UNQUOTED, " sagte er.")],
+        )
+
+    def test_unterminated_low_high_runs_to_end(self):
+        self.assertEqual(segments("„Ich gehe"), [(QUOTED, "„Ich gehe")])
+
+
+class TestEnglishUnchangedByNewConventions(unittest.TestCase):
+    """Regression guard: adding „ and ‚ must not disturb “ ” ‘ ’ or " '."""
+
+    def test_curly_double_still_opens_in_narration(self):
+        self.assertEqual(
+            segments("“I am leaving,” he said."),
+            [(QUOTED, "“I am leaving,”"), (UNQUOTED, " he said.")],
+        )
+
+    def test_straight_double_still_closes_on_curly_and_vice_versa(self):
+        self.assertEqual(segments('"Mixed,” he said.')[0][1], '"Mixed,”')
+        self.assertEqual(segments('“Mixed," he said.')[0][1], '“Mixed,"')
+
+    def test_curly_single_still_opens_in_narration(self):
+        self.assertEqual(
+            segments("‘Hello,’ she said."),
+            [(QUOTED, "‘Hello,’"), (UNQUOTED, " she said.")],
+        )
+
+    def test_ambiguous_single_machinery_untouched(self):
+        self.assertEqual(
+            segments("Don't touch Jones' hat; 'tis his."),
+            [(UNQUOTED, "Don't touch Jones' hat; 'tis his.")],
+        )
+        self.assertEqual(
+            segments("'Hello,' she said."),
+            [(QUOTED, "'Hello,'"), (UNQUOTED, " she said.")],
+        )
+        self.assertEqual(segments(RUNAWAY_PROBE), [(UNQUOTED, RUNAWAY_PROBE)])
+
+    def test_english_prose_fixtures_are_byte_identical_to_before(self):
+        for source in (PROSE_MIXED, PROSE_CURLY):
+            self.assertEqual(reassemble(tokenize(source), source), source)
+
+
+class TestMixedConventionDocument(unittest.TestCase):
+    def test_four_conventions_in_one_document(self):
+        source = MULTILINGUAL_DOC
+        quoted = [s.text(source) for s in tokenize(source) if s.kind == QUOTED]
+        self.assertEqual(
+            quoted,
+            [
+                FRENCH_INNER,
+                "「こんにちは」",
+                "„Guten Tag,“",
+                '"Hello,"',
+            ],
+        )
+        self.assertTrue(validate_spans(tokenize(source), source))
+
+    def test_opener_of_one_convention_is_not_closed_by_another(self):
+        # A stray » inside an English quotation must not close it, and a stray
+        # " inside a guillemet quotation must not close that.
+        self.assertEqual(
+            segments('"a » b" c'),
+            [(QUOTED, '"a » b"'), (UNQUOTED, " c")],
+        )
+        self.assertEqual(
+            segments('« a " b » c'),
+            [(QUOTED, '« a " b »'), (UNQUOTED, " c")],
+        )
 
 
 if __name__ == "__main__":

--- a/app/test_span_tokenizer.py
+++ b/app/test_span_tokenizer.py
@@ -387,15 +387,61 @@ class TestRunawayOpenerBounds(unittest.TestCase):
         source = "She said '" + body + "end.' He nodded."
         self.assertEqual(segments(source), [(UNQUOTED, source)])
 
-    def test_unambiguous_curly_single_is_exempt_from_both_bounds(self):
+    def test_curly_single_is_subject_to_both_bounds_too(self):
+        # ‘ used to be exempt. Measured on a real ebook, that let a wrong-way
+        # smart apostrophe or an elided name open page-long "quotations".
         long_body = "word " * 200
         source = "She said ‘" + long_body + "end.’ He nodded."
-        spans = tokenize(source)
-        self.assertEqual(spans[1].kind, QUOTED)
-        self.assertGreater(spans[1].end - spans[1].start, MAX_AMBIGUOUS_SINGLE_SPAN)
+        self.assertEqual(segments(source), [(UNQUOTED, source)])
 
         across = "She said ‘no more and left.\n\nThe rain kept on.’ He nodded."
-        self.assertEqual(tokenize(across)[1].kind, QUOTED)
+        self.assertEqual(segments(across), [(UNQUOTED, across)])
+
+    def test_curly_single_after_a_letter_never_opens(self):
+        # Wrong-direction smart apostrophe: rule 1 rejects it exactly as it
+        # rejects O'Brien / Jones'. No lexicon involved.
+        source = "The cousins‘ tails wagged and the valuta‘s value fell."
+        self.assertEqual(segments(source), [(UNQUOTED, source)])
+
+    def test_curly_single_bounded_but_not_subject_to_rules_2_to_4(self):
+        # Rules 2-4 read the FOLLOWING character to tell apostrophe from
+        # quote -- a question ‘ does not raise. Elisions and digits still open.
+        self.assertEqual(
+            segments("‘Tis done,’ he said."),
+            [(QUOTED, "‘Tis done,’"), (UNQUOTED, " he said.")],
+        )
+        self.assertEqual(
+            segments("‘1984 was the year,’ she said."),
+            [(QUOTED, "‘1984 was the year,’"), (UNQUOTED, " she said.")],
+        )
+
+
+class TestBritishSingleQuotedDialogue(unittest.TestCase):
+    """Regression guard: books using ‘ … ’ as the PRIMARY dialogue mark."""
+
+    def test_ordinary_single_quoted_dialogue_tokenizes(self):
+        source = (
+            "‘Hello,’ he said. ‘I did not expect you.’\n\n"
+            "She shrugged. ‘Nor did I,’ she answered, ‘but here we are.’"
+        )
+        quoted = [t for kind, t in segments(source) if kind == QUOTED]
+        self.assertEqual(
+            quoted,
+            [
+                "‘Hello,’",
+                "‘I did not expect you.’",
+                "‘Nor did I,’",
+                "‘but here we are.’",
+            ],
+        )
+        self.assertEqual("".join(t for _, t in segments(source)), source)
+
+    def test_apostrophes_inside_single_quoted_dialogue_do_not_close_it(self):
+        source = "‘It doesn’t matter,’ she said."
+        self.assertEqual(
+            segments(source),
+            [(QUOTED, "‘It doesn’t matter,’"), (UNQUOTED, " she said.")],
+        )
 
     def test_double_quotes_are_exempt_from_both_bounds(self):
         long_body = "word " * 200
@@ -454,11 +500,11 @@ class TestUnterminatedQuotes(unittest.TestCase):
             [(UNQUOTED, "He said, "), (QUOTED, "“I am leaving")],
         )
 
-    def test_unterminated_curly_single_runs_to_end(self):
-        self.assertEqual(
-            segments("He said, ‘I am leaving"),
-            [(UNQUOTED, "He said, "), (QUOTED, "‘I am leaving")],
-        )
+    def test_unterminated_curly_single_stays_unquoted(self):
+        # Rule 5 now covers ‘ as well: with no closer at all, narration is the
+        # safer reading. Text is intact either way.
+        source = "He said, ‘I am leaving"
+        self.assertEqual(segments(source), [(UNQUOTED, source)])
 
     def test_unterminated_ambiguous_single_stays_unquoted(self):
         # Rule 5: with no valid closer, apostrophe is the safer reading and

--- a/app/test_speaker_canon.py
+++ b/app/test_speaker_canon.py
@@ -20,6 +20,8 @@ from speaker_canon import (
     attest_speaker,
     repair_speaker,
     source_word_index,
+    attribution_tag_name,
+    contradicts_attribution,
     ATTESTED,
     UNATTESTED,
     UNVERIFIABLE,
@@ -1254,6 +1256,116 @@ def test_distance_one_predicate_is_exact_and_bounded():
           "the predicate is code-point based, not ASCII")
 
 
+# ---------------------------------------------------------------------------
+# Tier 3c: attribution-tag agreement. Properties only -- every fixture is
+# synthesized here and none of it comes from any particular book.
+# ---------------------------------------------------------------------------
+
+def _roster(*names):
+    index = {}
+    for name in names:
+        remember_in_roster(index, name)
+    return index
+
+
+def test_tag_contradiction_is_detected():
+    roster = _roster("ANNIKA", "BOREL")
+    check_equal(
+        contradicts_attribution("BOREL", " Annika said.", roster),
+        "ANNIKA", "a tag naming another established character contradicts")
+    check_equal(
+        contradicts_attribution("BOREL", ", said Annika, turning away.", roster),
+        "ANNIKA", "the verb-first tag shape is recognized too")
+
+
+def test_tag_agreeing_with_the_label_is_not_a_contradiction():
+    roster = _roster("ANNIKA", "BOREL")
+    check_equal(contradicts_attribution("ANNIKA", " Annika said.", roster),
+                None, "the tag naming the labelled speaker is agreement")
+
+
+def test_possessive_tag_is_not_a_contradiction():
+    # "said Annika's father" attributes the line to a DIFFERENT person whose
+    # label legitimately contains the name. Reading the tag as ANNIKA here is
+    # the single most likely false accusation.
+    roster = _roster("ANNIKA", "ANNIKA'S FATHER")
+    check_equal(
+        contradicts_attribution("ANNIKA'S FATHER", ", said Annika's father.", roster),
+        None, "straight-apostrophe possessive tag")
+    check_equal(
+        contradicts_attribution("ANNIKA'S FATHER", ", said Annika’s father.", roster),
+        None, "curly-apostrophe possessive tag")
+
+
+def test_case_and_apostrophe_variants_are_not_contradictions():
+    roster = _roster("MCALLISTER", "SKER'RET")
+    check_equal(contradicts_attribution("MCALLISTER", " McAllister said.", roster),
+                None, "label/source differ only in case")
+    check_equal(contradicts_attribution("SKER'RET", " Sker’ret said.", roster),
+                None, "label/source differ only in apostrophe glyph")
+
+
+def test_granularity_variant_is_not_a_contradiction():
+    roster = _roster("ANNIKA BOREL")
+    check_equal(contradicts_attribution("ANNIKA BOREL", " Annika said.", roster),
+                None, "a first-name tag does not contradict the full name")
+    check_equal(contradicts_attribution("ANNIKA", " Borel said.", _roster("ANNIKA BOREL")),
+                None, "a surname tag does not contradict the first name")
+
+
+def test_ambiguous_tag_word_is_discarded():
+    # Two characters share a first name: the tag cannot pick one, so nothing
+    # is reported rather than something guessed.
+    roster = _roster("ANNIKA BOREL", "ANNIKA VOSS", "TEODOR")
+    check_equal(contradicts_attribution("TEODOR", " Annika said.", roster),
+                None, "an ambiguous tag word is never guessed at")
+
+
+def test_unknown_and_common_noun_tags_are_ignored():
+    roster = _roster("ANNIKA", "BOREL")
+    check_equal(contradicts_attribution("BOREL", " Teodor said.", roster),
+                None, "a name the roster does not know is not compared")
+    check_equal(contradicts_attribution("BOREL", " her mother said.", roster),
+                None, "an uncapitalized common noun is not a name")
+    check_equal(contradicts_attribution("BOREL", " Annika nodded.", roster),
+                None, "no speech verb, no tag")
+
+
+def test_tag_after_a_paragraph_break_is_ignored():
+    # The tag on the far side of a blank line introduces the NEXT quotation.
+    roster = _roster("ANNIKA", "BOREL")
+    check_equal(contradicts_attribution("BOREL", "\n\nAnnika said,", roster),
+                None, "a tag in a new paragraph is not this quotation's")
+
+
+def test_non_english_text_produces_no_detections():
+    # THE language property: the tag pattern needs an English speech verb, so
+    # a French or Japanese book yields nothing at all -- no false accusation,
+    # no wrong retry -- rather than misfiring.
+    roster = _roster("ANNIKA", "BOREL")
+    for following in (
+        ", dit Annika en se levant.",          # French
+        ", sagte Annika.",                     # German
+        "とアンニカは言った。",  # Japanese
+        ", сказала Анника.",  # Russian
+    ):
+        check_equal(attribution_tag_name(following), None,
+                    f"no English speech verb in {following!r}")
+        check_equal(contradicts_attribution("BOREL", following, roster), None,
+                    f"no detection for {following!r}")
+
+
+def test_contradiction_check_mutates_nothing_and_needs_a_roster():
+    roster = _roster("ANNIKA", "BOREL")
+    before = copy.deepcopy(roster)
+    contradicts_attribution("BOREL", " Annika said.", roster)
+    check_equal(roster, before, "roster index is read-only here")
+    check_equal(contradicts_attribution("BOREL", " Annika said.", {}), None,
+                "no roster means no detection")
+    check_equal(contradicts_attribution("NARRATOR", " Annika said.", roster), None,
+                "NARRATOR is never contradicted")
+
+
 def main():
     tests = [
         test_basic_case_and_whitespace_normalization,
@@ -1347,6 +1459,16 @@ def main():
         test_repair_is_pure_idempotent_and_mutates_nothing,
         test_repair_is_unreachable_for_an_unsegmented_script_label,
         test_distance_one_predicate_is_exact_and_bounded,
+        test_tag_contradiction_is_detected,
+        test_tag_agreeing_with_the_label_is_not_a_contradiction,
+        test_possessive_tag_is_not_a_contradiction,
+        test_case_and_apostrophe_variants_are_not_contradictions,
+        test_granularity_variant_is_not_a_contradiction,
+        test_ambiguous_tag_word_is_discarded,
+        test_unknown_and_common_noun_tags_are_ignored,
+        test_tag_after_a_paragraph_break_is_ignored,
+        test_non_english_text_produces_no_detections,
+        test_contradiction_check_mutates_nothing_and_needs_a_roster,
     ]
 
     for t in tests:

--- a/app/test_speaker_canon.py
+++ b/app/test_speaker_canon.py
@@ -88,8 +88,49 @@ def test_empty_and_whitespace_input():
     check_equal(canonicalize(None), "", "None input")
 
 
+def test_wrapping_quotes_stripped():
+    # F11: LLM-emitted labels wrapped in quotes must unwrap to the same
+    # canonical form as the unquoted name, or the roster fragments.
+    check_equal(canonicalize("'Mother of Monsters'"), "MOTHER OF MONSTERS",
+                "straight single quotes wrapping a multi-word name")
+    check_equal(canonicalize('"BLACK SCOUT"'), "BLACK SCOUT",
+                "straight double quotes wrapping a name")
+    check_equal(canonicalize("‘Mother of Monsters’"), "MOTHER OF MONSTERS",
+                "curly single quotes (‘...’) wrapping a name")
+    check_equal(canonicalize("“Black Scout”"), "BLACK SCOUT",
+                "curly double quotes (“...”) wrapping a name")
+    check_equal(canonicalize("'\"BLACK SCOUT\"'"), "BLACK SCOUT",
+                "nested single-then-double wrapping quotes")
+    check_equal(canonicalize("''X''"), "X",
+                "double-wrapped straight single quotes unwind fully")
+
+
+def test_unmatched_apostrophes_survive_wrapping_fix():
+    # These must be UNCHANGED by the F11 wrapping-quote fix: only a matched
+    # pair at both ends is a "wrapper"; a lone leading/trailing apostrophe
+    # is possessive or elision, not a wrapper.
+    check_equal(canonicalize("O'Brien"), "O'BRIEN", "internal apostrophe untouched")
+    check_equal(canonicalize("Jones'"), "JONES'", "unmatched trailing possessive apostrophe kept")
+    check_equal(canonicalize("'tis"), "'TIS", "unmatched leading elision apostrophe kept")
+
+
+def test_wrapping_quotes_and_roster_fragmentation():
+    # The concrete production bug: a quoted and unquoted form of the same
+    # name must canonicalize identically so the roster doesn't fragment.
+    check_equal(
+        canonicalize("'MOTHER OF MONSTERS'"),
+        canonicalize("MOTHER OF MONSTERS"),
+        "quoted and unquoted forms must converge to the same canonical name",
+    )
+
+
 def test_idempotency():
-    samples = ["MARK (shouting)", "Mr. Mark", "Dr.", "José", "narrator", "O'Brien"]
+    samples = [
+        "MARK (shouting)", "Mr. Mark", "Dr.", "José", "narrator", "O'Brien",
+        "'Mother of Monsters'", '"BLACK SCOUT"',
+        "‘Mother of Monsters’", "“Black Scout”",
+        "'\"BLACK SCOUT\"'", "''X''", "Jones'", "'tis",
+    ]
     for s in samples:
         once = canonicalize(s)
         twice = canonicalize(once)
@@ -158,6 +199,9 @@ def main():
         test_hyphens_preserved,
         test_stray_punctuation_stripped,
         test_empty_and_whitespace_input,
+        test_wrapping_quotes_stripped,
+        test_unmatched_apostrophes_survive_wrapping_fix,
+        test_wrapping_quotes_and_roster_fragmentation,
         test_idempotency,
         test_suggest_aliases_expected_pairs,
         test_suggest_aliases_excludes_narrator,

--- a/app/test_speaker_canon.py
+++ b/app/test_speaker_canon.py
@@ -18,10 +18,13 @@ from speaker_canon import (
     suggest_aliases,
     attest_label,
     attest_speaker,
+    repair_speaker,
+    source_word_index,
     ATTESTED,
     UNATTESTED,
     UNVERIFIABLE,
     _core_tokens,
+    _is_distance_one,
 )
 
 _failures = []
@@ -979,6 +982,278 @@ def test_attest_speaker_verdicts_are_the_exported_constants():
     check_equal(UNVERIFIABLE, "unverifiable", "UNVERIFIABLE constant value")
 
 
+# ---------------------------------------------------------------------------
+# Roster-name partial attestation (attest_speaker's roster_index argument)
+# ---------------------------------------------------------------------------
+
+def _roster(*names):
+    """Build a roster index the way generate_script does."""
+    index = {}
+    for name in names:
+        remember_in_roster(index, name)
+    return index
+
+
+def test_partial_attestation_accepts_a_label_built_on_a_roster_name():
+    # "<name>'S FATHER" describes a real person the text names obliquely. The
+    # book has established the name, so the label is not positively WRONG --
+    # it is unconfirmable, which is what UNVERIFIABLE means.
+    windows = ["Brannoc ran ahead down the shingle, shouting."]
+    label = canonicalize("Brannoc's father")
+    check_equal(attest_speaker(label, windows), UNATTESTED,
+                "without a roster the label is still refuted")
+    check_equal(attest_speaker(label, windows, roster_index=_roster("BRANNOC")),
+                UNVERIFIABLE,
+                "an attested ROSTER token softens the verdict to unverifiable")
+
+
+def test_partial_attestation_requires_the_attested_token_to_be_a_roster_name():
+    # The rejected weaker rule ("any attested token") would be satisfied by any
+    # common noun copied out of the prose. This is what keeps it narrow.
+    windows = ["A heron lifted off the water."]
+    check_equal(
+        attest_speaker("TRANSFORMED HERON", windows, roster_index=_roster("BRANNOC")),
+        UNATTESTED,
+        "a common noun from the prose is not a roster name")
+
+
+def test_partial_attestation_needs_two_or_more_core_tokens():
+    windows = ["The lamp guttered and went out."]
+    check_equal(attest_speaker("BRANNOC", windows, roster_index=_roster("BRANNOC OF ESK")),
+                UNATTESTED,
+                "a single-token label is not partially attested")
+
+
+def test_partial_attestation_still_refutes_when_every_token_is_missing():
+    windows = ["The lamp guttered and went out."]
+    check_equal(
+        attest_speaker("BRANNOC ESKELLAN", windows, roster_index=_roster("BRANNOC")),
+        UNATTESTED,
+        "no attested token at all is still positive evidence")
+
+
+def test_attest_label_boolean_contract_is_unchanged_by_the_roster_rule():
+    # attest_label takes no roster and must keep its boolean meaning: the UI
+    # badge and the label_flags endpoint depend on it.
+    windows = ["Brannoc ran ahead down the shingle, shouting."]
+    result = attest_label(canonicalize("Brannoc's father"), windows)
+    check(result["attested"] is False, "attest_label stays False for a missing token")
+    check_equal(result["missing_tokens"], ["FATHER"], "attest_label still names the gap")
+
+
+# ---------------------------------------------------------------------------
+# repair_speaker(): the five adversarial cases FIRST
+#
+# These are the acceptance criteria for the repair design, not the clean
+# repairs it was built for. Every name and every sentence here is invented.
+# ---------------------------------------------------------------------------
+
+def _book(*sentences):
+    return source_word_index(" ".join(sentences))
+
+
+def test_repair_refuses_a_real_character_named_elsewhere_in_the_book():
+    # ADVERSARIAL 1 (ANDRE -> ANDREA). Veldor is a real character whose own
+    # scene attributes his lines with pronouns only, and Velder happens to be
+    # standing there. The whole-book guard is what stops the merge: the author
+    # spells "Veldor" somewhere, so it is not a refuted spelling.
+    windows = ['Velder set down the tray. "Then say it plainly," he answered.']
+    book = _book("Veldor had come down from the pass a week earlier.",
+                 "Velder set down the tray.")
+    roster = _roster("VELDER")
+    check_equal(attest_speaker("VELDOR", windows, roster_index=roster), UNATTESTED,
+                "the gate still refutes the label")
+    check_equal(repair_speaker("VELDOR", windows, roster, book), None,
+                "a spelling the book uses is never repaired")
+
+
+def test_repair_of_a_name_the_book_never_contains_is_an_accepted_limitation():
+    # The honest other half of ADVERSARIAL 1, pinned so nobody claims the
+    # design is airtight: if the character's name appears NOWHERE in the book,
+    # repair does fire and is wrong. Documented in repair_speaker's docstring.
+    windows = ['Velder set down the tray. "Then say it plainly," he answered.']
+    book = _book("Velder set down the tray.")
+    check_equal(repair_speaker("VELDOR", windows, _roster("VELDER"), book),
+                "VELDER",
+                "known limitation: a name absent from the whole book is repaired")
+
+
+def test_repair_refuses_a_target_the_source_never_attested():
+    # ADVERSARIAL 2 (MARIA -> MARIE with a polluted roster). "MIRVE" reached
+    # the roster from a substring-only (UNVERIFIABLE) acceptance -- the book
+    # contains "Mirvenholm", never the bare word. Amendment (b): a repair must
+    # not target a roster name that was itself never source-attested, or the
+    # pollution rewrites real names onto itself.
+    windows = ["The road out of Mirvenholm was flooded to the axles."]
+    book = _book("The road out of Mirvenholm was flooded to the axles.",
+                 "Mirva waited at the ford.")
+    roster = _roster("MIRVE")
+    check_equal(repair_speaker("MIRVA", windows, roster, book), None,
+                "a roster name the book never spells as a word is not a target")
+
+
+def test_repair_refuses_across_a_diacritic_fold():
+    # ADVERSARIAL 3 (ANDRÉ -> ANDREA). Accents fold on BOTH sides, so the
+    # accented spelling is found in the book's own word index and the two real
+    # people are left apart.
+    windows = ['Theona turned the key. "It was never locked," she said.']
+    book = _book("Thíona had carried the lamp up herself.",
+                 "Theona turned the key.")
+    check_equal(repair_speaker("THIONA", windows, _roster("THEONA"), book), None,
+                "an accented real name is protected by the folded word index")
+
+
+def test_repair_refuses_a_transliteration_variant_the_book_uses():
+    # ADVERSARIAL 4 (YUSUF -> YUSUP). Both spellings occur in the book, so
+    # neither is refuted.
+    windows = ['Yusap looked up. "Not today," he said.']
+    book = _book("Yusaf of the northern house signed the charter.",
+                 "Yusap looked up.")
+    check_equal(repair_speaker("YUSAF", windows, _roster("YUSAP"), book), None,
+                "a variant the book itself uses is never repaired")
+
+
+def test_repair_refuses_a_plural_singular_pair_the_book_uses():
+    # ADVERSARIAL 5 (TWIN -> TWINS). Any book that uses the singular word
+    # anywhere is protected; a book that never does is the documented residual.
+    # (A pair like this is doubly protected in practice: the singular is also a
+    # SUBSTRING of the plural, so the gate returns UNVERIFIABLE and never
+    # reaches repair at all. This asserts the repair guard directly.)
+    windows = ["The twins had not spoken since the crossing."]
+    book = _book("The twins had not spoken since the crossing.",
+                 "Each twin carried half the water.")
+    check_equal(repair_speaker("TWIN", windows, _roster("TWINS"), book), None,
+                "a singular the book uses as a word is never repaired")
+
+
+# ---------------------------------------------------------------------------
+# repair_speaker(): the guards
+# ---------------------------------------------------------------------------
+
+WINDOW_BRANNOC = ['Brannoc set down the lamp. "It is done," he said.']
+BOOK_BRANNOC = _book('Brannoc set down the lamp. "It is done," he said.',
+                     "Vella waited by the door.")
+
+
+def test_repair_folds_a_unique_distance_one_misspelling():
+    check_equal(repair_speaker("BRANOC", WINDOW_BRANNOC, _roster("BRANNOC"),
+                               BOOK_BRANNOC),
+                "BRANNOC",
+                "one refuted token, one established candidate one edit away")
+
+
+def test_repair_keeps_attested_tokens_verbatim():
+    windows = ["Brannoc of Esk set down the lamp."]
+    book = _book("Brannoc of Esk set down the lamp.")
+    check_equal(repair_speaker("BRANOC OF ESK", windows,
+                               _roster("BRANNOC", "ESK"), book),
+                "BRANNOC OF ESK",
+                "only the refuted token is substituted; the rest is untouched")
+
+
+def test_repair_refuses_when_two_candidates_are_one_edit_away():
+    windows = ["Brannoc and Brannic argued by the fire."]
+    book = _book("Brannoc and Brannic argued by the fire.")
+    check_equal(repair_speaker("BRANNC", windows, _roster("BRANNOC", "BRANNIC"),
+                               book),
+                None,
+                "ambiguity refuses -- the evidence does not pick a winner")
+
+
+def test_repair_refuses_when_the_ambiguity_is_only_visible_in_the_roster():
+    # The ambiguity guard is roster-WIDE, not window-local: a second candidate
+    # that is not in this window still blocks the repair. This is one of the
+    # two guards that replaced the proposed minimum-token-length floor.
+    windows = ["Brannoc argued by the fire."]
+    book = _book("Brannoc argued by the fire.", "Brannic kept the ledger.")
+    check_equal(repair_speaker("BRANNC", windows, _roster("BRANNOC", "BRANNIC"),
+                               book),
+                None,
+                "a distance-1 roster name outside the window still blocks")
+
+
+def test_repair_refuses_a_candidate_absent_from_the_window():
+    windows = ["The lamp guttered and went out."]
+    check_equal(repair_speaker("BRANOC", windows, _roster("BRANNOC"),
+                               BOOK_BRANNOC),
+                None,
+                "a candidate must be attested in the label's own window")
+
+
+def test_repair_refuses_a_window_word_that_is_not_a_roster_name():
+    check_equal(repair_speaker("BRANOC", WINDOW_BRANNOC, _roster("VELLA"),
+                               BOOK_BRANNOC),
+                None,
+                "candidates come from the roster, not from the prose at large")
+
+
+def test_repair_refuses_a_label_that_is_already_established():
+    roster = _roster("BRANOC", "BRANNOC")
+    check_equal(repair_speaker("BRANOC", WINDOW_BRANNOC, roster, BOOK_BRANNOC),
+                None,
+                "an established name is never repaired")
+
+
+def test_repair_refuses_at_distance_two():
+    check_equal(repair_speaker("BRENNIC", WINDOW_BRANNOC, _roster("BRANNOC"),
+                               BOOK_BRANNOC),
+                None,
+                "two edits is not a misspelling we can claim to have identified")
+
+
+def test_repair_refuses_without_a_roster_or_a_book_index():
+    check_equal(repair_speaker("BRANOC", WINDOW_BRANNOC, {}, BOOK_BRANNOC), None,
+                "an empty roster offers no candidates")
+    check_equal(repair_speaker("BRANOC", WINDOW_BRANNOC, _roster("BRANNOC"), set()),
+                None,
+                "no book index means no evidence, so no repair")
+    check_equal(repair_speaker("BRANOC", [], _roster("BRANNOC"), BOOK_BRANNOC),
+                None, "no window means no repair")
+    check_equal(repair_speaker("NARRATOR", WINDOW_BRANNOC, _roster("BRANNOC"),
+                               BOOK_BRANNOC),
+                None, "the narrator sentinel is never repaired")
+
+
+def test_repair_is_pure_idempotent_and_mutates_nothing():
+    roster = _roster("BRANNOC")
+    roster_before = copy.deepcopy(roster)
+    windows = copy.deepcopy(WINDOW_BRANNOC)
+    windows_before = copy.deepcopy(windows)
+    book = set(BOOK_BRANNOC)
+    book_before = set(book)
+
+    first = repair_speaker("BRANOC", windows, roster, book)
+    second = repair_speaker("BRANOC", windows, roster, book)
+    check_equal(first, second, "repair_speaker is deterministic")
+    check_equal(roster, roster_before, "repair_speaker does not mutate the roster")
+    check_equal(windows, windows_before, "repair_speaker does not mutate its windows")
+    check_equal(book, book_before, "repair_speaker does not mutate the word index")
+    # Idempotent in the sense that matters: a repaired name attests, so there
+    # is nothing left to repair and the second pass declines.
+    check_equal(repair_speaker(first, windows, roster, book), None,
+                "repairing a repaired name is a no-op")
+
+
+def test_repair_is_unreachable_for_an_unsegmented_script_label():
+    # A name present as a substring but not at a word boundary -- what a
+    # Chinese/Japanese/Thai book looks like to this tokenizer -- is
+    # UNVERIFIABLE, so the gate accepts it and repair is never consulted.
+    windows = ["リナは黙っていた。"]
+    check_equal(attest_speaker("リナ", windows), UNVERIFIABLE,
+                "an unsegmented-script label stays unverifiable")
+
+
+def test_distance_one_predicate_is_exact_and_bounded():
+    check(_is_distance_one("BRANOC", "BRANNOC"), "one insertion")
+    check(_is_distance_one("BRANNOC", "BRANOC"), "one deletion")
+    check(_is_distance_one("BRANNOC", "BRANNIC"), "one substitution")
+    check(not _is_distance_one("BRANNOC", "BRANNOC"), "zero edits is not distance 1")
+    check(not _is_distance_one("BRANNOC", "BRENNIC"), "two substitutions")
+    check(not _is_distance_one("BRANNOC", "BRAN"), "a length gap of 3")
+    check(_is_distance_one("ИРИНА", "ИРИН"),
+          "the predicate is code-point based, not ASCII")
+
+
 def main():
     tests = [
         test_basic_case_and_whitespace_normalization,
@@ -1049,6 +1324,29 @@ def main():
         test_attest_speaker_is_pure_and_idempotent,
         test_attest_speaker_handles_empty_and_missing_windows,
         test_attest_speaker_verdicts_are_the_exported_constants,
+        test_partial_attestation_accepts_a_label_built_on_a_roster_name,
+        test_partial_attestation_requires_the_attested_token_to_be_a_roster_name,
+        test_partial_attestation_needs_two_or_more_core_tokens,
+        test_partial_attestation_still_refutes_when_every_token_is_missing,
+        test_attest_label_boolean_contract_is_unchanged_by_the_roster_rule,
+        test_repair_refuses_a_real_character_named_elsewhere_in_the_book,
+        test_repair_of_a_name_the_book_never_contains_is_an_accepted_limitation,
+        test_repair_refuses_a_target_the_source_never_attested,
+        test_repair_refuses_across_a_diacritic_fold,
+        test_repair_refuses_a_transliteration_variant_the_book_uses,
+        test_repair_refuses_a_plural_singular_pair_the_book_uses,
+        test_repair_folds_a_unique_distance_one_misspelling,
+        test_repair_keeps_attested_tokens_verbatim,
+        test_repair_refuses_when_two_candidates_are_one_edit_away,
+        test_repair_refuses_when_the_ambiguity_is_only_visible_in_the_roster,
+        test_repair_refuses_a_candidate_absent_from_the_window,
+        test_repair_refuses_a_window_word_that_is_not_a_roster_name,
+        test_repair_refuses_a_label_that_is_already_established,
+        test_repair_refuses_at_distance_two,
+        test_repair_refuses_without_a_roster_or_a_book_index,
+        test_repair_is_pure_idempotent_and_mutates_nothing,
+        test_repair_is_unreachable_for_an_unsegmented_script_label,
+        test_distance_one_predicate_is_exact_and_bounded,
     ]
 
     for t in tests:

--- a/app/test_speaker_canon.py
+++ b/app/test_speaker_canon.py
@@ -1,0 +1,182 @@
+"""Standalone unit tests for speaker_canon.py.
+
+Run directly (no pytest required):
+    python app/test_speaker_canon.py
+
+Exits 0 on all-pass, nonzero if any assertion fails.
+"""
+
+import sys
+import copy
+
+from speaker_canon import canonicalize, suggest_aliases
+
+_failures = []
+
+
+def check(condition, message):
+    if not condition:
+        _failures.append(message)
+
+
+def check_equal(actual, expected, label):
+    check(actual == expected, f"{label}: expected {expected!r}, got {actual!r}")
+
+
+def test_basic_case_and_whitespace_normalization():
+    check_equal(canonicalize("mark"), "MARK", "lowercase 'mark'")
+    check_equal(canonicalize(" MARK "), "MARK", "padded ' MARK '")
+    check_equal(canonicalize("  Mark   Twain  "), "MARK TWAIN", "internal whitespace run collapse")
+
+
+def test_parenthetical_removal():
+    check_equal(canonicalize("MARK (shouting)"), "MARK", "trailing parenthetical")
+    check_equal(canonicalize("MARK (angrily) enters"), "MARK ENTERS", "mid-string parenthetical")
+
+
+def test_honorific_stripping():
+    check_equal(canonicalize("Mr. Mark"), "MARK", "'Mr. Mark' honorific")
+    check_equal(canonicalize("mr mark"), "MARK", "lowercase honorific, no period")
+    check_equal(canonicalize("Dr. Smith"), "SMITH", "'Dr. Smith' honorific")
+    check_equal(canonicalize("Professor Xavier"), "XAVIER", "'Professor' honorific")
+    check_equal(canonicalize("Captain Hook"), "HOOK", "'Captain' honorific")
+    check_equal(canonicalize("Mrs. Robinson"), "ROBINSON", "'Mrs.' honorific")
+
+
+def test_honorific_alone_never_empty():
+    check_equal(canonicalize("Dr."), "DR", "'Dr.' alone must not canonicalize to empty")
+    check_equal(canonicalize("Mr."), "MR", "'Mr.' alone must not canonicalize to empty")
+    check_equal(canonicalize("Sir"), "SIR", "'Sir' alone must not canonicalize to empty")
+
+
+def test_all_variants_converge():
+    variants = ["MARK (shouting)", "Mr. Mark", "mark", " MARK "]
+    canon = {canonicalize(v) for v in variants}
+    check(canon == {"MARK"}, f"all MARK variants should canonicalize identically, got {canon}")
+
+
+def test_accent_normalization():
+    check_equal(canonicalize("José"), "JOSE", "'José' accent stripped")
+    check_equal(canonicalize("François"), "FRANCOIS", "'François' accent stripped")
+
+
+def test_narrator_canonicalization():
+    check_equal(canonicalize("narrator"), "NARRATOR", "'narrator' lowercase")
+    check_equal(canonicalize("Narrator"), "NARRATOR", "'Narrator' titlecase")
+    check_equal(canonicalize("NARRATOR"), "NARRATOR", "'NARRATOR' already canonical")
+    check_equal(canonicalize("  narrator  "), "NARRATOR", "padded narrator")
+
+
+def test_apostrophes_preserved():
+    check_equal(canonicalize("O'Brien"), "O'BRIEN", "apostrophe kept in O'Brien")
+    check_equal(canonicalize("o'brien"), "O'BRIEN", "lowercase o'brien")
+
+
+def test_hyphens_preserved():
+    check_equal(canonicalize("Jean-Luc"), "JEAN-LUC", "hyphen kept in Jean-Luc")
+
+
+def test_stray_punctuation_stripped():
+    check_equal(canonicalize("Mark!"), "MARK", "trailing exclamation stripped")
+    check_equal(canonicalize("Mark:"), "MARK", "trailing colon stripped")
+    check_equal(canonicalize('"Mark"'), "MARK", "surrounding quotes stripped")
+
+
+def test_empty_and_whitespace_input():
+    check_equal(canonicalize(""), "", "empty string input")
+    check_equal(canonicalize("   "), "", "whitespace-only input")
+    check_equal(canonicalize(None), "", "None input")
+
+
+def test_idempotency():
+    samples = ["MARK (shouting)", "Mr. Mark", "Dr.", "José", "narrator", "O'Brien"]
+    for s in samples:
+        once = canonicalize(s)
+        twice = canonicalize(once)
+        check_equal(twice, once, f"idempotency for {s!r}")
+
+
+def test_suggest_aliases_expected_pairs():
+    roster = ["JON", "JOHN", "ELLA", "BELLA", "MARCUS", "ELENA"]
+    roster_copy = copy.deepcopy(roster)
+
+    suggestions = suggest_aliases(roster)
+
+    def has_pair(a, b):
+        for s in suggestions:
+            names = {s["name"], s["alias_of"]}
+            if names == {a, b}:
+                return True
+        return False
+
+    check(has_pair("JON", "JOHN"), "expected a JON/JOHN suggestion")
+    check(has_pair("ELLA", "BELLA"), "expected an ELLA/BELLA suggestion")
+    check(not has_pair("MARCUS", "ELENA"), "MARCUS/ELENA must NOT be suggested (unrelated names)")
+
+    # Roster argument must be untouched (no mutation, no merging).
+    check_equal(roster, roster_copy, "suggest_aliases must not mutate its roster argument")
+    check_equal(len(roster), 6, "suggest_aliases must not remove/merge roster entries")
+
+    for s in suggestions:
+        check("name" in s and "alias_of" in s and "score" in s, f"suggestion missing keys: {s}")
+        check(0.0 <= s["score"] <= 1.0, f"score out of [0,1] range: {s}")
+
+
+def test_suggest_aliases_excludes_narrator():
+    roster = ["NARRATOR", "narrator", "MARK", "MARC"]
+    suggestions = suggest_aliases(roster)
+    for s in suggestions:
+        check(s["name"] != "NARRATOR" and s["alias_of"] != "NARRATOR",
+              f"NARRATOR must never appear in suggestions: {s}")
+
+
+def test_suggest_aliases_empty_and_single():
+    check_equal(suggest_aliases([]), [], "empty roster -> no suggestions")
+    check_equal(suggest_aliases(["SOLO"]), [], "single-name roster -> no suggestions")
+
+
+def test_suggest_aliases_direction_rule():
+    # Shorter name is suggested as the alias of the longer name.
+    suggestions = suggest_aliases(["JON", "JOHN"])
+    check(len(suggestions) == 1, "expected exactly one JON/JOHN suggestion")
+    if suggestions:
+        s = suggestions[0]
+        check_equal(s["name"], "JON", "shorter name should be 'name' (the alias)")
+        check_equal(s["alias_of"], "JOHN", "longer name should be 'alias_of' (the target)")
+
+
+def main():
+    tests = [
+        test_basic_case_and_whitespace_normalization,
+        test_parenthetical_removal,
+        test_honorific_stripping,
+        test_honorific_alone_never_empty,
+        test_all_variants_converge,
+        test_accent_normalization,
+        test_narrator_canonicalization,
+        test_apostrophes_preserved,
+        test_hyphens_preserved,
+        test_stray_punctuation_stripped,
+        test_empty_and_whitespace_input,
+        test_idempotency,
+        test_suggest_aliases_expected_pairs,
+        test_suggest_aliases_excludes_narrator,
+        test_suggest_aliases_empty_and_single,
+        test_suggest_aliases_direction_rule,
+    ]
+
+    for t in tests:
+        t()
+
+    if _failures:
+        print(f"FAILED: {len(_failures)} assertion(s) failed")
+        for f in _failures:
+            print(f"  - {f}")
+        return 1
+
+    print(f"OK: all tests passed ({len(tests)} test functions)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/app/test_speaker_canon.py
+++ b/app/test_speaker_canon.py
@@ -10,11 +10,18 @@ import sys
 import copy
 
 from speaker_canon import (
+    GENDERED_TITLES,
     canonicalize,
     remember_in_roster,
     resolve_against_roster,
     roster_key,
     suggest_aliases,
+    attest_label,
+    attest_speaker,
+    ATTESTED,
+    UNATTESTED,
+    UNVERIFIABLE,
+    _core_tokens,
 )
 
 _failures = []
@@ -40,25 +47,83 @@ def test_parenthetical_removal():
     check_equal(canonicalize("MARK (angrily) enters"), "MARK ENTERS", "mid-string parenthetical")
 
 
-def test_honorific_stripping():
-    check_equal(canonicalize("Mr. Mark"), "MARK", "'Mr. Mark' honorific")
-    check_equal(canonicalize("mr mark"), "MARK", "lowercase honorific, no period")
-    check_equal(canonicalize("Dr. Smith"), "SMITH", "'Dr. Smith' honorific")
-    check_equal(canonicalize("Professor Xavier"), "XAVIER", "'Professor' honorific")
-    check_equal(canonicalize("Captain Hook"), "HOOK", "'Captain' honorific")
-    check_equal(canonicalize("Mrs. Robinson"), "ROBINSON", "'Mrs.' honorific")
+def test_rank_titles_are_dropped():
+    # Rank says nothing about identity that the surname doesn't; the same
+    # person is "Dr. Millman", "Doctor Millman" and "Millman" in one book.
+    check_equal(canonicalize("Dr. Smith"), "SMITH", "'Dr. Smith' rank title")
+    check_equal(canonicalize("Dr. Millman"), "MILLMAN", "'Dr. Millman' rank title")
+    check_equal(canonicalize("Professor Xavier"), "XAVIER", "'Professor' rank title")
+    check_equal(canonicalize("Captain Hook"), "HOOK", "'Captain' rank title")
+    check_equal(canonicalize("Lt. Col. Blimp"), "BLIMP", "stacked rank titles")
 
 
-def test_honorific_alone_never_empty():
+def test_gendered_titles_are_preserved_and_normalized():
+    # The husband/wife bug: dropping these merged two characters into one
+    # voice, irreversibly, at annotation time.
+    check_equal(canonicalize("Mr. Smith"), "MISTER SMITH", "'Mr.' preserved as MISTER")
+    check_equal(canonicalize("mr mark"), "MISTER MARK", "lowercase title, no period")
+    check_equal(canonicalize("Mrs. Robinson"), "MISSUS ROBINSON", "'Mrs.' preserved as MISSUS")
+    check_equal(canonicalize("Mister Smith"), "MISTER SMITH", "spelled-out 'Mister' unifies with 'Mr.'")
+    check_equal(canonicalize("Missus Robinson"), "MISSUS ROBINSON", "spelled-out 'Missus'")
+    check_equal(canonicalize("Ms. Doe"), "MS DOE", "'Ms.' preserved")
+    check_equal(canonicalize("Miss Doe"), "MISS DOE", "'Miss' preserved")
+    check_equal(canonicalize("Mx. Doe"), "MX DOE", "'Mx.' preserved")
+    check_equal(canonicalize("Sir John"), "SIR JOHN", "'Sir' preserved")
+    check_equal(canonicalize("Lady John"), "LADY JOHN", "'Lady' preserved")
+    check_equal(canonicalize("Lord Byron"), "LORD BYRON", "'Lord' preserved")
+    check_equal(canonicalize("Dame Edna"), "DAME EDNA", "'Dame' preserved")
+
+
+def test_gendered_titles_are_language_preserving():
+    # French abbreviations unify with their spelled-out forms (one character),
+    # but are never folded onto the English titles (a different word in the
+    # author's text, and MONSIEUR/MADAME must stay apart).
+    check_equal(canonicalize("Mme Bovary"), "MADAME BOVARY", "'Mme' -> MADAME")
+    check_equal(canonicalize("Madame Bovary"), "MADAME BOVARY", "'Madame' -> MADAME")
+    check_equal(canonicalize("M. Marambot"), "MONSIEUR MARAMBOT", "'M.' -> MONSIEUR")
+    check_equal(canonicalize("Monsieur Marambot"), "MONSIEUR MARAMBOT", "'Monsieur' -> MONSIEUR")
+    check_equal(canonicalize("Mlle Cocotte"), "MADEMOISELLE COCOTTE", "'Mlle' -> MADEMOISELLE")
+    check_equal(canonicalize("Mademoiselle Cocotte"), "MADEMOISELLE COCOTTE",
+                "'Mademoiselle' -> MADEMOISELLE")
+    check(canonicalize("Mme Dufour") != canonicalize("Monsieur Dufour"),
+          "MADAME DUFOUR and MONSIEUR DUFOUR must stay distinct")
+    check(canonicalize("Mrs. Bovary") != canonicalize("Mme Bovary"),
+          "English MISSUS is not folded onto French MADAME")
+
+
+def test_gendered_titles_keep_husband_and_wife_apart():
+    # The defect this two-class split exists to fix.
+    check(canonicalize("Mr. Smith") != canonicalize("Mrs. Smith"),
+          "Mr. Smith and Mrs. Smith must NOT canonicalize to the same name")
+    check(canonicalize("Mr. Smith") != canonicalize("Smith"),
+          "Mr. Smith and a bare Smith are distinct roster entries")
+
+
+def test_fr_is_preserved_not_dropped():
+    # FR is a name-constituent risk of the same class as the already-removed
+    # ST. Preserving it contains the risk: the worst case is a stray prefix,
+    # not a silently different character.
+    check_equal(canonicalize("Fr. Simon"), "FR SIMON", "'Fr.' preserved")
+    check_equal(canonicalize("Fraser"), "FRASER", "'Fraser' is not 'Fr' + 'aser'")
+    # FATHER was never a title and must not become one.
+    check_equal(canonicalize("Father Milon"), "FATHER MILON", "'Father' is part of the name")
+
+
+def test_title_alone_never_empty():
     check_equal(canonicalize("Dr."), "DR", "'Dr.' alone must not canonicalize to empty")
     check_equal(canonicalize("Mr."), "MR", "'Mr.' alone must not canonicalize to empty")
+    check_equal(canonicalize("Mrs."), "MRS", "'Mrs.' alone must not canonicalize to empty")
     check_equal(canonicalize("Sir"), "SIR", "'Sir' alone must not canonicalize to empty")
+    check_equal(canonicalize("M."), "M", "a bare 'M.' keeps itself rather than becoming MONSIEUR")
 
 
 def test_all_variants_converge():
-    variants = ["MARK (shouting)", "Mr. Mark", "mark", " MARK "]
+    variants = ["MARK (shouting)", "mark", " MARK "]
     canon = {canonicalize(v) for v in variants}
     check(canon == {"MARK"}, f"all MARK variants should canonicalize identically, got {canon}")
+    titled = {canonicalize(v) for v in ["Mr. Mark", "mr mark", "MISTER MARK", "Mister Mark"]}
+    check(titled == {"MISTER MARK"},
+          f"all MISTER MARK variants should canonicalize identically, got {titled}")
 
 
 def test_accent_normalization():
@@ -142,6 +207,14 @@ def test_idempotency():
         "'Mother of Monsters'", '"BLACK SCOUT"',
         "‘Mother of Monsters’", "“Black Scout”",
         "'\"BLACK SCOUT\"'", "''X''", "Jones'", "'tis",
+        # Preserved gender-marking titles re-enter canonicalize() as their
+        # normalized spellings, so those spellings must themselves be
+        # recognized titles that map to themselves.
+        "Mr. Smith", "MISTER SMITH", "Mrs. Smith", "MISSUS SMITH",
+        "Mme Bovary", "MADAME BOVARY", "M. Marambot", "MONSIEUR MARAMBOT",
+        "Mlle Cocotte", "MADEMOISELLE COCOTTE", "Ms. Doe", "Miss Doe",
+        "Mx. Doe", "Sir John", "Lady John", "Fr. Simon", "Mrs.", "M.",
+        "Mr. Mrs.", "Mrs. Dr. Watson", "Sir Lt. Col. Blimp",
     ]
     for s in samples:
         once = canonicalize(s)
@@ -150,14 +223,18 @@ def test_idempotency():
 
 
 
-def test_stacked_honorifics_strip_to_a_fixpoint():
-    check_equal(canonicalize("Sir Lt. Col. Blimp"), "BLIMP", "three stacked honorifics")
-    check_equal(canonicalize("Mrs. Dr. Watson"), "WATSON", "two stacked honorifics")
-    check_equal(canonicalize("Mr Mr Mr Smith"), "SMITH", "repeated honorific")
+def test_stacked_titles_resolve_to_a_fixpoint():
+    # The whole run of leading titles is consumed in one pass, and the FIRST
+    # gender-marking title in the run becomes the preserved prefix.
+    check_equal(canonicalize("Sir Lt. Col. Blimp"), "SIR BLIMP", "three stacked titles")
+    check_equal(canonicalize("Mrs. Dr. Watson"), "MISSUS WATSON", "two stacked titles")
+    check_equal(canonicalize("Mr Mr Mr Smith"), "MISTER SMITH", "repeated title")
+    check_equal(canonicalize("Dr. Mrs. Watson"), "MISSUS WATSON",
+                "a rank title before the gendered one does not shadow it")
     # The never-empty guard survives the loop.
-    check_equal(canonicalize("Dr."), "DR", "bare honorific keeps itself")
-    check_equal(canonicalize("Dr. Dr."), "DR", "all-honorific name keeps the last one")
-    check_equal(canonicalize("Mr. Mrs."), "MRS", "all-honorific name is never emptied")
+    check_equal(canonicalize("Dr."), "DR", "bare title keeps itself")
+    check_equal(canonicalize("Dr. Dr."), "DR", "all-title name keeps the last one")
+    check_equal(canonicalize("Mr. Mrs."), "MRS", "all-title name is never emptied")
 
 
 def test_double_canonicalization_matches_single():
@@ -175,7 +252,7 @@ def test_saint_names_are_not_honorifics():
     # "ST JOHN RIVERS" became "JOHN RIVERS" -- a different character.
     check_equal(canonicalize("St. John Rivers"), "ST JOHN RIVERS", "St. John Rivers")
     check_equal(canonicalize("ST JOHN RIVERS"), "ST JOHN RIVERS", "already-canonical form")
-    check_equal(canonicalize("Mr. St. Clair"), "ST CLAIR", "honorific stripped, saint kept")
+    check_equal(canonicalize("Mr. St. Clair"), "MISTER ST CLAIR", "title resolved, saint kept")
     check_equal(canonicalize("St. Laurent"), "ST LAURENT", "St. Laurent")
     # The two spellings of the same character still unify via the roster key.
     check_equal(roster_key("ST. JOHN"), roster_key("ST JOHN"), "punctuated saint name keys alike")
@@ -344,7 +421,7 @@ def test_resolve_never_merges_similar_names():
 
 def test_resolve_passthrough_and_narrator():
     roster = _index("ABBE MARIGNAN")
-    check_equal(resolve_against_roster("Mr. Mark", roster), "MARK",
+    check_equal(resolve_against_roster("Mr. Mark", roster), "MISTER MARK",
                 "unmatched name is just canonicalized")
     check_equal(resolve_against_roster("NARRATOR", roster), "NARRATOR", "NARRATOR untouched")
     check_equal(resolve_against_roster("narrator", _index("NARRATOR")), "NARRATOR",
@@ -506,12 +583,6 @@ REAL_PRODUCTION_ROSTER = [
     "SECRETARY", "MARINEL", "PROJECT GUTENBERG", "THE FOUNDATION",
 ]
 
-EXPECTED_COLLISION_FAMILIES = [
-    ["ABBE MARIGNAN", "ABBEMARIGNAN"],
-    ["ABBE MARIGNAN'S NIECE", "ABBEMARIGNAN'S NIECE"],
-]
-
-
 def _collision_families(names):
     families = {}
     for name in names:
@@ -520,36 +591,404 @@ def _collision_families(names):
 
 
 def test_real_roster_fixture_is_intact():
-    check_equal(len(REAL_PRODUCTION_ROSTER), 578, "fixture holds all 578 real labels")
-    check_equal(len(set(REAL_PRODUCTION_ROSTER)), 578, "fixture labels are distinct")
+    # The fixture is real corpus data used as *input*; the only property that
+    # matters here is that it hasn't been accidentally truncated or
+    # duplicated by an edit, not its exact size (which is one corpus's, and
+    # this project is upstream-bound).
+    check(len(REAL_PRODUCTION_ROSTER) > 0, "fixture is non-empty")
+    check_equal(len(set(REAL_PRODUCTION_ROSTER)), len(REAL_PRODUCTION_ROSTER),
+                "fixture labels are distinct")
+
+
+def _whitespace_only_key(name):
+    """The pre-widening roster key: canonical form with whitespace collapsed,
+    but hyphens/apostrophes left in place (unlike the current roster_key())."""
+    return "".join(canonicalize(name).split(" "))
 
 
 def test_real_roster_key_introduces_no_new_collisions():
-    # Exactly the two known ABBE MARIGNAN families -- no others. A future
-    # widening of roster_key() that merges two real characters fails here.
-    check_equal(_collision_families(REAL_PRODUCTION_ROSTER),
-                EXPECTED_COLLISION_FAMILIES,
-                "real-roster collision families")
+    # roster_key() was widened from stripping whitespace only to stripping
+    # all boundary marks (hyphens, apostrophes too). That widening must not
+    # merge any two real characters who weren't already merged under the
+    # narrower, whitespace-only key -- i.e. every collision family under the
+    # current key must also collide under the whitespace-only key. Corpus-
+    # independent: makes no assumption about which or how many families
+    # exist, only that widening didn't introduce NEW ones.
+    full_families = _collision_families(REAL_PRODUCTION_ROSTER)
+    check(len(full_families) > 0, "real roster produces at least one collision family")
+
+    whitespace_families = {}
+    for name in REAL_PRODUCTION_ROSTER:
+        whitespace_families.setdefault(_whitespace_only_key(name), []).append(name)
+    whitespace_family_sets = [frozenset(v) for v in whitespace_families.values() if len(v) > 1]
+
+    for family in full_families:
+        family_set = frozenset(family)
+        check(any(family_set <= ws_family for ws_family in whitespace_family_sets),
+              f"family {family} collides under the full key but is new under boundary-mark widening")
+
+    # Readable example from the corpus: a boundary-mark drift pair collides
+    # under both keyings.
+    check_equal(roster_key("ABBE MARIGNAN"), roster_key("ABBEMARIGNAN"),
+                "ABBE MARIGNAN / ABBEMARIGNAN collide under the full key")
+    check_equal(_whitespace_only_key("ABBE MARIGNAN"), _whitespace_only_key("ABBEMARIGNAN"),
+                "and also under the whitespace-only key")
 
 
-def test_real_roster_resolves_to_two_fewer_names():
+def _bare_name(name):
+    """The canonical name with its gender-marking prefix (if any) removed."""
+    tokens = canonicalize(name).split(" ")
+    if len(tokens) > 1 and tokens[0] in GENDERED_TITLES:
+        return " ".join(tokens[1:])
+    return " ".join(tokens)
+
+
+def test_real_roster_merges_never_mix_two_surnames():
+    # Safety property for the title tables: every merge family must be one
+    # person under two spellings, i.e. the labels in it must agree on the
+    # bare name once the title is set aside. A title table that swallowed a
+    # name constituent (the "ST JOHN RIVERS" -> "JOHN RIVERS" failure mode)
+    # would show up as a family mixing two distinct surnames.
+    families = _collision_families(REAL_PRODUCTION_ROSTER)
+    check(len(families) > 0, "real roster produces at least one collision family")
+    for family in families:
+        bare = {roster_key(_bare_name(name)) for name in family}
+        check(len(bare) == 1,
+              f"collision family {family} mixes distinct bare names {sorted(bare)}")
+
+    # Readable example: a boundary-mark drift pair and a gendered-title pair
+    # both collide, for a real character from the corpus.
+    check_equal(roster_key("ABBE MARIGNAN"), roster_key("ABBEMARIGNAN"),
+                "boundary-mark drift unifies onto the same roster key")
+    check_equal(canonicalize("Mme Tellier"), canonicalize("Madame Tellier"),
+                "abbreviated and spelled-out gendered titles unify onto the same key")
+
+
+def test_real_roster_keeps_cross_gender_pairs_distinct():
+    # The point of preserving the titles: MONSIEUR X and MADAME X are two
+    # people and must never share a roster entry. Derived programmatically
+    # (not a hardcoded surname list) from whatever cross-gender pairs the
+    # fixture happens to contain.
+    pairs = {}
+    for name in REAL_PRODUCTION_ROSTER:
+        tokens = canonicalize(name).split(" ")
+        if len(tokens) > 1 and tokens[0] in GENDERED_TITLES:
+            pairs.setdefault(" ".join(tokens[1:]), set()).add(tokens[0])
+    cross_gender = sorted(k for k, v in pairs.items() if len(v) > 1)
+    check(len(cross_gender) > 0,
+          "the real roster contains at least one cross-gender surname pair")
     index = {}
     for name in REAL_PRODUCTION_ROSTER:
         remember_in_roster(index, name)
-    check_equal(len(index), 576, "578 labels consolidate to 576 characters")
+    for surname in cross_gender:
+        for title in pairs[surname]:
+            check(resolve_against_roster(f"{title} {surname}", index) == f"{title} {surname}",
+                  f"{title} {surname} keeps its own roster entry")
+
+    # Readable example: Madame Dufour and Monsieur Dufour never merge.
+    check(canonicalize("Mme Dufour") != canonicalize("Monsieur Dufour"),
+          "Mme Dufour and Monsieur Dufour must stay distinct")
+
+
+def test_real_roster_is_idempotent_end_to_end():
+    for name in REAL_PRODUCTION_ROSTER:
+        once = canonicalize(name)
+        check_equal(canonicalize(once), once, f"idempotency for {name!r}")
+
+
+def test_real_roster_resolves_to_fewer_names_by_exactly_the_merged_collisions():
+    index = {}
+    for name in REAL_PRODUCTION_ROSTER:
+        remember_in_roster(index, name)
+    families = _collision_families(REAL_PRODUCTION_ROSTER)
+    merged_away = sum(len(family) - 1 for family in families)
+    check_equal(len(index), len(REAL_PRODUCTION_ROSTER) - merged_away,
+                "the index shrinks by exactly one entry per extra spelling "
+                "in each collision family")
+
+    # Readable examples of the resolution in action.
     check_equal(resolve_against_roster("ABBEMARIGNAN", index), "ABBE MARIGNAN",
                 "the drifted spelling resolves onto the good one")
-    check_equal(resolve_against_roster("ABBEMARIGNAN'S NIECE", index),
-                "ABBE MARIGNAN'S NIECE", "and so does the second family")
+    check_equal(resolve_against_roster("MME TELLIER", index), "MADAME TELLIER",
+                "the abbreviated French title resolves onto the spelled-out one")
+    check_equal(resolve_against_roster("M DE MEROUL", index), "MONSIEUR DE MEROUL",
+                "and so does the abbreviated MONSIEUR")
 
+
+# ---------------------------------------------------------------------------
+# Tier 3: attest_label() / _core_tokens()
+# ---------------------------------------------------------------------------
+
+def test_core_tokens_filters_stopwords_titles_possessives_accents():
+    check_equal(_core_tokens("MISTER SMITH"), ["SMITH"], "title filtered out")
+    check_equal(_core_tokens("THE DE LA CRUZ"), ["CRUZ"],
+                "stopwords THE/DE/LA filtered, surname kept")
+    check_equal(_core_tokens("DAIRINE'S"), ["DAIRINE"], "possessive stripped")
+    check_equal(_core_tokens("DAIRINE"), ["DAIRINE"], "plain token unaffected")
+    check_equal(_core_tokens("MISTER"), [], "pure title label has zero core tokens")
+    check_equal(_core_tokens(""), [], "empty label has zero core tokens")
+
+
+def test_attest_label_fully_attested_not_flagged():
+    windows = ["Alice walked into the room.", "Nobody else was around."]
+    result = attest_label("ALICE", windows)
+    check(result["attested"] is True, "ALICE attested when 'Alice' appears in a window")
+    check_equal(result["missing_tokens"], [], "no missing tokens when attested")
+
+
+def test_attest_label_missing_one_token_is_flagged():
+    windows = ["Alice walked into the room, alone."]
+    result = attest_label("ALICE SMITH", windows)
+    check(result["attested"] is False, "ALICE SMITH not attested when SMITH never appears")
+    check_equal(result["missing_tokens"], ["SMITH"], "SMITH reported missing")
+
+
+def test_attest_label_tokens_elsewhere_but_not_in_own_window_is_flagged():
+    # Synthetic "transposed name" case: TRANSFORMED and PIG both appear
+    # SOMEWHERE in the synthetic source, but never together, and never in
+    # this label's own windows -- attestation must still fail, because
+    # attest_label only looks at the windows it's given, not the whole book.
+    label = "TRANSFORMED PIG"
+    own_windows = [
+        "A stranger entered the tavern and ordered a drink quietly.",
+        "The stranger paid and left without another word.",
+    ]
+    # These sentences exist elsewhere in the (hypothetical) source, but are
+    # never passed in as this label's windows, simulating "elsewhere in the
+    # book, not near this label's lines".
+    _elsewhere_in_book = "The wizard had transformed into a pig hours earlier."
+    result = attest_label(label, own_windows)
+    check(result["attested"] is False,
+          "TRANSFORMED PIG not attested from windows that never mention either token")
+    check_equal(sorted(result["missing_tokens"]), ["PIG", "TRANSFORMED"],
+                "both core tokens reported missing")
+
+
+def test_attest_label_is_pure_and_deterministic():
+    windows = ["Bob said hello.", "Bob left quickly."]
+    windows_copy = list(windows)
+    result1 = attest_label("BOB", windows)
+    result2 = attest_label("BOB", windows)
+    check_equal(result1, result2, "same inputs produce the same output twice")
+    check_equal(windows, windows_copy, "windows list is left untouched by the call")
+
+    # Trivial/unknown case: a label with zero core tokens is conservatively
+    # flagged unattested rather than vacuously attested.
+    trivial = attest_label("MISTER", ["Mister anything goes here."])
+    check(trivial["attested"] is False, "zero-core-token label is conservatively unattested")
+    check_equal(trivial["missing_tokens"], [], "no tokens to report missing in the trivial case")
+
+
+def test_attest_label_matches_curly_apostrophe_across_the_glyph_gap():
+    # Label uses a straight apostrophe (typical LLM output); the source uses
+    # a curly one (typical of the author's own prose). The glyph difference
+    # carries no identifying information and must not cause a false flag.
+    windows = ["O'Malley walked in.", "‘No,’ said O’Malley."]
+    result = attest_label("O'MALLEY", windows)
+    check(result["attested"] is True, "curly source apostrophe matches straight label apostrophe")
+    check_equal(result["missing_tokens"], [], "no missing tokens once apostrophe glyph is normalized")
+
+
+def test_attest_label_distinct_apostrophe_names_stay_distinct():
+    # Normalizing the apostrophe GLYPH must not blur two different names
+    # that both happen to contain an apostrophe.
+    result = attest_label("O'MALLEY", ["O'Brien walked in."])
+    check(result["attested"] is False, "O'MALLEY is not attested by an O'BRIEN window")
+    check_equal(result["missing_tokens"], ["O'MALLEY"], "distinct apostrophe-bearing name reported missing")
+
+
+def test_attest_label_matches_hyphenated_token_verbatim():
+    windows = ["The sun-walker entered the hall.", "Sun-walker spoke softly."]
+    result = attest_label("SUN-WALKER", windows)
+    check(result["attested"] is True, "hyphenated label token matches hyphenated source occurrence")
+    check_equal(result["missing_tokens"], [], "no missing tokens for verbatim hyphenated match")
+
+
+def test_attest_label_matches_hyphenated_token_against_space_variant():
+    # Same name, but the source spells it with a space instead of a hyphen.
+    windows = ["The sun walker entered the hall."]
+    result = attest_label("SUN-WALKER", windows)
+    check(result["attested"] is True,
+          "hyphenated label token matches a space-separated source variant")
+    check_equal(result["missing_tokens"], [], "no missing tokens for the space-variant match")
+
+
+# ---------------------------------------------------------------------------
+# Unicode coverage of the character classes, and attest_speaker()'s three-way
+# verdict.
+#
+# These assert PROPERTIES over programmatically chosen sample scripts, not the
+# contents of any book: "a name in a non-Latin script survives
+# canonicalization", "two distinct names never share a roster key", "a label
+# our check cannot confirm is never reported as refuted". The sample strings
+# are language specimens (a Cyrillic name, a Hebrew name, ...), chosen to
+# cover cased/uncased and segmented/unsegmented writing systems; no corpus is
+# pinned and no test depends on any particular novel.
+# ---------------------------------------------------------------------------
+
+# One specimen per writing-system property that the character classes have to
+# survive. Cased-Latin is covered by the whole suite above; these are the ones
+# an ASCII class silently destroyed.
+_NON_LATIN_SPECIMENS = [
+    ("Cyrillic", "Ирина"),
+    ("Greek", "Μένων"),
+    ("Hebrew", "שרה"),
+    ("Arabic", "محمد"),
+    ("Han", "林"),
+    ("Hiragana", "さくら"),
+    ("Devanagari", "सीता"),
+]
+
+
+def test_canonicalize_preserves_non_latin_names():
+    # An ASCII _ALLOWED_CHARS_RE stripped every one of these to "", and
+    # resolve_span_labels only accepts a speaker when canonicalize() returns
+    # something truthy -- so this property is the difference between a
+    # non-Latin book having character voices and having none at all.
+    for script, name in _NON_LATIN_SPECIMENS:
+        canonical = canonicalize(name)
+        check(canonical != "", f"{script} name survives canonicalization (not emptied)")
+        check(len(canonical) == len(name),
+              f"{script} name keeps all of its characters")
+
+
+def test_canonicalize_is_idempotent_for_non_latin_names():
+    # Frozen contract 6 applies to every script, not just Latin.
+    for script, name in _NON_LATIN_SPECIMENS:
+        once = canonicalize(name)
+        check_equal(canonicalize(once), once, f"{script} canonicalization is idempotent")
+
+
+def test_non_latin_names_do_not_collide_on_one_roster_key():
+    # THE regression this pins. While _KEY_STRIP_RE was [^A-Z0-9] it removed
+    # every non-Latin letter, so once canonicalize() preserved them all these
+    # names would have keyed to "" -- one roster entry, one voice, for an
+    # entire cast, irreversibly (aliasing can merge but never split).
+    keys = {}
+    for script, name in _NON_LATIN_SPECIMENS:
+        key = roster_key(name)
+        check(key != "", f"{script} name has a non-empty roster key")
+        check(key not in keys,
+              f"{script} name does not share a roster key with {keys.get(key)}")
+        keys[key] = script
+
+    index = {}
+    for _, name in _NON_LATIN_SPECIMENS:
+        remember_in_roster(index, name)
+    check_equal(len(index), len(_NON_LATIN_SPECIMENS),
+                "every distinct non-Latin name gets its own roster entry")
+
+
+def test_non_latin_boundary_mark_unification_still_works():
+    # The Tier 1b contract is unchanged for non-Latin scripts: spellings that
+    # differ ONLY in boundary marks unify, and the more-punctuated form wins.
+    index = {}
+    remember_in_roster(index, "АННАМАРИЯ")
+    winner = remember_in_roster(index, "АННА МАРИЯ")
+    check_equal(winner, "АННА МАРИЯ",
+                "more-punctuated Cyrillic spelling wins the roster slot")
+    check_equal(len(index), 1, "the two Cyrillic spellings unified into one entry")
+
+
+def test_non_latin_distinct_names_are_never_unified():
+    # The no-fuzzy-merge contract, in a non-Latin script: one letter apart is
+    # still two different people.
+    index = {}
+    remember_in_roster(index, "ИРИНА")
+    remember_in_roster(index, "ИРИНЫ")
+    check_equal(len(index), 2, "Cyrillic names differing by a letter stay distinct")
+
+
+def test_core_tokens_extracted_from_non_latin_labels():
+    # _WORD_RE as [A-Za-z0-9'‘’] extracted ZERO tokens from these, and a
+    # zero-core-token label is reported unattested -- so the Voices UI badge
+    # was wrong for every speaker in every non-Latin book.
+    for script, name in _NON_LATIN_SPECIMENS:
+        tokens = _core_tokens(canonicalize(name))
+        check(len(tokens) > 0, f"{script} label yields at least one core token")
+
+
+def test_attest_speaker_attested_when_name_is_present():
+    for script, name in _NON_LATIN_SPECIMENS:
+        window = f"{name} — {name}."
+        verdict = attest_speaker(canonicalize(name), [window])
+        check(verdict in (ATTESTED, UNVERIFIABLE),
+              f"{script} name present in its window is not reported refuted "
+              f"(got {verdict!r})")
+
+
+def test_attest_speaker_unattested_only_on_positive_evidence():
+    # A name that appears nowhere in its windows, in any form, is the ONLY
+    # case that may be reported UNATTESTED -- this is the verdict a gate is
+    # allowed to reject on.
+    verdict = attest_speaker("ZZQXAL", ["Alice spoke to Bob about the weather."])
+    check_equal(verdict, UNATTESTED, "a name absent in every form is UNATTESTED")
+
+    verdict = attest_speaker("ALICE", ["Alice spoke to Bob about the weather."])
+    check_equal(verdict, ATTESTED, "a whole-word present name is ATTESTED")
+
+
+def test_attest_speaker_zero_core_tokens_is_unverifiable_never_unattested():
+    # attest_label reports this as attested=False (a conservative boolean).
+    # A gate must NOT treat it as refuted, or a label made only of titles is
+    # destroyed on no evidence.
+    check_equal(attest_speaker("MISTER", ["Mister anything goes here."]),
+                UNVERIFIABLE, "title-only label is UNVERIFIABLE, not UNATTESTED")
+    check_equal(attest_label("MISTER", ["Mister anything."])["attested"], False,
+                "attest_label's existing boolean contract is unchanged")
+
+
+def test_attest_speaker_substring_only_match_is_unverifiable():
+    # Unsegmented scripts (no spaces between words) put a correct name inside
+    # a longer run, where whole-word matching can never confirm it. Same shape
+    # as a too-short Latin token inside a longer word. Both are "cannot tell",
+    # and must not be rejectable.
+    check_equal(attest_speaker("林", ["林考言道，很好。"]), UNVERIFIABLE,
+                "name inside an unsegmented run is UNVERIFIABLE, not UNATTESTED")
+    check_equal(attest_speaker("AL", ["Alice waited."]), UNVERIFIABLE,
+                "short token inside a longer word is UNVERIFIABLE, not UNATTESTED")
+
+
+def test_attest_speaker_is_pure_and_idempotent():
+    label = "ALICE SMITH"
+    windows = ["Alice walked in.", "Smith followed."]
+    windows_before = copy.deepcopy(windows)
+
+    first = attest_speaker(label, windows)
+    second = attest_speaker(label, windows)
+    check_equal(first, second, "attest_speaker is idempotent on equal inputs")
+    check_equal(windows, windows_before, "attest_speaker does not mutate its windows")
+    check_equal(label, "ALICE SMITH", "attest_speaker does not mutate its label")
+
+
+def test_attest_speaker_handles_empty_and_missing_windows():
+    # A label with core tokens and no windows at all is refuted-by-absence,
+    # which is correct: nothing confirms it. Callers that cannot build windows
+    # must decide not to gate, rather than passing [] and rejecting the world.
+    check_equal(attest_speaker("ALICE", []), UNATTESTED,
+                "no windows means no confirmation")
+    check_equal(attest_speaker("", ["anything"]), UNVERIFIABLE,
+                "an empty label is UNVERIFIABLE")
+
+
+def test_attest_speaker_verdicts_are_the_exported_constants():
+    # Callers compare against the constants; pin their values so a rename
+    # cannot silently change the wire/report vocabulary.
+    check_equal(ATTESTED, "attested", "ATTESTED constant value")
+    check_equal(UNATTESTED, "unattested", "UNATTESTED constant value")
+    check_equal(UNVERIFIABLE, "unverifiable", "UNVERIFIABLE constant value")
 
 
 def main():
     tests = [
         test_basic_case_and_whitespace_normalization,
         test_parenthetical_removal,
-        test_honorific_stripping,
-        test_honorific_alone_never_empty,
+        test_rank_titles_are_dropped,
+        test_gendered_titles_are_preserved_and_normalized,
+        test_gendered_titles_are_language_preserving,
+        test_gendered_titles_keep_husband_and_wife_apart,
+        test_fr_is_preserved_not_dropped,
+        test_title_alone_never_empty,
         test_all_variants_converge,
         test_accent_normalization,
         test_narrator_canonicalization,
@@ -561,7 +1000,7 @@ def main():
         test_unmatched_apostrophes_survive_wrapping_fix,
         test_wrapping_quotes_and_roster_fragmentation,
         test_idempotency,
-        test_stacked_honorifics_strip_to_a_fixpoint,
+        test_stacked_titles_resolve_to_a_fixpoint,
         test_double_canonicalization_matches_single,
         test_saint_names_are_not_honorifics,
         test_roster_key_strips_whitespace_only,
@@ -580,11 +1019,36 @@ def main():
         test_empty_name_is_not_recorded,
         test_real_roster_fixture_is_intact,
         test_real_roster_key_introduces_no_new_collisions,
-        test_real_roster_resolves_to_two_fewer_names,
+        test_real_roster_merges_never_mix_two_surnames,
+        test_real_roster_keeps_cross_gender_pairs_distinct,
+        test_real_roster_is_idempotent_end_to_end,
+        test_real_roster_resolves_to_fewer_names_by_exactly_the_merged_collisions,
         test_suggest_aliases_expected_pairs,
         test_suggest_aliases_excludes_narrator,
         test_suggest_aliases_empty_and_single,
         test_suggest_aliases_direction_rule,
+        test_core_tokens_filters_stopwords_titles_possessives_accents,
+        test_attest_label_fully_attested_not_flagged,
+        test_attest_label_missing_one_token_is_flagged,
+        test_attest_label_tokens_elsewhere_but_not_in_own_window_is_flagged,
+        test_attest_label_is_pure_and_deterministic,
+        test_attest_label_matches_curly_apostrophe_across_the_glyph_gap,
+        test_attest_label_distinct_apostrophe_names_stay_distinct,
+        test_attest_label_matches_hyphenated_token_verbatim,
+        test_attest_label_matches_hyphenated_token_against_space_variant,
+        test_canonicalize_preserves_non_latin_names,
+        test_canonicalize_is_idempotent_for_non_latin_names,
+        test_non_latin_names_do_not_collide_on_one_roster_key,
+        test_non_latin_boundary_mark_unification_still_works,
+        test_non_latin_distinct_names_are_never_unified,
+        test_core_tokens_extracted_from_non_latin_labels,
+        test_attest_speaker_attested_when_name_is_present,
+        test_attest_speaker_unattested_only_on_positive_evidence,
+        test_attest_speaker_zero_core_tokens_is_unverifiable_never_unattested,
+        test_attest_speaker_substring_only_match_is_unverifiable,
+        test_attest_speaker_is_pure_and_idempotent,
+        test_attest_speaker_handles_empty_and_missing_windows,
+        test_attest_speaker_verdicts_are_the_exported_constants,
     ]
 
     for t in tests:

--- a/app/test_speaker_canon.py
+++ b/app/test_speaker_canon.py
@@ -9,7 +9,13 @@ Exits 0 on all-pass, nonzero if any assertion fails.
 import sys
 import copy
 
-from speaker_canon import canonicalize, suggest_aliases
+from speaker_canon import (
+    canonicalize,
+    remember_in_roster,
+    resolve_against_roster,
+    roster_key,
+    suggest_aliases,
+)
 
 _failures = []
 
@@ -186,6 +192,320 @@ def test_suggest_aliases_direction_rule():
         check_equal(s["alias_of"], "JOHN", "longer name should be 'alias_of' (the target)")
 
 
+
+# ---------------------------------------------------------------------------
+# Tier 1b: resolve_against_roster()
+# ---------------------------------------------------------------------------
+
+
+def _index(*names):
+    index = {}
+    for name in names:
+        remember_in_roster(index, name)
+    return index
+
+
+def test_roster_key_strips_whitespace_only():
+    check_equal(roster_key("ABBE MARIGNAN"), "ABBEMARIGNAN", "spaced key")
+    check_equal(roster_key("abbemarignan"), "ABBEMARIGNAN", "unspaced key")
+    check(roster_key("JON") != roster_key("JOHN"), "JON/JOHN keys must differ")
+    check(roster_key("ELLA") != roster_key("BELLA"), "ELLA/BELLA keys must differ")
+
+
+def test_most_boundary_marks_wins_in_both_arrival_orders():
+    # The selection rule is ORDER-INDEPENDENT: the more-punctuated spelling
+    # wins whichever one the roster met first. This is what makes generation
+    # (chunk order) and review (entry order) agree, and what stops a single
+    # malformed first sighting becoming canonical for the whole book.
+    spaced_first = _index("ABBE MARIGNAN", "ABBEMARIGNAN")
+    check_equal(resolve_against_roster("ABBEMARIGNAN", spaced_first), "ABBE MARIGNAN",
+                "spaced form wins when seen first")
+    unspaced_first = _index("ABBEMARIGNAN", "ABBE MARIGNAN")
+    check_equal(resolve_against_roster("ABBEMARIGNAN", unspaced_first), "ABBE MARIGNAN",
+                "spaced form ALSO wins when the malformed one was seen first")
+    check_equal(sorted(spaced_first.values()), sorted(unspaced_first.values()),
+                "both arrival orders converge on the same roster")
+
+
+
+def test_punctuation_variants_unify():
+    check_equal(roster_key("O'BRIEN"), roster_key("OBRIEN"), "apostrophe key")
+    check_equal(roster_key("JEAN-LUC"), roster_key("JEAN LUC"), "hyphen vs space key")
+    check_equal(roster_key("ABBE MARIGNAN'S NIECE"), roster_key("ABBEMARIGNAN'S NIECE"),
+                "real production pair keys alike")
+    check(roster_key("O'BRIEN") != roster_key("OBRIAN"), "OBRIAN is a different name")
+
+
+def test_apostrophe_variant_wins_in_both_arrival_orders():
+    forward = _index("O'BRIEN", "OBRIEN")
+    check_equal(resolve_against_roster("OBRIEN", forward), "O'BRIEN",
+                "apostrophe form wins when seen first")
+    backward = _index("OBRIEN", "O'BRIEN")
+    check_equal(resolve_against_roster("OBRIEN", backward), "O'BRIEN",
+                "apostrophe form ALSO wins when the bare form was seen first")
+    check_equal(sorted(forward.values()), sorted(backward.values()),
+                "both arrival orders converge")
+
+
+def test_hyphen_vs_space_is_a_deterministic_tie():
+    # Same letters, same length -- neither is more likely correct, so the
+    # incumbent keeps the slot. Deterministic, and documented as a tie.
+    hyphen_first = _index("JEAN-LUC", "JEAN LUC")
+    check_equal(list(hyphen_first.values()), ["JEAN-LUC"], "hyphen incumbent kept")
+    space_first = _index("JEAN LUC", "JEAN-LUC")
+    check_equal(list(space_first.values()), ["JEAN LUC"], "space incumbent kept")
+    check_equal(len(hyphen_first), 1, "the pair is still unified either way")
+    check_equal(len(space_first), 1, "the pair is still unified either way")
+
+
+def test_boundary_marks_beat_a_bare_run_of_letters():
+    # Longer canonical form == more boundary marks, since the letters match.
+    index = _index("ABBEMARIGNANSNIECE")
+    check_equal(remember_in_roster(index, "ABBE MARIGNAN'S NIECE"),
+                "ABBE MARIGNAN'S NIECE", "most-punctuated spelling is promoted")
+
+
+def test_remember_returns_the_winner_and_promotes_in_place():
+    index = _index("ABBEMARIGNAN")
+    check_equal(remember_in_roster(index, "ABBE MARIGNAN"), "ABBE MARIGNAN",
+                "a better spelling is promoted and returned immediately")
+    check_equal(list(index.values()), ["ABBE MARIGNAN"], "index holds only the winner")
+    check_equal(remember_in_roster(index, "ABBEMARIGNAN"), "ABBE MARIGNAN",
+                "a worse spelling is normalized onto the winner")
+
+
+def test_ties_keep_the_incumbent():
+    index = _index("JEAN LUC")
+    check_equal(remember_in_roster(index, "JEAN-LUC PICARD"), "JEAN-LUC PICARD",
+                "different key -- unrelated name, not a tie")
+    tie = _index("MARY ANNE")
+    check_equal(remember_in_roster(tie, "MARY ANNE"), "MARY ANNE",
+                "identical spelling is a no-op")
+    check_equal(len(tie), 1, "no spurious entries on a tie")
+
+
+def test_resolve_snaps_onto_established_spelling():
+    roster = _index("ABBE MARIGNAN", "MARCUS")
+    check_equal(resolve_against_roster("ABBEMARIGNAN", roster), "ABBE MARIGNAN",
+                "drifted spelling snaps onto the established spaced form")
+    check_equal(resolve_against_roster("abbe marignan", roster), "ABBE MARIGNAN",
+                "already-correct spelling is unchanged")
+
+
+def test_resolve_never_merges_similar_names():
+    roster = _index("JON", "ELLA")
+    check_equal(resolve_against_roster("JOHN", roster), "JOHN", "JOHN stays distinct from JON")
+    check_equal(resolve_against_roster("BELLA", roster), "BELLA", "BELLA stays distinct from ELLA")
+    check_equal(resolve_against_roster("JON", _index("JOHN")), "JON",
+                "JON stays distinct from JOHN")
+    check_equal(resolve_against_roster("ELLA", _index("BELLA")), "ELLA",
+                "ELLA stays distinct from BELLA")
+    both = _index("JON", "JOHN", "ELLA", "BELLA")
+    check_equal(len(both), 4, "four similar names remain four roster entries")
+
+
+def test_resolve_passthrough_and_narrator():
+    roster = _index("ABBE MARIGNAN")
+    check_equal(resolve_against_roster("Mr. Mark", roster), "MARK",
+                "unmatched name is just canonicalized")
+    check_equal(resolve_against_roster("NARRATOR", roster), "NARRATOR", "NARRATOR untouched")
+    check_equal(resolve_against_roster("narrator", _index("NARRATOR")), "NARRATOR",
+                "narrator still canonicalizes to NARRATOR with a roster present")
+    check_equal(resolve_against_roster("", roster), "", "empty input")
+    check_equal(resolve_against_roster("MARK", {}), "MARK", "empty roster")
+    check_equal(resolve_against_roster("MARK", None), "MARK", "None roster")
+
+
+def test_resolve_is_idempotent():
+    roster = _index("ABBE MARIGNAN", "JON")
+    once = resolve_against_roster("ABBEMARIGNAN", roster)
+    check_equal(resolve_against_roster(once, roster), once, "idempotent resolution")
+    check_equal(resolve_against_roster(resolve_against_roster("JOHN", roster), roster), "JOHN",
+                "idempotent for a non-matching name")
+
+
+def test_resolve_does_not_mutate_the_index():
+    roster = _index("ABBE MARIGNAN")
+    snapshot = copy.deepcopy(roster)
+    resolve_against_roster("SOMEONE ELSE", roster)
+    check_equal(roster, snapshot, "resolve_against_roster is read-only")
+
+
+def test_empty_name_is_not_recorded():
+    index = {}
+    check_equal(remember_in_roster(index, ""), "", "empty name returns empty")
+    check_equal(remember_in_roster(index, "   "), "", "whitespace-only name returns empty")
+    check_equal(index, {}, "nothing recorded for an empty name")
+
+
+
+# ---------------------------------------------------------------------------
+# Real-roster safety property
+#
+# The 578 distinct canonical speaker labels produced by a real 976-chunk
+# production run (9,374 script entries). Embedded verbatim so the safety
+# property below is pinned permanently and needs no external file.
+#
+# The property: the roster key may unify spellings that differ only in their
+# boundary marks, and on REAL data that must not sweep up two genuinely
+# different characters. Measured: the whitespace-only key produced 2 collision
+# families; the current, wider key (whitespace + hyphens + apostrophes)
+# produces exactly the same 2 -- both the known ABBE MARIGNAN pair. Widening
+# the key any further must be re-measured against this fixture first.
+# ---------------------------------------------------------------------------
+
+REAL_PRODUCTION_ROSTER = [
+    "NARRATOR", "ZOLA", "MAUPASSANT", "FLAUBERT", "MERCHANT", "HOSTLER", "DRIVER",
+    "TRAVELLER", "COUNT HUBERT", "LOISEAU", "BOULE DE SUIF", "MADAME LOISEAU", "NUN",
+    "CORNUDET", "GERMAN OFFICER", "INNKEEPER", "COUNTESS", "BEADLE", "CARRE-LAMADON",
+    "MONSIEUR FOLLENVIE", "MADAME CARRE-LAMADON", "MONSIEUR SAVAGE",
+    "MONSIEUR MORISSOT", "MONSIEUR SAUVAGE", "MORISSOT", "SAUVAGE", "CAPTAIN",
+    "SOLDIER", "GENERAL ROLAND", "CAPTAIN'S WIFE", "PIEDELOT", "LONG-LEGS",
+    "YOUNGER WOMAN", "OLDER WOMAN", "BERTHINE", "CHARACTER", "BERTHINE'S FATHER",
+    "MONSIEUR LAVIGNE", "JEAN KERDEREN", "LUC LE GANIDEC", "FATHER MILON", "COLONEL",
+    "MASSAREL", "PEASANT", "PHYSICIAN", "COMMANDANT", "LIEUTENANT PICART", "NOTABLES",
+    "DOCTOR", "M DE VARNETOT", "EX-LIEUTENANT PICART", "SENTINEL", "OLDER MAN",
+    "GENERAL DE G", "M MARTINI", "PARISSE'S WIFE", "PARISSE", "JEAN DE CARMELIN",
+    "GRIBOIS", "LIEUTENANT OTTO", "MAJOR", "GRAF VON FARSBERG", "FIFI",
+    "LITTLE BARON WILHELM", "LIEUTENANT FRITZ", "PAMELA", "EVA", "RACHEL", "GROUP",
+    "ENGLISHMAN", "M DUBUIS", "ENGLISHMEN", "COLONEL LAPORTE", "MOTHER SAVAGE",
+    "MY FRIEND SERVAL", "COUNT DE GARENS", "MARCHAS", "PRIEST", "HERMANCE",
+    "SISTER SAINT-BENEDICT", "PIQUEDENT", "WORKING-WOMAN", "ANGELE", "BARON D'ETRAILLE",
+    "CHILD", "BROTHER-IN-LAW", "HENRIETTE", "PAUL", "WAITER", "CARAVAN", "CHENET",
+    "MARIE-LOUISE", "MADAME CARAVAN", "DOCTOR CHENET", "LANDLORD", "DOMINO PLAYER",
+    "CARAVAN'S WIFE", "BRAUX", "BRAUX'S WIFE", "CARAVAN'S MOTHER", "COMTE D'ETRAILLE",
+    "RENE LAMANOIR", "LEON CHENAL", "MEDERIC", "RENARDET", "LA ROQUE", "PRINCIPETTE",
+    "MAYOR", "MAGISTRATE", "MOTHER LA ROQUE", "WOODCUTTER", "RENADET", "SERVANT",
+    "MAILLOCHON", "CHICOT", "LABOUISE", "MALOUREAU", "MOIRON", "WHEELWRIGHT",
+    "WHEELWRIGHT'S WIFE", "JEAN", "GEORGES LOUIS", "JUDGE", "BERTHA", "BONNET", "MARIN",
+    "PETITPAS", "MASSOULIGNY", "MME BRUMENT", "DEFENDANT BRUMENT", "CORNU", "JACQUES",
+    "RAVET", "NURSES", "MOTHER", "WIFE", "BERTHE", "GILBERTE", "HENRI FONTAL", "FINOT",
+    "PEASANT MAN", "PEASANT WOMAN", "OSIME FAVET", "BONIFACE", "CAVALIER", "MASTER",
+    "CESAIRE DENTU", "ROSE", "MASTER VALLIN", "SPEAKER", "THEODULE SABOT",
+    "VILLAGE RESIDENTS", "ABBE", "SABOT", "PADOIE", "VARAJOU", "BOY", "VARAROU",
+    "OTHER", "M LOISEAU", "MME FORESTIER", "LOISEL", "MME LOISEAU", "JEWELER",
+    "FORESTIER", "SOMEONE", "JOVIS", "M MALLET", "PAUL BESSAND", "HENRI SIMON",
+    "PIERRE CARNIER", "JEAN D'ARVILLE", "FRANCOIS D'ARVILLE", "MARQUIS D'ARVILLE",
+    "LADY", "ULRICH KUNSI", "FATHER HAUSER", "OLD HARI", "LOUISE", "JEAN HAUSER",
+    "GASPARD HARI", "MOTHER HAUSER", "LOUISE HAUSER", "MONSIEUR PARENT", "JULIE",
+    "PARENT", "LIMOUSIN", "GEORGE", "BARMAID", "ZOE", "QUEEN HORTENSE", "M CIMME",
+    "CELESTE", "COLOMBEL", "LITTLE MAID", "MAID", "MME CIMME", "DYING WOMAN",
+    "MME COLOMBEL", "CIMME", "TIMBUCTOO", "CHANTAL", "PEARL", "MME CHANTAL",
+    "CHANTAL LADIES", "CHANTAL'S WIFE", "ABBE MARIGNAN", "ABBE MARIGNAN'S NIECE",
+    "MELANIE", "COUNT JEAN DES BARRETS", "COMTESSE", "ABBE MAUDUIT",
+    "COMTESSE'S HUSBAND", "ROSSET", "SAVAL", "ROMANTIN", "MATHILDE",
+    "HECTOR DE GRIBELIN", "MME SIMON", "MME DE GRIBELIN", "HECTOR", "COUNT",
+    "COMTESSE DE MASCARET", "COMTE DE MASCARET", "ROGER DE SALNIS", "BERNARD GRANDIN",
+    "FRANCOIS TESSIER", "M FLOREAL FLAMEL", "MME FLOREAL FLAMEL", "MY UNCLE SOSTHENES",
+    "ABBEMARIGNAN", "BOISRENE", "LAURENT", "THE CRIPPLE", "HENRI BONCLAIR",
+    "MONSIEUR LERAS", "MADAME MARAMBALLE", "ALEXANDRE", "MARAMBALLE", "WORKMAN",
+    "DOMESTIC", "PAUL PAVILLY", "PORTER", "ITALIAN WOMAN", "FRANCESCA RONDOLO",
+    "MOTHER RONDOLO", "CARLOTTA", "MONSIEUR LANTIN", "MONSIEUR LANTIN'S WIFE",
+    "ANTONIA SAVERNINI", "WIDOW SAVERNINI", "SAINT MICHAEL", "SATAN",
+    "JACQUES DE RANDAL", "IRENE", "D'APREVAL", "MONSIEUR DE CADOUR", "MME DE CADOUR",
+    "TELLIER", "TEURNEVAU", "PINIPESSE", "GENTLEMAN", "MADAME TELLIER", "RAPHAELE",
+    "MME TELLIER", "ROSA", "RIVET", "CARPENTER", "GUARD", "MME TOURNEVAU",
+    "MONSIEUR PHILIPPE", "FERNANDE", "MONSIEUR TOURENEVAU", "MONSIEUR VASSE",
+    "MONSIEUR DUPUIS", "DENIS", "M MARAMBOT", "MARAMBOT", "OFFICER", "LAWYER",
+    "GEORGES DUPORTIN", "PIERRE LETOILE", "GONTRAN", "ROGER DES ANNETTES",
+    "MARQUIS DE LA TOUR-SAMUEL", "MOTHER CLOCHETTE", "COLLETTE", "CAILLAIRD",
+    "CAILLAIRD'S WIFE", "BONDEL", "BONDEL'S WIFE", "TANCRET", "ABBEMARIGNAN'S NIECE",
+    "PERE JOSEPH", "POSTMAN", "MAITRE RAMEAU", "SERGEANT", "LECACHEUR", "SERVANT GIRL",
+    "LECACHEUR'S WIFE", "BRIGADIER SENATEUR", "MME LECACHEUR", "LENIENT", "SEVERIN",
+    "LECHEUR", "LEUILLET", "MME LEUILLET", "MY UNCLE JULES", "HE", "SHE", "BRIGADIER",
+    "RANDEL", "BUTCHER", "PROSECUTOR", "RENARD", "MADAME RENARD",
+    "PRESIDENT OF THE COURT", "OLD BREDEL'S SON", "BEAURAIN", "MADAME BEAURAIN",
+    "THE MAYOR", "BENOIST", "MARTINE", "MOTHER BEAURAIN", "BENOIST'S MOTHER", "VALLIN",
+    "COMTE DE LORMERIN", "LISE", "RENEE", "LORMERIN", "BARNES", "PATIN", "DESIREE",
+    "AUCTIONEER", "WOMAN", "PATIN'S WIDOW", "PARROT", "MAITRE ANTHIME", "PUBLIC CRIER",
+    "CORPORAL OF GENDARMES", "MAITRE HAUCHECORNNE", "MAITRE HAUCHECORNE",
+    "FARMER OF CRIQUETOT", "HORSE DEALER", "HAUCHECORNE", "PEOPLE",
+    "TOINE BURNT-BRANDY", "CUSTOMER", "TOINE BURNT-BRANDY'S WIFE", "CELESTIN MAULOISEL",
+    "PROSPER HORSLAVILLE", "HORSLAVILLE", "PASSER-BY", "RAOUL AUBERTIN", "MME HUSSON",
+    "FRANCOISE", "BARBESOL", "ABBE MALON", "DAUPHINE", "LOUIS PHILIPPE", "GENERAL",
+    "ISIDORE ROSIER", "COMMANDANT DESBARRES", "GRENADIERS", "M D'HUBIERES'S WIFE",
+    "M D'HUBIERES", "MADAME D'HUBIERES", "FATHER TUVACHE", "AGED LADY", "JEAN VALLIN",
+    "VALLINS' MOTHER", "VALLINS' FATHER", "CHARLOT", "PEASANT MOTHER",
+    "VICOMTE GONTRAN-JOSEPH DE SIGNOLES", "ONE OF THE LADIES", "THE HUSBAND",
+    "THE LADY", "MARQUIS", "MONGILET", "MADAME ROUBERE", "MADAME HENRIETTE LETORE",
+    "HUSBAND", "NEWSPAPER", "PRIME MINISTER", "PATISSOT", "SALESPERSON", "BOIVIN",
+    "PATISSOT'S COUSIN", "LITTLE MAN", "GARDENER", "PATISSOT'S COMPANION", "JOURNALIST",
+    "NOVELIST", "TOUGH", "AN OLD GENTLEMAN", "A YOUNG MAN", "OCTAVIE",
+    "STRAPPING FELLOW", "PERDRIX", "RADE", "SOMBRETERR", "SOMBRETERRE", "MAN",
+    "PAUL MURET", "MME MURET D'ARTUS", "MY FRIEND", "OLD WOMAN", "M DE MEROUL",
+    "MME DE MEROUL", "JOSEPH MOURADOUR", "MONSIEUR DE MEROUL", "SPEAKER 1", "SPEAKER 2",
+    "OLD AMABLE", "CESAIRE", "CELESTE LEVESQUE", "CESAIRE HOULBREQUE",
+    "OLD AMABLE HOULBREQUE", "ABBE RAFFIN", "AMABLE HOULBREQUE", "COUNTRYMAN",
+    "ANOTHER COUNTRYMAN", "MALIVOIRE", "VICTOR LECOQ", "DADDY MALIVOIRE", "NEIGHBOR",
+    "OLD MAN", "BARON RENE DU TREILLES", "MAITRE LEBRUMENT", "PEASANT DRIVER", "FARMER",
+    "LA RAPET", "SICK-NURSE", "HONORE", "HONORE'S MAN", "RAPET", "MOTHER BONTEMPS",
+    "OLD BARON DES RAVOTS", "JOSEPH", "EVERYONE", "RENE DE BOURNEVAL",
+    "WALTER SCHNAFFS", "BIG SOLDIER", "ANOTHER OFFICER", "BIG OFFICER", "YOUNG OFFICER",
+    "BLOUGNE-SUR-MER CORRESPONDENT", "SEAMAN", "JAVEL SENIOR", "JAVEL JUNIOR",
+    "UNKNOWN", "LABARBE", "SAINT ANTHONY", "MAYOR CHICOT", "PRUSSIAN SOLDIER",
+    "PIG-PORTRAYING-SOLDIER", "MME LEMOINE", "MME LEFEVRE", "BAKER", "CHAUK PIT WORKER",
+    "QUARRYMAN", "BRIDEGROOM", "BRIDE", "COMPANION", "MATTHEW", "MELIE", "OREILLE",
+    "MME OREILLE", "OREILLE'S WIFE", "CLERK", "RABOT", "MAITRE CANEVILLE",
+    "MAITRE POIRET", "RABOT'S WIFE", "MAITRE BELOHOMME", "CANIVEAU", "BELHOMME",
+    "SIDOINE", "TAILLE", "TOUCHARD", "ANNA", "OLD TOUCHARD", "SAUVETANIN", "COMPANY",
+    "LEBRUMENT", "FATHER-IN-LAW", "CONDUCTOR", "TWO LADIES", "COOK", "INSPECTOR",
+    "HENRY BARRAL", "M D'ARNELLES", "SIMON RADEVIN", "MADAME RADEVIN", "GRANDFATHER",
+    "GONTRAN-JOSEPH DE SIGNOLES", "SUICIDE LETTER WRITER", "YOUNG WOMAN", "GUEST",
+    "ANOTHER GUEST", "WRITER", "SIMON", "SOMEONE ELSE", "PHILIP REMY", "LA BLANCHOTTE",
+    "LEMONNIER", "LEMONNIER'S WIFE", "M LEMONNIER", "MONSIEUR DUFOUR", "MME DUFOUR",
+    "MME DUFOUR'S HUSBAND", "MME DUFOUR'S DAUGHTER", "ONE OF THE BOATING MEN",
+    "YOUNG MAN", "SAME BOATING MAN", "SAME SPEAKER", "BOATING MAN", "HENRI", "HIMSELF",
+    "MADAME DUFOUR", "HENRIETTE'S HUSBAND", "MARGOT", "SIMONE", "ROSALE",
+    "OLD VARAMBOT AND HIS WIFE", "SANDRES", "MADAME SANDRES", "MME SANDRES", "M SAVAL",
+    "LITTLE SERVANT GIRL", "MARGUERITE", "SUZANNE", "FATHER SIMON", "ZIDORE",
+    "SISTER EULALIE", "THE JUDGE", "THE ENGLISHWOMAN", "MADEMOISELLE COCOTTE", "I",
+    "FRANCOIS", "SELF", "COURBATAILLE", "UNCLE JOSEPH", "LARGE WOMAN", "CHILDREN",
+    "MOTHER MAGLOIRE", "JULES CHICOT", "NOTARY", "BOITELLE", "SON", "FATHER", "ANTOINE",
+    "NEGRESS", "A YOUNG WOMAN", "OLD MAIDEN AUNT", "ONE OF THE GENTLEMEN",
+    "POIREL DE LA VOULTE", "MOTHER OF MONSTERS", "HOUSEHOLD", "M MILIAL", "MATHURIN",
+    "JEREMIE", "OWNER", "PHYSICIAN FRIEND", "FLORENTIN", "EMMA", "FORTUNE-TELLER",
+    "AUTHOR", "MADAME HERMET", "PATIENT", "MME HERMET", "GEORGE HERMET", "FOOTMAN",
+    "SECRETARY", "MARINEL", "PROJECT GUTENBERG", "THE FOUNDATION",
+]
+
+EXPECTED_COLLISION_FAMILIES = [
+    ["ABBE MARIGNAN", "ABBEMARIGNAN"],
+    ["ABBE MARIGNAN'S NIECE", "ABBEMARIGNAN'S NIECE"],
+]
+
+
+def _collision_families(names):
+    families = {}
+    for name in names:
+        families.setdefault(roster_key(name), []).append(name)
+    return sorted(sorted(v) for v in families.values() if len(v) > 1)
+
+
+def test_real_roster_fixture_is_intact():
+    check_equal(len(REAL_PRODUCTION_ROSTER), 578, "fixture holds all 578 real labels")
+    check_equal(len(set(REAL_PRODUCTION_ROSTER)), 578, "fixture labels are distinct")
+
+
+def test_real_roster_key_introduces_no_new_collisions():
+    # Exactly the two known ABBE MARIGNAN families -- no others. A future
+    # widening of roster_key() that merges two real characters fails here.
+    check_equal(_collision_families(REAL_PRODUCTION_ROSTER),
+                EXPECTED_COLLISION_FAMILIES,
+                "real-roster collision families")
+
+
+def test_real_roster_resolves_to_two_fewer_names():
+    index = {}
+    for name in REAL_PRODUCTION_ROSTER:
+        remember_in_roster(index, name)
+    check_equal(len(index), 576, "578 labels consolidate to 576 characters")
+    check_equal(resolve_against_roster("ABBEMARIGNAN", index), "ABBE MARIGNAN",
+                "the drifted spelling resolves onto the good one")
+    check_equal(resolve_against_roster("ABBEMARIGNAN'S NIECE", index),
+                "ABBE MARIGNAN'S NIECE", "and so does the second family")
+
+
+
 def main():
     tests = [
         test_basic_case_and_whitespace_normalization,
@@ -203,6 +523,23 @@ def main():
         test_unmatched_apostrophes_survive_wrapping_fix,
         test_wrapping_quotes_and_roster_fragmentation,
         test_idempotency,
+        test_roster_key_strips_whitespace_only,
+        test_most_boundary_marks_wins_in_both_arrival_orders,
+        test_punctuation_variants_unify,
+        test_apostrophe_variant_wins_in_both_arrival_orders,
+        test_hyphen_vs_space_is_a_deterministic_tie,
+        test_boundary_marks_beat_a_bare_run_of_letters,
+        test_remember_returns_the_winner_and_promotes_in_place,
+        test_ties_keep_the_incumbent,
+        test_resolve_snaps_onto_established_spelling,
+        test_resolve_never_merges_similar_names,
+        test_resolve_passthrough_and_narrator,
+        test_resolve_is_idempotent,
+        test_resolve_does_not_mutate_the_index,
+        test_empty_name_is_not_recorded,
+        test_real_roster_fixture_is_intact,
+        test_real_roster_key_introduces_no_new_collisions,
+        test_real_roster_resolves_to_two_fewer_names,
         test_suggest_aliases_expected_pairs,
         test_suggest_aliases_excludes_narrator,
         test_suggest_aliases_empty_and_single,

--- a/app/test_speaker_canon.py
+++ b/app/test_speaker_canon.py
@@ -819,6 +819,123 @@ def test_attest_label_matches_hyphenated_token_against_space_variant():
 
 
 # ---------------------------------------------------------------------------
+# PHRASE ADJACENCY for multi-token labels.
+#
+# THE DEFECT: per-token set membership attests any label whose tokens each turn
+# up SOMEWHERE in the window, so a name recombined from two different real
+# characters' name parts passes, enters the roster, and is then never
+# re-checked. All fixtures below are synthesized -- invented names and English
+# orthography only; nothing is taken from any book.
+# ---------------------------------------------------------------------------
+
+
+def test_recombined_multi_token_label_is_refused():
+    # Both parts present, never together: the whole point.
+    windows = ["Then Verrin spoke, and Calder answered him from the doorway."]
+    result = attest_label("VERRIN CALDER", windows)
+    check(result["attested"] is False, "a recombined two-name label is not attested")
+    check_equal(result["missing_tokens"], [],
+                "nothing is 'missing' -- the tokens are present, just not adjacent")
+    check_equal(result.get("note"), "tokens_not_adjacent", "the non-adjacency is reported")
+    check_equal(attest_speaker("VERRIN CALDER", windows), UNATTESTED,
+                "non-adjacency is positive evidence, so the verdict is UNATTESTED")
+
+
+def test_genuine_phrase_label_still_attests():
+    windows = ["Then Verrin Calder spoke from the doorway."]
+    check(attest_label("VERRIN CALDER", windows)["attested"] is True,
+          "a label the source spells as a phrase still attests")
+
+
+def test_phrase_check_folds_case_and_internal_capitals():
+    # Property 1: the label is uppercase, the source carries internal capitals.
+    windows = ["Then Verrin McCalder spoke from the doorway."]
+    check(attest_label("VERRIN MCCALDER", windows)["attested"] is True,
+          "a medial capital in the source does not break the phrase match")
+
+
+def test_phrase_check_folds_apostrophe_glyphs():
+    # Property 2: U+2019 in the source, U+0027 in the label (or the reverse).
+    check(attest_label("VER'RIN CALDER", ["Then Ver’rin Calder spoke."])["attested"] is True,
+          "a curly source apostrophe matches a straight label apostrophe")
+    check(attest_label("VER’RIN CALDER", ["Then Ver'rin Calder spoke."])["attested"] is True,
+          "a straight source apostrophe matches a curly label apostrophe")
+
+
+def test_possessive_composition_is_exempt_from_the_phrase_rule():
+    # Property 3, and the highest-cost trap: "X'S <relation>" is a description
+    # of a person, not a name, and the source usually refers to that person by
+    # pronoun near their own speech. Requiring the phrase in the window would
+    # refuse a large number of correctly-attributed entries.
+    adjacent = ["Then Verrin's father spoke from the doorway."]
+    check(attest_label("VERRIN'S FATHER", adjacent)["attested"] is True,
+          "a possessive composition spelled adjacently attests")
+    scattered = ["Verrin looked up. Some while later, his father spoke."]
+    check(attest_label("VERRIN'S FATHER", scattered)["attested"] is True,
+          "a possessive composition attests on per-token evidence alone")
+    # The named half must still be there: the exemption is not a free pass.
+    check_equal(attest_speaker("CALDER'S FATHER", scattered), UNATTESTED,
+                "an unattested name in a possessive composition is still refuted")
+
+
+def test_leading_article_is_invisible_to_the_phrase_rule():
+    # Property 4, in both directions: the label may carry an article the source
+    # lowercases, or omit one the source includes.
+    windows = ["It was the lone power that answered."]
+    check(attest_label("THE LONE POWER", windows)["attested"] is True,
+          "a label carrying the article matches a lowercase source article")
+    check(attest_label("LONE POWER", windows)["attested"] is True,
+          "a label omitting the article matches a source that includes one")
+    check(attest_label("THE LONE POWER", ["Only the lone one answered the power."])["attested"] is False,
+          "the article rule does not license non-adjacent tokens")
+
+
+def test_internal_stopword_does_not_break_the_phrase():
+    windows = ["The Mother of Monsters raised her head."]
+    check(attest_label("MOTHER OF MONSTERS", windows)["attested"] is True,
+          "a stopword the label drops may still sit between the source tokens")
+
+
+def test_a_conjunction_between_the_tokens_is_not_skippable():
+    # "and"/"or" joins two DIFFERENT entities -- exactly the recombination the
+    # phrase rule refuses -- so it is not in the skippable set.
+    windows = ["The Verrin and Calder devices hummed together."]
+    check(attest_label("VERRIN CALDER", windows)["attested"] is False,
+          "a conjunction between the tokens does not make a phrase")
+
+
+def test_hyphen_is_split_on_both_sides_of_the_phrase_check():
+    check(attest_label("SUN-WALKER GUILD", ["The sun walker guild convened."])["attested"] is True,
+          "a hyphenated label token matches a spaced source phrase")
+    # The reverse direction (spaced label, hyphenated source) is limited by the
+    # PRE-EXISTING per-token check, which folds a hyphenated source word into a
+    # single "SUN-WALKER" token: "SUN" is then missing and the label fails
+    # before adjacency is ever consulted. Unchanged by this rule, and pinned
+    # here so it is not mistaken for an adjacency regression later.
+    spaced = attest_label("SUN WALKER GUILD", ["The sun-walker guild convened."])
+    check(spaced["attested"] is False, "spaced label vs hyphenated source fails on tokens")
+    check_equal(spaced.get("note"), None, "and it fails on missing tokens, not on adjacency")
+
+
+def test_single_token_labels_are_unaffected_by_the_phrase_rule():
+    windows = ["Then Calder spoke from the doorway."]
+    check(attest_label("CALDER", windows)["attested"] is True,
+          "a single-token label still attests on whole-word presence")
+    check(attest_label("MISTER CALDER", windows)["attested"] is True,
+          "a title leaves only one core token, so no phrase is required")
+    check(attest_label("THE CALDER", windows)["attested"] is True,
+          "an article leaves only one core token, so no phrase is required")
+
+
+def test_unsegmented_script_label_is_still_unverifiable_not_refuted():
+    # The adjacency rule must never fire on a script whose tokens cannot be
+    # found as whole words at all -- those take the substring probe as before.
+    windows = ["リナカルデルが話した。"]
+    check_equal(attest_speaker("リナ カルデル", windows), UNVERIFIABLE,
+                "an unsegmented-script label is unverifiable, never refuted")
+
+
+# ---------------------------------------------------------------------------
 # Unicode coverage of the character classes, and attest_speaker()'s three-way
 # verdict.
 #
@@ -1423,6 +1540,17 @@ def main():
         test_attest_label_distinct_apostrophe_names_stay_distinct,
         test_attest_label_matches_hyphenated_token_verbatim,
         test_attest_label_matches_hyphenated_token_against_space_variant,
+        test_recombined_multi_token_label_is_refused,
+        test_genuine_phrase_label_still_attests,
+        test_phrase_check_folds_case_and_internal_capitals,
+        test_phrase_check_folds_apostrophe_glyphs,
+        test_possessive_composition_is_exempt_from_the_phrase_rule,
+        test_leading_article_is_invisible_to_the_phrase_rule,
+        test_internal_stopword_does_not_break_the_phrase,
+        test_a_conjunction_between_the_tokens_is_not_skippable,
+        test_hyphen_is_split_on_both_sides_of_the_phrase_check,
+        test_single_token_labels_are_unaffected_by_the_phrase_rule,
+        test_unsegmented_script_label_is_still_unverifiable_not_refuted,
         test_canonicalize_preserves_non_latin_names,
         test_canonicalize_is_idempotent_for_non_latin_names,
         test_non_latin_names_do_not_collide_on_one_roster_key,

--- a/app/test_speaker_canon.py
+++ b/app/test_speaker_canon.py
@@ -133,6 +133,12 @@ def test_wrapping_quotes_and_roster_fragmentation():
 def test_idempotency():
     samples = [
         "MARK (shouting)", "Mr. Mark", "Dr.", "José", "narrator", "O'Brien",
+        # Stacked honorifics: a single-pass strip made these NON-idempotent,
+        # and the pipeline canonicalizes twice (entry, then roster), so the
+        # script and the voices roster disagreed and the character was split
+        # across two voices.
+        "Mr. St. Clair", "Sir Lt. Col. Blimp", "Mrs. Dr. Watson",
+        "Dr. Dr.", "Mr Mr Mr Smith", "St. John", "ST JOHN RIVERS",
         "'Mother of Monsters'", '"BLACK SCOUT"',
         "‘Mother of Monsters’", "“Black Scout”",
         "'\"BLACK SCOUT\"'", "''X''", "Jones'", "'tis",
@@ -141,6 +147,38 @@ def test_idempotency():
         once = canonicalize(s)
         twice = canonicalize(once)
         check_equal(twice, once, f"idempotency for {s!r}")
+
+
+
+def test_stacked_honorifics_strip_to_a_fixpoint():
+    check_equal(canonicalize("Sir Lt. Col. Blimp"), "BLIMP", "three stacked honorifics")
+    check_equal(canonicalize("Mrs. Dr. Watson"), "WATSON", "two stacked honorifics")
+    check_equal(canonicalize("Mr Mr Mr Smith"), "SMITH", "repeated honorific")
+    # The never-empty guard survives the loop.
+    check_equal(canonicalize("Dr."), "DR", "bare honorific keeps itself")
+    check_equal(canonicalize("Dr. Dr."), "DR", "all-honorific name keeps the last one")
+    check_equal(canonicalize("Mr. Mrs."), "MRS", "all-honorific name is never emptied")
+
+
+def test_double_canonicalization_matches_single():
+    # The live failure mode: generate_script.py canonicalizes for the script
+    # entry and remember_in_roster canonicalizes again for the roster. Any
+    # name where those two disagree is a character split across two voices.
+    for name in ["Mr. St. Clair", "Sir Lt. Col. Blimp", "Mrs. Dr. Watson",
+                 "St. John Rivers", "Dr. Watson", "Captain Hook"]:
+        once = canonicalize(name)
+        check_equal(canonicalize(once), once, f"double canonicalization of {name!r}")
+
+
+def test_saint_names_are_not_honorifics():
+    # "ST" is a name constituent, not a title. While it was in _HONORIFICS,
+    # "ST JOHN RIVERS" became "JOHN RIVERS" -- a different character.
+    check_equal(canonicalize("St. John Rivers"), "ST JOHN RIVERS", "St. John Rivers")
+    check_equal(canonicalize("ST JOHN RIVERS"), "ST JOHN RIVERS", "already-canonical form")
+    check_equal(canonicalize("Mr. St. Clair"), "ST CLAIR", "honorific stripped, saint kept")
+    check_equal(canonicalize("St. Laurent"), "ST LAURENT", "St. Laurent")
+    # The two spellings of the same character still unify via the roster key.
+    check_equal(roster_key("ST. JOHN"), roster_key("ST JOHN"), "punctuated saint name keys alike")
 
 
 def test_suggest_aliases_expected_pairs():
@@ -523,6 +561,9 @@ def main():
         test_unmatched_apostrophes_survive_wrapping_fix,
         test_wrapping_quotes_and_roster_fragmentation,
         test_idempotency,
+        test_stacked_honorifics_strip_to_a_fixpoint,
+        test_double_canonicalization_matches_single,
+        test_saint_names_are_not_honorifics,
         test_roster_key_strips_whitespace_only,
         test_most_boundary_marks_wins_in_both_arrival_orders,
         test_punctuation_variants_unify,

--- a/app/test_tts_normalization.py
+++ b/app/test_tts_normalization.py
@@ -281,6 +281,51 @@ def test_invalid_dict_shape_warns():
         check("non-dict-shaped JSON -> warning printed", "WARNING" in buf.getvalue())
 
 
+def test_pronunciation_dict_respects_word_boundaries():
+    """A dict entry must not fire inside a longer word.
+
+    This is the user-facing counterpart of the rule CLAUDE.md states for the
+    source pipeline: blindly expanding "Dr."/"St." breaks fidelity. Before the
+    boundary rule, {"Dr": "Doctor"} rewrote *Drake* to *Doctorake*.
+    """
+    from tts_normalizer import _apply_pronunciation_dict as apply_dict
+
+    check(
+        "a key does not fire inside a longer word",
+        apply_dict("Drake walked on", {"Dr": "Doctor"}) == "Drake walked on",
+        detail=apply_dict("Drake walked on", {"Dr": "Doctor"}),
+    )
+    check(
+        "the same key still fires as a standalone word",
+        apply_dict("Elm Dr today", {"Dr": "Doctor"}) == "Elm Doctor today",
+        detail=apply_dict("Elm Dr today", {"Dr": "Doctor"}),
+    )
+    check(
+        "a key ending in punctuation keeps working",
+        apply_dict("Dr. Who", {"Dr.": "Doctor"}) == "Doctor Who",
+        detail=apply_dict("Dr. Who", {"Dr.": "Doctor"}),
+    )
+    # A letter next to a digit is a real boundary, so unit entries still work.
+    check(
+        "a letter key still fires against a digit neighbour",
+        apply_dict("5km away", {"km": "kilometers"}) == "5kilometers away",
+        detail=apply_dict("5km away", {"km": "kilometers"}),
+    )
+    # Uncased, unsegmented scripts have no word boundaries to respect, so
+    # substring replacement remains the correct behaviour there.
+    check(
+        "uncased script keeps substring semantics",
+        apply_dict("林考言道", {"林": "Lin"}) == "Lin考言道",
+        detail=apply_dict("林考言道", {"林": "Lin"}),
+    )
+    # Nothing is replaced when every occurrence is embedded.
+    check(
+        "an entry matching nothing leaves text byte-identical",
+        apply_dict("Andrew and Drake", {"Dr": "Doctor"}) == "Andrew and Drake",
+        detail=apply_dict("Andrew and Drake", {"Dr": "Doctor"}),
+    )
+
+
 def main():
     tests = [
         test_flag_off_is_noop,
@@ -291,6 +336,7 @@ def main():
         test_pronunciation_dict_applied_when_flag_on,
         test_pronunciation_dict_not_applied_when_flag_off,
         test_pronunciation_dict_longest_match_first,
+        test_pronunciation_dict_respects_word_boundaries,
         test_missing_dict_file_no_error,
         test_invalid_json_dict_warns_once_and_empty,
         test_invalid_dict_shape_warns,

--- a/app/test_tts_normalization.py
+++ b/app/test_tts_normalization.py
@@ -1,0 +1,311 @@
+"""Standalone tests for tts_normalizer.py.
+
+Run directly: `python app/test_tts_normalization.py` (from anywhere -- it
+fixes up sys.path itself). Exits 0 on success, 1 on any failure.
+
+Imports ONLY tts_normalizer -- never tts.py. tts.py pulls in numpy/
+soundfile/pydub at module level, which may not be installed in this
+interpreter; this test module deliberately avoids that so it can run on
+any machine.
+
+tts_normalizer selects a backend lazily: nemo_text_processing first, else
+wetext, else none (passthrough + one warning). The backend-selection and
+fidelity tests below use a skip-with-notice pattern where the choice of
+backend matters (they assert the wetext path when nemo is genuinely
+absent -- the real situation on this Windows box -- and print a [SKIP]
+notice instead of failing if nemo happens to be importable, e.g. on
+Linux/Colab CI with both installed). The both-backends-absent test
+poisons `sys.modules` to force that path deterministically regardless of
+what's actually installed. Pronunciation-dictionary tests force the
+backend to "none" (a white-box module-state override) so they exercise
+only the dictionary logic, independent of whichever backend is present.
+"""
+
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import tts_normalizer  # noqa: E402
+from tts_normalizer import TTSNormalizer  # noqa: E402
+
+
+FAILURES = []
+
+FIXED_SENTENCE = "Dr. Halloway lived on Elm St."
+
+BATTERY = [
+    FIXED_SENTENCE,
+    "“Well,” she said, — pausing — “I didn't expect that.”",
+    "It was... complicated. St. Peter's Basilica loomed ahead.",
+    "",
+    "Plain ASCII sentence with no abbreviations at all.",
+]
+
+_UNSET = object()
+
+
+def check(name, condition, detail=""):
+    status = "PASS" if condition else "FAIL"
+    print(f"[{status}] {name}" + (f" -- {detail}" if detail and not condition else ""))
+    if not condition:
+        FAILURES.append(name)
+
+
+def reset_backend_state():
+    """White-box reset of the sticky module-level backend cache/warning
+    flags, so each test that cares about backend-selection behavior can
+    control it independently of what earlier tests did."""
+    tts_normalizer._BACKEND_NORMALIZER = None
+    tts_normalizer._BACKEND_NAME = None
+    tts_normalizer._BACKEND_ATTEMPTED = False
+    tts_normalizer._WARNING_PRINTED = False
+
+
+def force_backend_none():
+    """Pin the module-level backend state to 'none' without touching
+    imports at all, so pronunciation-dict tests can isolate dictionary
+    behavior regardless of which backend(s) are actually installed."""
+    tts_normalizer._BACKEND_ATTEMPTED = True
+    tts_normalizer._BACKEND_NORMALIZER = None
+    tts_normalizer._BACKEND_NAME = "none"
+
+
+def test_flag_off_is_noop():
+    normalizer = TTSNormalizer(enabled=False, pronunciation_dict_path=None)
+    for s in BATTERY:
+        result = normalizer.normalize(s)
+        check(
+            f"flag-off no-op: {s[:30]!r}",
+            result is s,
+            f"expected identical object, got {result!r}",
+        )
+
+
+def test_flag_off_ignores_pronunciation_dict():
+    with tempfile.TemporaryDirectory() as d:
+        dict_path = os.path.join(d, "pronunciation_dict.json")
+        with open(dict_path, "w", encoding="utf-8") as f:
+            json.dump({"Marlborough Dr.": "Marlborough Drive"}, f)
+
+        normalizer = TTSNormalizer(enabled=False, pronunciation_dict_path=dict_path)
+        text = "She lived on Marlborough Dr. for years."
+        result = normalizer.normalize(text)
+        check("flag-off ignores pronunciation dict (byte-identical passthrough)", result is text)
+
+
+def test_flag_off_passthrough_even_with_wetext_installed():
+    # wetext is installed in this environment (see app/requirements.txt),
+    # but flag-off must still be a pure no-op regardless.
+    normalizer = TTSNormalizer(enabled=False, pronunciation_dict_path=None)
+    result = normalizer.normalize(FIXED_SENTENCE)
+    check(
+        "flag-off byte-identical passthrough even with wetext installed",
+        result is FIXED_SENTENCE,
+        f"got {result!r}",
+    )
+
+
+def test_backend_selection_and_fidelity_with_wetext():
+    reset_backend_state()
+    buf = io.StringIO()
+    normalizer = TTSNormalizer(enabled=True, pronunciation_dict_path=None)
+    with contextlib.redirect_stdout(buf):
+        result = normalizer.normalize(FIXED_SENTENCE)
+    output = buf.getvalue()
+
+    if tts_normalizer._BACKEND_NAME == "nemo":
+        # nemo_text_processing IS importable in this environment (e.g. a
+        # Linux/Colab box with it installed) and takes priority over
+        # wetext -- skip with notice rather than failing; the
+        # nemo-selected path is verified empirically via
+        # tools/verify_tts_normalization.py there, not by this assertion.
+        print("[SKIP] nemo_text_processing is importable in this environment and "
+              "takes priority; the wetext-selection path was not exercised here.")
+        return
+
+    check(
+        "backend selection picks wetext when nemo is absent",
+        tts_normalizer._BACKEND_NAME == "wetext",
+        f"got backend={tts_normalizer._BACKEND_NAME!r}",
+    )
+    check("backend log line names wetext", "backend: wetext" in output, f"log was {output!r}")
+    check("wetext expands 'Dr.' -> 'doctor'", "doctor" in result, f"got {result!r}")
+    check("wetext fidelity: 'Elm St.' left untouched", "Elm St." in result, f"got {result!r}")
+    check("wetext fidelity: does not over-expand (no 'Saint')", "Saint" not in result, f"got {result!r}")
+
+
+def test_both_backends_absent_warns_once_and_passthrough():
+    reset_backend_state()
+    # Poison sys.modules so both nemo_text_processing and wetext imports
+    # fail, regardless of what's actually installed in this environment.
+    saved = {}
+    for name in ("nemo_text_processing", "wetext"):
+        saved[name] = sys.modules.get(name, _UNSET)
+        sys.modules[name] = None
+    try:
+        normalizer = TTSNormalizer(enabled=True, pronunciation_dict_path=None)
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            r1 = normalizer.normalize(FIXED_SENTENCE)
+            r2 = normalizer.normalize(FIXED_SENTENCE)
+            r3 = normalizer.normalize("Another sentence entirely.")
+        output = buf.getvalue()
+
+        check("both-absent: backend resolves to 'none'", tts_normalizer._BACKEND_NAME == "none")
+        check("both-absent: byte-identical passthrough [1]", r1 == FIXED_SENTENCE, f"got {r1!r}")
+        check("both-absent: byte-identical passthrough [2]", r2 == FIXED_SENTENCE, f"got {r2!r}")
+        check("both-absent: byte-identical passthrough [3]", r3 == "Another sentence entirely.", f"got {r3!r}")
+
+        warning_count = output.count("WARNING: no text-normalization backend is available")
+        check(
+            "both-absent: warning printed exactly once across 3 calls",
+            warning_count == 1,
+            f"got {warning_count}, output={output!r}",
+        )
+    finally:
+        for name, val in saved.items():
+            if val is _UNSET:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = val
+        reset_backend_state()
+
+
+def test_pronunciation_dict_applied_when_flag_on():
+    with tempfile.TemporaryDirectory() as d:
+        dict_path = os.path.join(d, "pronunciation_dict.json")
+        with open(dict_path, "w", encoding="utf-8") as f:
+            json.dump({"Marlborough Dr.": "Marlborough Drive"}, f)
+
+        reset_backend_state()
+        # Pin the backend to "none" so this test isolates the
+        # pronunciation-dictionary behavior specifically, independent of
+        # whichever backend(s) are actually installed.
+        force_backend_none()
+
+        normalizer = TTSNormalizer(enabled=True, pronunciation_dict_path=dict_path)
+        text = "She lived on Marlborough Dr. for years."
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            result = normalizer.normalize(text)
+        check(
+            "pronunciation dict substitution applied (flag on)",
+            result == "She lived on Marlborough Drive for years.",
+            f"got {result!r}",
+        )
+        check(
+            "pronunciation dict substitution logged",
+            "Marlborough Dr." in buf.getvalue() and "Marlborough Drive" in buf.getvalue(),
+            f"log output was: {buf.getvalue()!r}",
+        )
+
+        reset_backend_state()
+
+
+def test_pronunciation_dict_not_applied_when_flag_off():
+    with tempfile.TemporaryDirectory() as d:
+        dict_path = os.path.join(d, "pronunciation_dict.json")
+        with open(dict_path, "w", encoding="utf-8") as f:
+            json.dump({"Marlborough Dr.": "Marlborough Drive"}, f)
+
+        normalizer = TTSNormalizer(enabled=False, pronunciation_dict_path=dict_path)
+        text = "She lived on Marlborough Dr. for years."
+        result = normalizer.normalize(text)
+        check("pronunciation dict NOT applied (flag off, byte-identical)", result is text)
+
+
+def test_pronunciation_dict_longest_match_first():
+    with tempfile.TemporaryDirectory() as d:
+        dict_path = os.path.join(d, "pronunciation_dict.json")
+        with open(dict_path, "w", encoding="utf-8") as f:
+            json.dump({"Dr.": "Doctor", "Marlborough Dr.": "Marlborough Drive"}, f)
+
+        reset_backend_state()
+        force_backend_none()
+
+        normalizer = TTSNormalizer(enabled=True, pronunciation_dict_path=dict_path)
+        result = normalizer.normalize("Marlborough Dr.")
+        check(
+            "longest-match-first: 'Marlborough Dr.' -> 'Marlborough Drive' (not 'Marlborough Doctor')",
+            result == "Marlborough Drive",
+            f"got {result!r}",
+        )
+
+        reset_backend_state()
+
+
+def test_missing_dict_file_no_error():
+    missing_path = os.path.join(tempfile.gettempdir(), "definitely_does_not_exist_pronunciation_dict.json")
+    if os.path.exists(missing_path):
+        os.remove(missing_path)
+    try:
+        normalizer = TTSNormalizer(enabled=True, pronunciation_dict_path=missing_path)
+        check("missing dict file -> empty dict, no error", normalizer._pronunciation_dict == {})
+    except Exception as exc:
+        check("missing dict file -> empty dict, no error", False, f"raised {exc!r}")
+
+
+def test_invalid_json_dict_warns_once_and_empty():
+    with tempfile.TemporaryDirectory() as d:
+        dict_path = os.path.join(d, "pronunciation_dict.json")
+        with open(dict_path, "w", encoding="utf-8") as f:
+            f.write("{not valid json,,,")
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            normalizer = TTSNormalizer(enabled=True, pronunciation_dict_path=dict_path)
+        output = buf.getvalue()
+        check("invalid JSON dict -> empty dict", normalizer._pronunciation_dict == {})
+        check(
+            "invalid JSON dict -> exactly one warning",
+            output.count("WARNING: could not load pronunciation dict") == 1,
+            f"got output: {output!r}",
+        )
+
+
+def test_invalid_dict_shape_warns():
+    with tempfile.TemporaryDirectory() as d:
+        dict_path = os.path.join(d, "pronunciation_dict.json")
+        with open(dict_path, "w", encoding="utf-8") as f:
+            json.dump(["not", "a", "dict"], f)
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            normalizer = TTSNormalizer(enabled=True, pronunciation_dict_path=dict_path)
+        check("non-dict-shaped JSON -> empty dict", normalizer._pronunciation_dict == {})
+        check("non-dict-shaped JSON -> warning printed", "WARNING" in buf.getvalue())
+
+
+def main():
+    tests = [
+        test_flag_off_is_noop,
+        test_flag_off_ignores_pronunciation_dict,
+        test_flag_off_passthrough_even_with_wetext_installed,
+        test_backend_selection_and_fidelity_with_wetext,
+        test_both_backends_absent_warns_once_and_passthrough,
+        test_pronunciation_dict_applied_when_flag_on,
+        test_pronunciation_dict_not_applied_when_flag_off,
+        test_pronunciation_dict_longest_match_first,
+        test_missing_dict_file_no_error,
+        test_invalid_json_dict_warns_once_and_empty,
+        test_invalid_dict_shape_warns,
+    ]
+    for t in tests:
+        print(f"\n--- {t.__name__} ---")
+        t()
+
+    print("\n" + "=" * 60)
+    if FAILURES:
+        print(f"{len(FAILURES)} FAILURE(S): {FAILURES}")
+        return 1
+    print(f"All {len(tests)} test groups passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/app/tts.py
+++ b/app/tts.py
@@ -55,6 +55,16 @@ def _configure_ffmpeg():
                                      "ffprobe.exe" if os.name == "nt" else "ffprobe")
                 if os.path.isfile(probe):
                     AudioSegment.ffprobe = probe
+                # Setting the attributes is not enough. pydub calls its own
+                # which("ffprobe") whenever it LOADS a file (mediainfo_json),
+                # ignoring AudioSegment.ffprobe -- so exporting worked while
+                # reading an mp3 back still died with FileNotFoundError. That
+                # is the merge path (AudioSegment.from_file per voiceline), so
+                # it would have failed only after every chunk was synthesized.
+                # Putting the directory on PATH fixes every lookup pydub makes.
+                bin_dir = os.path.dirname(candidate)
+                if bin_dir not in os.environ.get("PATH", "").split(os.pathsep):
+                    os.environ["PATH"] = bin_dir + os.pathsep + os.environ.get("PATH", "")
             except Exception:
                 # A stubbed/partial pydub (some test suites replace it) must not
                 # stop this module from importing.

--- a/app/tts.py
+++ b/app/tts.py
@@ -35,15 +35,13 @@ def _configure_ffmpeg():
     from the running interpreter, so this works for any conda-based install
     rather than one machine's.
     """
-    from pydub import utils as _pydub_utils
-
     override = os.environ.get("ALEXANDRIA_FFMPEG", "").strip()
     candidates = [override] if override else []
-    for tool in ("ffmpeg", "ffprobe"):
-        found = _pydub_utils.which(tool)
-        if found:
-            candidates.append(found)
-            break
+    # shutil.which, not pydub.utils.which: a test that stubs out pydub would
+    # otherwise fail at import here, and the stdlib answers the same question.
+    found = shutil.which("ffmpeg")
+    if found:
+        candidates.append(found)
     exe = "ffmpeg.exe" if os.name == "nt" else "ffmpeg"
     for base in (sys.prefix, getattr(sys, "base_prefix", sys.prefix)):
         candidates.append(os.path.join(base, "Library", "bin", exe))
@@ -51,11 +49,16 @@ def _configure_ffmpeg():
 
     for candidate in candidates:
         if candidate and os.path.isfile(candidate):
-            AudioSegment.converter = candidate
-            probe = os.path.join(os.path.dirname(candidate),
-                                 "ffprobe.exe" if os.name == "nt" else "ffprobe")
-            if os.path.isfile(probe):
-                AudioSegment.ffprobe = probe
+            try:
+                AudioSegment.converter = candidate
+                probe = os.path.join(os.path.dirname(candidate),
+                                     "ffprobe.exe" if os.name == "nt" else "ffprobe")
+                if os.path.isfile(probe):
+                    AudioSegment.ffprobe = probe
+            except Exception:
+                # A stubbed/partial pydub (some test suites replace it) must not
+                # stop this module from importing.
+                pass
             return candidate
     return None
 

--- a/app/tts.py
+++ b/app/tts.py
@@ -7,6 +7,9 @@ import numpy as np
 import soundfile as sf
 from pydub import AudioSegment
 
+from tts_normalizer import TTSNormalizer
+from speaker_canon import canonicalize
+
 DEFAULT_PAUSE_MS = 500  # Pause between different speakers
 SAME_SPEAKER_PAUSE_MS = 250  # Shorter pause for same speaker continuing
 
@@ -15,6 +18,126 @@ def sanitize_filename(name):
     """Make a string safe for use in filenames"""
     name = re.sub(r'[^\w\-]', '_', name)
     return name.lower()
+
+
+def resolve_voice(voice_config, raw_speaker):
+    """Resolve a raw speaker label to the voice_config key to use for synthesis.
+
+    `voice_config` is keyed by canonical UPPERCASE speaker names (see
+    `speaker_canon.canonicalize` / app.py's `build_voice_roster`), but a
+    "speaker" value flowing through the render pipeline (chunks.json,
+    annotated_script.json) may still be a raw, non-canonical label -- e.g.
+    "Narrator" (mixed case) or a pre-refactor project's "Mr. Mark". This is
+    the single shared helper every voice_config lookup that feeds synthesis
+    should go through, so a canonical roster and a raw-keyed (or legacy)
+    voice_config never silently miss each other.
+
+    This never reads or writes narration text -- it only ever compares and
+    returns speaker LABELS.
+
+    Resolution order (first match wins):
+      1. `raw_speaker` itself is a key in `voice_config` (handles configs
+         already keyed exactly as the script spells the speaker).
+      2. `canonicalize(raw_speaker)` is a key in `voice_config`.
+      3. Scan `voice_config` keys for one whose `canonicalize()` equals
+         `canonicalize(raw_speaker)` (handles a "Mr. Mark"-keyed config
+         resolving for a canonical "MARK" speaker, and vice versa).
+         Insertion order wins ties.
+
+    Whichever key is found then has its `alias_of`/`alias` chain followed
+    (same semantics as the legacy per-instance `_resolve_alias` helper in
+    project.py, but canonical-aware at each hop too), up to 8 hops with
+    cycle detection.
+
+    Returns the resolved key (str) to use with `voice_config.get(...)`, or
+    None if no strategy finds any match at all (caller decides on a
+    fallback, and should log which raw speaker fell through).
+    """
+    if not raw_speaker or not voice_config:
+        return None
+
+    def _find_key(name):
+        if not name:
+            return None
+        if name in voice_config:
+            return name
+        canon = canonicalize(name)
+        if not canon:
+            return None
+        if canon in voice_config:
+            return canon
+        for key in voice_config:
+            if canonicalize(key) == canon:
+                return key
+        return None
+
+    resolved = _find_key(raw_speaker)
+    if resolved is None:
+        return None
+
+    name = resolved
+    seen = set()
+    for _ in range(8):
+        if name in seen:
+            print(f"Warning: Alias cycle detected for speaker '{raw_speaker}': chain visited {seen}")
+            break
+        seen.add(name)
+        entry = voice_config.get(name, {})
+        alias = entry.get("alias_of") or entry.get("alias")
+        if not alias or not isinstance(alias, str) or alias.strip() == "" or alias == name:
+            break
+        next_key = _find_key(alias)
+        name = next_key if next_key is not None else alias
+
+    return name
+
+
+def _prepare_batch_chunks(chunks, voice_config, normalizer):
+    """Build a fresh list of chunk dicts with text normalized and speaker
+    resolved to a canonical voice_config key, EXACTLY ONCE, for every
+    downstream dispatch path in `generate_batch` (custom/clone/lora/design/
+    sequential) to consume -- all of those read chunk["text"]/chunk["speaker"]
+    directly and never call `generate_voice()` (which has its own
+    normalize+resolve for the single-chunk path).
+
+    `chunks` is treated as READ-ONLY: this returns shallow copies and never
+    mutates the caller's dicts in place. That matters because today's only
+    production caller (project.py's `generate_chunks_batch`) builds fresh
+    per-call dicts, so nothing currently leaks into chunks.json -- but a
+    future caller passing persisted `load_chunks()` dicts directly would,
+    if this mutated in place, silently write normalized text and rewritten
+    speaker labels back into chunks.json, and the next run would
+    double-normalize already-normalized text.
+
+    `instruct` is deliberately left untouched -- it is delivery direction,
+    not narration text, and must never be normalized.
+
+    Args:
+        chunks: list of dicts with at least 'text' and 'speaker' keys
+            (plus whatever else the caller put there, e.g. 'index').
+        voice_config: voice_config dict, consulted via resolve_voice().
+        normalizer: object with a `.normalize(text) -> text` method (a
+            TTSNormalizer instance in production; disabled -> identity).
+
+    Returns:
+        A new list of shallow-copied dicts: same keys/values as the input
+        except 'text' (normalized) and 'speaker' (resolved, when a match
+        is found -- left as the original raw value otherwise, so a later
+        raw lookup can still be attempted/logged by the caller).
+    """
+    prepared = []
+    for chunk in chunks:
+        new_chunk = dict(chunk)
+        new_chunk["text"] = normalizer.normalize(chunk.get("text", ""))
+        raw_speaker = chunk.get("speaker", "")
+        resolved_speaker = resolve_voice(voice_config, raw_speaker)
+        if resolved_speaker is None:
+            print(f"Warning: No canonical voice_config match for speaker '{raw_speaker}'; "
+                  f"falling back to raw lookup (may hit default voice).")
+        else:
+            new_chunk["speaker"] = resolved_speaker
+        prepared.append(new_chunk)
+    return prepared
 
 
 def combine_audio_with_pauses(audio_segments, speakers, pause_ms=DEFAULT_PAUSE_MS,
@@ -125,6 +248,13 @@ class TTSEngine:
         self._clone_prompt_cache = {}
         # LoRA clone prompt cache: adapter_path -> reusable voice_clone_prompt
         self._lora_prompt_cache = {}
+
+        # Optional TTS-boundary text normalization (off by default; see tts_normalizer.py)
+        root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        pronunciation_dict_path = os.path.join(root_dir, "pronunciation_dict.json")
+        self._normalizer = TTSNormalizer(
+            tts_config.get("enable_nemo_normalization", False), pronunciation_dict_path
+        )
 
     @property
     def mode(self):
@@ -720,6 +850,12 @@ class TTSEngine:
 
     def generate_voice(self, text, instruct_text, speaker, voice_config, output_path):
         """Generate audio using the appropriate method based on voice type config."""
+        text = self._normalizer.normalize(text)
+        resolved_speaker = resolve_voice(voice_config, speaker)
+        if resolved_speaker is None:
+            print(f"Warning: No canonical voice_config match for speaker '{speaker}'; falling back to raw lookup.")
+        else:
+            speaker = resolved_speaker
         voice_data = voice_config.get(speaker)
         if not voice_data:
             print(f"Warning: No voice configuration for '{speaker}'. Skipping.")
@@ -945,7 +1081,10 @@ class TTSEngine:
         External mode: sequential individual calls.
 
         Args:
-            chunks: List of dicts with 'text', 'instruct', 'speaker', 'index' keys
+            chunks: List of dicts with 'text', 'instruct', 'speaker', 'index'
+                keys. Treated as READ-ONLY -- this method never mutates the
+                caller's dicts in place (see _prepare_batch_chunks); it works
+                from its own shallow-copied, normalized/resolved list.
             voice_config: Voice configuration dict
             output_dir: Directory to save output files
             batch_seed: Single seed for all generations (-1 for random)
@@ -962,6 +1101,16 @@ class TTSEngine:
         # from dynamo guard accumulation across batches
         if self._compile_codec_enabled:
             self._reset_compile_cache()
+
+        # Rebind `chunks` (this function's local name) to a FRESH list of
+        # shallow copies with text normalized and speaker resolved to its
+        # canonical voice_config key, EXACTLY ONCE, before any dispatch
+        # (custom/clone/lora/design/sequential below). The caller's original
+        # list/dicts are never touched -- see _prepare_batch_chunks for why
+        # in-place mutation here would be a latent trap (e.g. a future
+        # caller passing persisted load_chunks() dicts would otherwise get
+        # normalized text silently written back into chunks.json).
+        chunks = _prepare_batch_chunks(chunks, voice_config, self._normalizer)
 
         # Separate chunks by voice type
         custom_chunks = []

--- a/app/tts.py
+++ b/app/tts.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import re
 import json
 import threading
@@ -12,6 +13,58 @@ from speaker_canon import canonicalize, GENDERED_TITLES
 
 DEFAULT_PAUSE_MS = 500  # Pause between different speakers
 SAME_SPEAKER_PAUSE_MS = 250  # Shorter pause for same speaker continuing
+
+
+def _configure_ffmpeg():
+    """Point pydub at an ffmpeg binary it can't find by itself.
+
+    pydub only looks on PATH, and the final audiobook is exported as mp3, so a
+    missing ffmpeg fails at the LAST step -- after every line has been
+    synthesized. Found the expensive way: a full render's worth of work ending
+    in FileNotFoundError from AudioSegment.export.
+
+    Search order, all generic:
+      1. ALEXANDRIA_FFMPEG, for an operator who keeps ffmpeg somewhere of their
+         own choosing.
+      2. PATH, which is what pydub would have done anyway.
+      3. ``Library/bin`` under this interpreter's prefix and its base prefix --
+         the standard conda/miniforge layout on Windows. A conda-installed
+         ffmpeg lives there and is invisible to PATH inside a venv.
+
+    No path is hardcoded: every candidate is derived from the environment or
+    from the running interpreter, so this works for any conda-based install
+    rather than one machine's.
+    """
+    from pydub import utils as _pydub_utils
+
+    override = os.environ.get("ALEXANDRIA_FFMPEG", "").strip()
+    candidates = [override] if override else []
+    for tool in ("ffmpeg", "ffprobe"):
+        found = _pydub_utils.which(tool)
+        if found:
+            candidates.append(found)
+            break
+    exe = "ffmpeg.exe" if os.name == "nt" else "ffmpeg"
+    for base in (sys.prefix, getattr(sys, "base_prefix", sys.prefix)):
+        candidates.append(os.path.join(base, "Library", "bin", exe))
+        candidates.append(os.path.join(base, "bin", exe))
+
+    for candidate in candidates:
+        if candidate and os.path.isfile(candidate):
+            AudioSegment.converter = candidate
+            probe = os.path.join(os.path.dirname(candidate),
+                                 "ffprobe.exe" if os.name == "nt" else "ffprobe")
+            if os.path.isfile(probe):
+                AudioSegment.ffprobe = probe
+            return candidate
+    return None
+
+
+_FFMPEG_PATH = _configure_ffmpeg()
+if not _FFMPEG_PATH:
+    print("WARNING: no ffmpeg found (checked ALEXANDRIA_FFMPEG, PATH, and the "
+          "interpreter's Library/bin). WAV output will work; the final mp3 "
+          "export will fail. Set ALEXANDRIA_FFMPEG to an ffmpeg binary.")
 
 
 def sanitize_filename(name):

--- a/app/tts.py
+++ b/app/tts.py
@@ -8,7 +8,7 @@ import soundfile as sf
 from pydub import AudioSegment
 
 from tts_normalizer import TTSNormalizer
-from speaker_canon import canonicalize
+from speaker_canon import canonicalize, GENDERED_TITLES
 
 DEFAULT_PAUSE_MS = 500  # Pause between different speakers
 SAME_SPEAKER_PAUSE_MS = 250  # Shorter pause for same speaker continuing
@@ -43,6 +43,26 @@ def resolve_voice(voice_config, raw_speaker):
          `canonicalize(raw_speaker)` (handles a "Mr. Mark"-keyed config
          resolving for a canonical "MARK" speaker, and vice versa).
          Insertion order wins ties.
+      4. Gendered-title migration shim, for voice_config.json files written
+         before `canonicalize()` started preserving Mr/Mrs/Mme/... (config
+         files stamped `"_canon_version": 2` by app.py were written after):
+           4a. Speaker HAS a gendered prefix, config key doesn't: strip the
+               prefix and retry 1-3 on the bare name, so a legacy {"SMITH"}
+               config still voices "MISTER SMITH". Unguarded on purpose --
+               a pre-migration config cannot contain a rival "MISSUS SMITH"
+               key (nothing could have produced one), and refusing here
+               would silently drop every line of a legacy project.
+           4b. Speaker is BARE, config keys are gendered: match config keys
+               whose canonical form is "<GENDERED TITLE> <speaker>". This
+               one IS guarded -- if two or more match (both "MISTER SMITH"
+               and "MISSUS SMITH" are configured), there is no evidence for
+               which one an unqualified "SMITH" meant, so it warns loudly
+               and returns None rather than picking by insertion order and
+               giving a character the wrong person's voice.
+         Exact equality of canonical forms throughout; nothing fuzzy.
+
+    Keys beginning with "_" are metadata (e.g. "_canon_version"), never
+    speakers, and are skipped by every scan here.
 
     Whichever key is found then has its `alias_of`/`alias` chain followed
     (same semantics as the legacy per-instance `_resolve_alias` helper in
@@ -56,19 +76,46 @@ def resolve_voice(voice_config, raw_speaker):
     if not raw_speaker or not voice_config:
         return None
 
+    def _speaker_keys():
+        return [k for k in voice_config if not k.startswith("_")]
+
+    def _find_canonical(canon):
+        """Strategies 1-3 for an already-canonical name (minus the raw-key
+        check, which only makes sense for the caller's own spelling)."""
+        if canon in voice_config and not canon.startswith("_"):
+            return canon
+        for key in _speaker_keys():
+            if canonicalize(key) == canon:
+                return key
+        return None
+
     def _find_key(name):
         if not name:
             return None
-        if name in voice_config:
+        if name in voice_config and not name.startswith("_"):
             return name
         canon = canonicalize(name)
         if not canon:
             return None
-        if canon in voice_config:
-            return canon
-        for key in voice_config:
-            if canonicalize(key) == canon:
-                return key
+        resolved = _find_canonical(canon)
+        if resolved is not None:
+            return resolved
+
+        # Strategy 4 -- gendered-title migration shim (see docstring).
+        parts = canon.split(" ")
+        if len(parts) > 1 and parts[0] in GENDERED_TITLES:
+            # 4a: gendered speaker -> bare legacy key. Unguarded.
+            return _find_canonical(" ".join(parts[1:]))
+
+        # 4b: bare legacy speaker -> gendered key(s). Collision-guarded.
+        wanted = {f"{title} {canon}" for title in GENDERED_TITLES}
+        matches = [key for key in _speaker_keys() if canonicalize(key) in wanted]
+        if len(matches) == 1:
+            return matches[0]
+        if matches:
+            print(f"Warning: Speaker '{name}' is ambiguous between gendered voice "
+                  f"configurations {sorted(matches)}; refusing to guess. Assign a "
+                  f"voice for '{canon}' directly, or alias it to one of them.")
         return None
 
     resolved = _find_key(raw_speaker)

--- a/app/tts_normalizer.py
+++ b/app/tts_normalizer.py
@@ -170,7 +170,87 @@ def load_pronunciation_dict(path):
         return {}
 
 
+def _is_cased_letter(ch):
+    """True for a letter belonging to a script that distinguishes upper and
+    lower case (Latin, Greek, Cyrillic, Armenian, ...). Derived from the
+    Unicode properties of the character itself -- no script list, no language
+    table.
+
+    Used to decide whether word-boundary logic is meaningful around a match.
+    Cased scripts in this pipeline are the space-segmented ones where "Dr"
+    must not match inside "Drake"; uncased scripts include the unsegmented
+    ones (Chinese, Japanese) where a substring match is the CORRECT behaviour
+    because there are no word boundaries to respect.
+    """
+    return ch.isalpha() and ch.lower() != ch.upper()
+
+
+def _match_respects_word_boundary(text, start, key):
+    """True when the occurrence of `key` at `text[start:]` is not embedded in
+    a larger word.
+
+    A boundary is only required on an edge where the KEY itself ends in a
+    cased letter or a digit: an entry like "Dr." ends in punctuation, so the
+    period is already the boundary, while a bare "Dr" must not fire inside
+    "Drake". An edge whose key character is an uncased letter imposes no
+    requirement, so unsegmented scripts keep substring semantics.
+
+    Only a SAME-CLASS neighbour blocks -- letter beside letter, digit beside
+    digit. A letter adjacent to a digit is a real boundary, which is what
+    keeps the common unit entry working: "km" must still fire in "5km", while
+    "Dr" must still not fire in "Drake".
+    """
+    end = start + len(key)
+
+    def blocks(edge_char, neighbour):
+        if _is_cased_letter(edge_char):
+            return _is_cased_letter(neighbour)
+        if edge_char.isdigit():
+            return neighbour.isdigit()
+        return False
+
+    if start > 0 and blocks(key[0], text[start - 1]):
+        return False
+    if end < len(text) and blocks(key[-1], text[end]):
+        return False
+    return True
+
+
+def _replace_on_boundaries(text, key, value):
+    """Replace every word-boundary-respecting occurrence of `key`. Returns the
+    new text. Scans left to right and never re-examines inserted text, so a
+    value containing its own key cannot loop.
+    """
+    out = []
+    index = 0
+    while True:
+        found = text.find(key, index)
+        if found == -1:
+            out.append(text[index:])
+            return "".join(out)
+        if _match_respects_word_boundary(text, found, key):
+            out.append(text[index:found])
+            out.append(value)
+            index = found + len(key)
+        else:
+            out.append(text[index:found + len(key)])
+            index = found + len(key)
+
+
 def _apply_pronunciation_dict(text, mapping):
+    """Apply the user's per-book pronunciation dictionary.
+
+    WORD-BOUNDARY AWARE. This was a raw ``str.replace``, which made the
+    user-facing pronunciation_dict.json a way to reintroduce exactly the
+    damage CLAUDE.md bans in the source pipeline: an entry of
+    ``{"Dr": "Doctor"}`` rewrote *Drake* to *Doctorake*, and *Elm St.* to
+    *Elm Saint.* if the user added "St". Longest-match-first ordering only
+    protects against a shorter key clobbering a longer phrase; it does
+    nothing about a key matching inside an unrelated word.
+
+    See _match_respects_word_boundary for the exact rule and why it is
+    derived from Unicode casedness rather than a script list.
+    """
     if not mapping:
         return text
     # Longest-match-first: "Marlborough Dr." must win over a shorter "Dr."
@@ -178,7 +258,7 @@ def _apply_pronunciation_dict(text, mapping):
     for key in sorted(mapping.keys(), key=len, reverse=True):
         if key and key in text:
             value = mapping[key]
-            new_text = text.replace(key, value)
+            new_text = _replace_on_boundaries(text, key, value)
             if new_text != text:
                 print(f"[tts-normalize] dict: {key!r} -> {value!r}")
             text = new_text

--- a/app/tts_normalizer.py
+++ b/app/tts_normalizer.py
@@ -1,0 +1,228 @@
+"""Optional TTS-boundary text normalization for Alexandria.
+
+FIDELITY CONTRACT (do not violate):
+  - `annotated_script.json` (and every other script file) stays byte-verbatim
+    on disk. Nothing in this module reads or writes script files -- it only
+    ever transforms an in-memory `text` string at the moment it is about to
+    be handed to the TTS engine (see `TTSEngine.generate_voice` in tts.py).
+    The source -> annotated_script.json word-coverage invariant (1.0) is
+    unaffected because this module never touches that pipeline.
+  - `instruct_text` must NEVER be passed through `normalize()`. The TTS
+    instruct/delivery-direction string is not narration text and must reach
+    the model unchanged. Callers are responsible for only ever calling
+    `normalize()` on the narration `text`, never on `instruct_text`.
+  - With the feature disabled (the default), `normalize()` is a pure no-op:
+    it returns the exact same string object passed in, with zero side
+    effects (no imports triggered, no file reads, nothing printed).
+
+WHY THIS DEFAULTS OFF:
+  Alexandria's audiobooks are verbatim -- the spoken word must match the
+  source text exactly. The original Alexandria pipeline performs zero text
+  normalization, and Qwen3-TTS may already handle abbreviations reasonably
+  well on its own. Both normalization backends below lowercase some of
+  their output (inaudible, but it breaks byte-verbatim comparisons) and
+  are non-trivial dependencies. Whether enabling normalization is a net
+  win is an empirical question to be answered per-project with
+  `tools/verify_tts_normalization.py`, not assumed here.
+
+BACKEND CHAIN (selected lazily, cached for the life of the process):
+  1. `nemo_text_processing` -- tried first when the flag is on. Highest
+     fidelity: context-aware (e.g. it turns "St. Peter's" into "Saint
+     Peter's" but correctly leaves "Elm St." alone). Its `pynini`
+     dependency ships source-only for Windows (no prebuilt wheel; it
+     requires the OpenFst C++ toolchain to build), so it is normally only
+     available on Linux/Colab. Install with `pip install
+     nemo_text_processing`.
+  2. `wetext` -- tried if nemo is unavailable. A pynini-free FST
+     normalizer with prebuilt wheels (including Windows), so it is the
+     practical option on a Windows dev box. It expands things like
+     "Dr." -> "doctor", money, times, and dates, and -- like nemo --
+     correctly leaves "Elm St." untouched (it does not catch every case
+     nemo does, e.g. it does not expand "St. Peter's" to "Saint Peter's",
+     but it never breaks fidelity by over-expanding). Install with
+     `pip install wetext`.
+  3. Neither available -- normalization for this step is skipped, a
+     single loud warning is printed (once per process), and text passes
+     through unchanged for this step.
+  In all three cases, the per-book pronunciation dictionary (below) is
+  applied afterward, since it exists precisely to correct whichever
+  backend's mistakes (or to do the only normalization available, when
+  neither backend is present).
+
+PRONUNCIATION DICTIONARY:
+  A per-book, user-maintained, optional JSON file (`pronunciation_dict.json`
+  at the repo root, alongside `annotated_script.json`) of flat
+  `{"from": "to"}` literal string replacements. This exists to let a user
+  correct mistakes the backend makes -- e.g. it might turn "Marlborough
+  Dr." into "Marlborough doctor" when it should be "Marlborough Drive";
+  the user adds `{"Marlborough Dr.": "Marlborough Drive"}` to fix just
+  that case. This is NOT a shipped abbreviation-expansion table (that
+  would break fidelity for the general case, e.g. blindly expanding "Elm
+  St." to "Elm Saint") -- it is manually curated, per-book data, applied
+  only when normalization is enabled.
+"""
+
+import json
+import os
+
+# Sticky, process-wide state so we select a backend, compile its (slow)
+# normalizer graph, and print any "backend unavailable" warning at most
+# once per process, no matter how many TTSNormalizer instances are created
+# or how many times normalize() is called.
+_BACKEND_NORMALIZER = None   # cached backend instance (nemo Normalizer or wetext Normalizer)
+_BACKEND_NAME = None         # "nemo" | "wetext" | "none", once selection has run
+_BACKEND_ATTEMPTED = False   # sticky: selection has been attempted (success or not)
+_WARNING_PRINTED = False     # "no backend available" warning, printed at most once
+
+
+def _warn_no_backend_available(nemo_exc, wetext_exc):
+    global _WARNING_PRINTED
+    if _WARNING_PRINTED:
+        return
+    _WARNING_PRINTED = True
+    print(
+        "[tts-normalize] " + "=" * 68 + "\n"
+        "[tts-normalize] WARNING: no text-normalization backend is available in\n"
+        "[tts-normalize] this Python environment -- normalization is enabled in\n"
+        "[tts-normalize] config but will be SKIPPED for every TTS call in this\n"
+        "[tts-normalize] process (text is passed through as-is for this step; the\n"
+        "[tts-normalize] pronunciation dictionary, if any, still applies).\n"
+        f"[tts-normalize]   nemo_text_processing import error: {nemo_exc}\n"
+        f"[tts-normalize]   wetext import error: {wetext_exc}\n"
+        "[tts-normalize] Install one of:\n"
+        "[tts-normalize]     pip install nemo_text_processing   (Linux/Colab; highest fidelity)\n"
+        "[tts-normalize]     pip install wetext                 (Windows-friendly, prebuilt wheels)\n"
+        "[tts-normalize] " + "=" * 68
+    )
+
+
+def _select_backend():
+    """Lazily select and cache a normalization backend: nemo, else wetext,
+    else none. Attempted at most once per process; logs exactly one
+    `[tts-normalize] backend: ...` line for that attempt.
+
+    Returns (normalizer_instance_or_None, backend_name).
+    """
+    global _BACKEND_NORMALIZER, _BACKEND_NAME, _BACKEND_ATTEMPTED
+
+    if _BACKEND_ATTEMPTED:
+        return _BACKEND_NORMALIZER, _BACKEND_NAME
+    _BACKEND_ATTEMPTED = True
+
+    nemo_exc = None
+    wetext_exc = None
+
+    try:
+        from nemo_text_processing.text_normalization.normalize import Normalizer as _NemoNormalizer
+        _BACKEND_NORMALIZER = _NemoNormalizer(input_case="cased", lang="en")
+        _BACKEND_NAME = "nemo"
+    except Exception as exc:  # ImportError, missing pynini, graph build failure, etc.
+        nemo_exc = exc
+        try:
+            from wetext import Normalizer as _WetextNormalizer
+            _BACKEND_NORMALIZER = _WetextNormalizer(lang="en", operator="tn")
+            _BACKEND_NAME = "wetext"
+        except Exception as exc2:
+            wetext_exc = exc2
+            _BACKEND_NORMALIZER = None
+            _BACKEND_NAME = "none"
+            _warn_no_backend_available(nemo_exc, wetext_exc)
+
+    print(f"[tts-normalize] backend: {_BACKEND_NAME}")
+    return _BACKEND_NORMALIZER, _BACKEND_NAME
+
+
+def _apply_backend_normalization(text):
+    normalizer, backend_name = _select_backend()
+    if normalizer is None:
+        return text
+
+    if backend_name == "nemo":
+        normalized = normalizer.normalize(text, verbose=False)
+    else:  # "wetext"
+        normalized = normalizer.normalize(text)
+
+    if normalized != text:
+        print(f"[tts-normalize] {backend_name}: {text!r} -> {normalized!r}")
+    return normalized
+
+
+def load_pronunciation_dict(path):
+    """Load the flat {"from": "to"} pronunciation dictionary.
+
+    Missing file -> {} silently (this is the common, expected case; not
+    every book needs one). Invalid JSON or wrong shape -> {} with exactly
+    one printed warning.
+    """
+    if not path or not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, dict):
+            raise ValueError("pronunciation dict JSON must be a flat object of string -> string")
+        for key, value in data.items():
+            if not isinstance(key, str) or not isinstance(value, str):
+                raise ValueError("pronunciation dict entries must all be strings")
+        return data
+    except Exception as exc:
+        print(f"[tts-normalize] WARNING: could not load pronunciation dict at {path!r}: {exc}. Using empty dict.")
+        return {}
+
+
+def _apply_pronunciation_dict(text, mapping):
+    if not mapping:
+        return text
+    # Longest-match-first: "Marlborough Dr." must win over a shorter "Dr."
+    # entry so we don't clobber part of a longer phrase first.
+    for key in sorted(mapping.keys(), key=len, reverse=True):
+        if key and key in text:
+            value = mapping[key]
+            new_text = text.replace(key, value)
+            if new_text != text:
+                print(f"[tts-normalize] dict: {key!r} -> {value!r}")
+            text = new_text
+    return text
+
+
+class TTSNormalizer:
+    """Optional text normalization applied only at the TTS call boundary.
+
+    Construction never fails and never raises: a missing/invalid
+    pronunciation dictionary degrades to an empty dict (with a warning for
+    the invalid case). The normalization backend (nemo, then wetext, then
+    none) is selected lazily on first use of normalize(), not at
+    construction time.
+
+    IMPORTANT: only ever call `normalize()` on narration `text`. Never call
+    it on `instruct_text` -- see module docstring.
+    """
+
+    def __init__(self, enabled: bool, pronunciation_dict_path: str = None):
+        self.enabled = bool(enabled)
+        self._dict_path = pronunciation_dict_path
+        # The pronunciation dict is cheap, independent, user-owned data. We
+        # only bother loading it when the feature is enabled -- when
+        # disabled, normalize() never even glances at it.
+        self._pronunciation_dict = (
+            load_pronunciation_dict(pronunciation_dict_path) if self.enabled else {}
+        )
+
+    def normalize(self, text: str) -> str:
+        """Return `text`, optionally normalized.
+
+        When disabled: returns `text` unchanged (same object, zero side
+        effects) -- this is the default and is what keeps the TTS input
+        byte-identical to the source script text.
+
+        When enabled: applies the selected backend's text normalization
+        (nemo, else wetext, else a no-op with a warning) followed by the
+        pronunciation dictionary (longest-match-first, literal,
+        case-sensitive substitution).
+        """
+        if not self.enabled:
+            return text
+
+        normalized = _apply_backend_normalization(text)
+        normalized = _apply_pronunciation_dict(normalized, self._pronunciation_dict)
+        return normalized

--- a/default_prompts.txt
+++ b/default_prompts.txt
@@ -30,6 +30,7 @@ RULES:
 2. ATTRIBUTION TAGS AND ACTION BEATS STAY NARRATION. " he said.", ", said Marcus, unable to meet her gaze." and any stage direction are role "narration" — the narrator reads them aloud. This is an audiobook, not an audio drama: nothing is dropped, nothing is reworded, nothing is moved.
 
 3. IDENTIFYING THE SPEAKER: use the attribution tag in the neighbouring unquoted span, the alternating-speaker convention of a two-person exchange, and the character roster given in the context block. If you genuinely cannot tell who speaks a quoted span, label it "NARRATOR" / "narration" rather than inventing a name.
+   NEVER invent a placeholder label. "SPEAKER", "SPEAKER 1", "SPEAKER 2", "VOICE 1", "SOMEONE", "OTHER", "UNKNOWN", "CHARACTER", "MAN", "BOY", or a bare pronoun ("HE", "SHE", "THEY") are all wrong: each one becomes a separate character with its own voice in the finished audiobook. An unidentifiable speaker is "NARRATOR" / "narration" — that is the correct answer, not a fallback. Only use a name the text actually gives you.
 
 4. SPEAKER NAMES: UPPERCASE, and byte-identical every time the same character speaks. Reuse the exact spelling from the roster in the context block instead of introducing a variant ("MARCUS", not "MARCUS BELL" or "Marcus" once the roster says MARCUS). Use a bare name with no honorific.
 

--- a/default_prompts.txt
+++ b/default_prompts.txt
@@ -1,58 +1,59 @@
-You are a script writer converting books into audiobook scripts for an advanced TTS system. Output ONLY valid JSON arrays — no markdown, no explanations.
+You are a dialogue and speaker CLASSIFIER for an audiobook pipeline (prompt schema: span-labels-v1). You never write, rewrite, echo, translate, correct, summarize or emit book text. You only attach labels to text that already exists.
 
-FORMAT:
+Code has already split the source into numbered SPANS that tile it exactly. You receive one JSON object per line:
+{"id": 1, "kind": "quoted", "text": "\"I am leaving,\""}
+{"id": 2, "kind": "unquoted", "text": " he said."}
+
+You return ONLY a JSON array of label objects — no markdown, no commentary, no code fences:
 [
-  {"speaker": "NARRATOR", "text": "The room had gone cold. Elena stood by the window, arms folded, watching the last light drain from the sky.", "instruct": "Quiet, tense narration."},
-  {"speaker": "ELENA", "text": "Tell me the truth.", "instruct": "Firm quiet authority, low and controlled, voice tight with restrained anger."},
-  {"speaker": "MARCUS", "text": "There is nothing to tell.", "instruct": "Defensive evasion, flat and guarded, forcing calm he does not feel."},
-  {"speaker": "NARRATOR", "text": "Marcus could not meet her gaze. He had always been a poor liar, and they both knew it.", "instruct": "Neutral, even narration."}
+  {"id": 1, "speaker": "ELENA", "role": "dialogue", "instruct": "Firm quiet authority, low and controlled, voice tight with restrained anger."},
+  {"id": 2, "speaker": "NARRATOR", "role": "narration", "instruct": "Neutral, even narration."}
 ]
 
-FIELDS:
-- "speaker": Character name in UPPERCASE. "NARRATOR" for ALL non-dialogue (descriptions, thoughts, actions, scene-setting).
-- "text": Exactly what the TTS voice says.
+FIELDS — exactly these four, and no others:
+- "id": the span id, copied exactly from the input. One label object per span, in ascending id order.
+- "speaker": character name in UPPERCASE for dialogue; "NARRATOR" for narration.
+- "role": "dialogue" or "narration". REQUIRED on every object. A span whose role is not exactly "dialogue" is read by the narrator, whatever name you put in "speaker" — so an omitted role silently costs a character voice.
 - "instruct": 1-2 sentence voice direction (~8-15 words) for the TTS engine.
+
+NEVER output a "text" field. The audiobook text is rebuilt by code from the span offsets, verbatim. Any text you write is discarded, and every span you fail to label is read by the NARRATOR.
 
 RULES:
 
 1. NARRATOR vs CHARACTER (most important rule):
-   CHARACTER = words spoken aloud (dialogue). NARRATOR = everything else (descriptions, actions, thoughts, internal monologue).
-   - NEVER convert narration to dialogue. Third-person stays third-person:
-     WRONG: Source "He had always been a poor liar" → MARCUS: "I have always been a poor liar"
-     RIGHT: → NARRATOR: "He had always been a poor liar."
-   - Split mixed paragraphs by tracking quotation marks — inside quotes = CHARACTER, outside = NARRATOR:
-     Source: '"We should leave," he said, pulling on his coat. "Now, before they notice."'
-     → MARCUS: "We should leave." → NARRATOR: "Marcus pulled on his coat." → MARCUS: "Now, before they notice."
+   CHARACTER = words spoken aloud. NARRATOR = everything else (description, action, thought, scene-setting).
+   - "quoted" spans are dialogue candidates: normally role "dialogue" with the speaking character's name. A quotation that is not speech — a quoted title, a sign, a scare-quoted word, a quoted term inside narration — stays role "narration".
+   - "unquoted" spans are narration BY DEFAULT: role "narration", speaker "NARRATOR".
+   - EXCEPTION: unquoted dialogue, em-dash dialogue (— Then go again) and sustained first-person interior monologue MAY be role "dialogue" with a character name when the words are clearly spoken or thought in that character's own voice.
+   - Third person is never dialogue. "He had always been a poor liar" is narration, always.
 
-2. PRESERVE THE AUTHOR'S TEXT. Do not change tense, person, or wording.
+2. ATTRIBUTION TAGS AND ACTION BEATS STAY NARRATION. " he said.", ", said Marcus, unable to meet her gaze." and any stage direction are role "narration" — the narrator reads them aloud. This is an audiobook, not an audio drama: nothing is dropped, nothing is reworded, nothing is moved.
 
-3. NEVER remove narration. All narration must appear in output — standalone paragraphs, interleaved actions, and actions extracted from attribution tags.
+3. IDENTIFYING THE SPEAKER: use the attribution tag in the neighbouring unquoted span, the alternating-speaker convention of a two-person exchange, and the character roster given in the context block. If you genuinely cannot tell who speaks a quoted span, label it "NARRATOR" / "narration" rather than inventing a name.
 
-4. Drop attribution tags ("he said", "she replied") but ALWAYS extract descriptive actions as NARRATOR using the character's name (not a pronoun):
-   Source: '"There is nothing to tell," said Marcus, unable to meet her gaze.'
-   → MARCUS: "There is nothing to tell." → NARRATOR: "Marcus was unable to meet her gaze."
+4. SPEAKER NAMES: UPPERCASE, and byte-identical every time the same character speaks. Reuse the exact spelling from the roster in the context block instead of introducing a variant ("MARCUS", not "MARCUS BELL" or "Marcus" once the roster says MARCUS). Use a bare name with no honorific.
 
-5. NARRATOR GROUPING: Keep consecutive narrator text in ONE entry unless the emotional tone genuinely shifts. Do not split narration sentence-by-sentence.
-   EXCEPTION: Book titles, author names, dedications, chapter numbers, chapter titles, and other front-matter or structural text must each be their own separate entry — they are distinct items, not continuous narration. A bare chapter number ("1", "CHAPTER THREE") and its chapter title ("SPADE & ARCHER") may be combined into one entry ("1 SPADE & ARCHER").
+5. SPECIAL CASES:
+   - A character reading a document, letter or sign aloud: attribute to the READER, not the document's author.
+   - Non-human or unvoiced entities: role "narration".
+   - Front matter, chapter numbers and chapter titles: role "narration", speaker "NARRATOR".
 
-6. TEXT FORMATTING:
-   - No bracket sounds ([gasps], <sigh>). Use real words: "Ah!", "Oh!", "Haha!", "Haah...", "Mmm..."
-   - Convert for TTS: "Chapter I" → "Chapter One", "Dr." → "Doctor", "Mr." → "Mister", "&" → "and", "3rd" → "third"
-   - Preserve internal quotation marks (quoted letters, foreign terms, emphasis) — only remove outermost dialogue quotes.
-   - Characters reading documents aloud: attribute to the reader, not the document's author.
-   - Non-human characters: describe through NARRATOR, no speaking lines.
-
-7. INSTRUCT GUIDELINES:
+6. INSTRUCT GUIDELINES:
    Layer up to three dimensions — EMOTIONAL TONE (furious, fearful, triumphant), DELIVERY (whispered, clipped, measured), VOCAL QUALITY (voice cracking, gravelly, breathy). Not every line needs all three.
-   - NARRATOR default: "Neutral, even narration." Shift only at scene-level tone changes and hold across consecutive entries.
-   - CHARACTER: Lean into the line's emotional grain. Be direct — no weak qualifiers ("slightly", "a bit").
+   - NARRATOR default: "Neutral, even narration." Shift only at scene-level tone changes and hold it across consecutive spans.
+   - CHARACTER: lean into the line's emotional grain. Be direct — no weak qualifiers ("slightly", "a bit").
    - Describe the VOICE, not the body. "Shocked, voice breaking." NOT "Trembling with shock."
-   - Convey pacing through energy: "urgent intensity" not "fast and urgent".
-   - Each line is processed in isolation by TTS — give the instruct all needed context. Repeat emotional state explicitly ("Sad, quiet sobbing." not "still crying").
+   - Convey pacing through energy: "urgent intensity", not "fast and urgent".
+   - Each line is processed in isolation by the TTS engine, so restate the emotional state explicitly ("Sad, quiet sobbing." not "still crying").
+   - Keep instructs short. Labels are cheap; long instructs are what run you out of room to finish the array.
+
+7. COVERAGE: emit one label for EVERY span id you were given, in ascending order. Do not skip ids, do not invent ids, do not merge spans. An unlabelled span is not an error you will see — it is simply narrated.
 ---SEPARATOR---
 {context}
 
-Remember: if another character in the scene would hear the words, it is CHARACTER dialogue. Everything else is NARRATOR. Preserve the author's original wording, person, and tense exactly.
+Classify every span listed below (prompt schema: span-labels-v1). Return ONLY a JSON array of {{"id", "speaker", "role", "instruct"}} objects — one per span id, in ascending order, with no "text" field and no text of your own.
 
-SOURCE TEXT:
+Remember: if another character in the scene would hear the words, it is dialogue. Everything else, including attribution tags such as "he said", is narration.
+
+SPANS:
 {chunk}

--- a/review_prompts.txt
+++ b/review_prompts.txt
@@ -13,10 +13,12 @@ CRITICAL RULES — NEVER VIOLATE THESE:
 WHAT TO CHECK:
 
 1. SPEAKER ATTRIBUTION
-   Is the entry attributed to the right character? Use the surrounding context (previous/next entries, the character roster if given) to judge. Common errors to fix:
-   - A line of dialogue attributed to the wrong character in a back-and-forth exchange.
-   - Narration mislabeled with a character's name instead of "NARRATOR".
-   - Dialogue mislabeled as "NARRATOR" when it is clearly a character speaking.
+   ATTRIBUTION TAGS AND ACTION BEATS STAY NARRATION. An entry that merely NAMES a character is not spoken BY that character. " he said.", "Dairine said.", ", said Marcus, unable to meet her gaze.", "Ronan shook his head." and any stage direction are the NARRATOR's, and the narrator reads them aloud. This is an audiobook, not an audio drama: the tag is not dropped, not reworded, not folded into the character's voice. Naming the speaker of a nearby quotation is exactly what an attribution tag does — that is the reason it says a character's name, and it is not a reason to change "NARRATOR" to that name. Practical test: an entry with no quotation marks in it is almost always "NARRATOR"; before changing one to a character, be sure the words are spoken aloud rather than describing who spoke.
+
+   Beyond that: is the entry attributed to the right character? Use the surrounding context (previous/next entries, the character roster if given) to judge. Common errors to fix:
+   - A line of dialogue attributed to the wrong character in a back-and-forth exchange. The attribution tag in the neighbouring entry is the strongest evidence you have: if an entry of dialogue is followed by "Nita said," then that dialogue is NITA's, whatever speaker it currently carries.
+   - Narration mislabeled with a character's name instead of "NARRATOR" — including an attribution tag or action beat that was given the name of the character it describes.
+   - Dialogue mislabeled as "NARRATOR" when it is clearly a character speaking. This means QUOTED words that a character says aloud, never an unquoted tag or beat.
    - Inconsistent spelling/casing of the same character's name across entries — normalize to the spelling used elsewhere in the batch.
    If you are not confident who speaks an entry, leave the existing speaker as-is rather than guessing a change.
 

--- a/review_prompts.txt
+++ b/review_prompts.txt
@@ -1,4 +1,4 @@
-You are a script reviewer for an audiobook TTS pipeline. You receive batches of JSON entries from a generated audiobook script. Each entry has three fields: "speaker" (character name in UPPERCASE, or "NARRATOR"), "text" (the spoken/narrated text), and "instruct" (TTS voice direction).
+You are a script reviewer for an audiobook TTS pipeline (prompt schema: verbatim-review-v1). You receive batches of JSON entries from a generated audiobook script. Each entry has three fields: "speaker" (character name in UPPERCASE, or "NARRATOR"), "text" (the spoken/narrated text), and "instruct" (TTS voice direction).
 
 Your ONLY job is to check two things per entry: (1) is "speaker" the correct attribution, and (2) is "instruct" a good voice direction. Fix ONLY those two fields when they are wrong. You do not restructure, split, merge, or rewrite anything — the text has already been finalized by an earlier stage and is verbatim from the source book; code enforces that guarantee regardless of what you output here.
 
@@ -32,7 +32,7 @@ WHAT TO CHECK:
 ---SEPARATOR---
 {context}
 
-Review the following batch of audiobook script entries. Check ONLY speaker attribution and instruct quality per your instructions — do not add, remove, split, merge, or rewrite any entry, and never edit "text". Return a JSON array with exactly the same number of entries, in the same order, as the input batch, each with all three fields.
+Review the following batch of audiobook script entries (prompt schema: verbatim-review-v1). Check ONLY speaker attribution and instruct quality per your instructions — do not add, remove, split, merge, or rewrite any entry, and never edit "text". Return a JSON array with exactly the same number of entries, in the same order, as the input batch, each with all three fields.
 
 SCRIPT ENTRIES TO REVIEW:
 {batch}

--- a/review_prompts.txt
+++ b/review_prompts.txt
@@ -1,83 +1,38 @@
-You are a script reviewer for an audiobook TTS pipeline. You receive batches of JSON entries from a generated audiobook script. Each entry has three fields: "speaker" (character name in UPPERCASE, or "NARRATOR"), "text" (the spoken text), and "instruct" (TTS voice direction).
+You are a script reviewer for an audiobook TTS pipeline. You receive batches of JSON entries from a generated audiobook script. Each entry has three fields: "speaker" (character name in UPPERCASE, or "NARRATOR"), "text" (the spoken/narrated text), and "instruct" (TTS voice direction).
 
-Your job is to find and fix these specific errors. Do NOT rewrite or rephrase anything — only restructure when necessary.
+Your ONLY job is to check two things per entry: (1) is "speaker" the correct attribution, and (2) is "instruct" a good voice direction. Fix ONLY those two fields when they are wrong. You do not restructure, split, merge, or rewrite anything — the text has already been finalized by an earlier stage and is verbatim from the source book; code enforces that guarantee regardless of what you output here.
 
-OUTPUT FORMAT: A JSON array of corrected entries, same format as input. Include ALL entries — both fixed and unchanged. Output ONLY the JSON array, no markdown, no explanations.
+OUTPUT FORMAT: A JSON array with exactly the same number of objects, in exactly the same order, as the input batch. Each object has the same three fields as its corresponding input entry. Output ONLY the JSON array, no markdown, no explanations.
 
 CRITICAL RULES — NEVER VIOLATE THESE:
-- Every entry in your output MUST have all three fields: "speaker", "text", and "instruct". Never omit a field.
-- NEVER drop text. When you split or restructure an entry, every sentence from the original MUST appear in exactly one output entry. The combined text of all output entries must account for ALL text from all input entries. Dropping even a single sentence is a critical failure.
-- NEVER change the author's wording, tense, person, or phrasing. If the source text says "I did so", keep "I did so" — do NOT rewrite it as "Watson did so" or any other form.
-- NEVER change punctuation — dashes (--), ellipses (...), quotes, or any other punctuation must stay exactly as they appear.
-- NEVER split a CHARACTER entry into multiple entries of the SAME speaker. If Holmes says three sentences in a row with no narration or attribution tag between them, that is ONE entry — not three. Only split when there is an attribution tag (like "said he") or narration embedded between separate quoted sentences that needs to be extracted. Splitting at sentence boundaries within a single continuous speech is WRONG.
+- Output MUST have exactly as many entries as the input batch, in the same order. Never add, remove, split, or merge entries — not even to fix a genuine attribution or narration problem. If you can't fix an issue without restructuring, leave the entry as-is instead.
+- Every output object MUST have all three fields: "speaker", "text", and "instruct". Never omit a field.
+- NEVER change, rewrite, reword, retype, or otherwise touch "text". Copy it through unchanged. (In practice, code discards whatever you put in "text" and reuses the original byte-for-byte — but treat it as read-only regardless, and never let a text edit distract you from the speaker/instruct check.)
+- Speaker names: UPPERCASE, "NARRATOR" for narration. Reuse the exact spelling already used for a character elsewhere in the batch/context — never introduce a variant spelling, honorific, or nickname as a "fix".
 
-FIXES TO APPLY:
+WHAT TO CHECK:
 
-1. STRIP ATTRIBUTION TAGS FROM DIALOGUE
-   Character dialogue should contain ONLY the spoken words. Remove attribution phrases like "said he", "she replied", "I remarked", "he continued", "asked Holmes", etc. — but keep ALL surrounding dialogue intact. Only the attribution tag itself is removed; every sentence of dialogue must remain.
-   WRONG: {"speaker": "HOLMES", "text": "It is simplicity itself, said he; my eyes tell me that the leather is scored by six cuts.", "instruct": "Quietly triumphant."}
-   RIGHT: {"speaker": "HOLMES", "text": "It is simplicity itself; my eyes tell me that the leather is scored by six cuts.", "instruct": "Quietly triumphant."}
-   When the attribution contains a physical action (participial phrase like "lighting a cigarette", "glancing out the window"), extract it as a NEW NARRATOR entry inserted directly after the dialogue. The new NARRATOR entry MUST have "instruct": "Neutral, even narration.":
-   WRONG: {"speaker": "HOLMES", "text": "Quite so, he answered, lighting a cigarette, and throwing himself down into an armchair. You see, but you do not observe.", "instruct": "Quietly analytical."}
-   RIGHT:
-     {"speaker": "HOLMES", "text": "Quite so.", "instruct": "Quietly analytical."}
-     {"speaker": "NARRATOR", "text": "Holmes lit a cigarette and threw himself down into an armchair.", "instruct": "Neutral, even narration."}
-     {"speaker": "HOLMES", "text": "You see, but you do not observe.", "instruct": "Quietly analytical."}
-   Note: When extracting actions to NARRATOR, use the character's name (not a pronoun) and convert participial phrases to past tense. This is the ONLY case where you may rephrase text.
+1. SPEAKER ATTRIBUTION
+   Is the entry attributed to the right character? Use the surrounding context (previous/next entries, the character roster if given) to judge. Common errors to fix:
+   - A line of dialogue attributed to the wrong character in a back-and-forth exchange.
+   - Narration mislabeled with a character's name instead of "NARRATOR".
+   - Dialogue mislabeled as "NARRATOR" when it is clearly a character speaking.
+   - Inconsistent spelling/casing of the same character's name across entries — normalize to the spelling used elsewhere in the batch.
+   If you are not confident who speaks an entry, leave the existing speaker as-is rather than guessing a change.
 
-2. SPLIT NARRATION OUT OF CHARACTER ENTRIES
-   A CHARACTER entry must contain ONLY words spoken aloud. If it contains narration that is clearly NOT dialogue (third-person descriptions of actions, scene-setting mixed in before or after the quoted speech), split them out as NARRATOR entries.
-   WRONG: {"speaker": "WATSON", "text": "I could not help laughing at the ease with which he explained his process of deduction. When I hear you give your reasons, the thing always appears to me to be so ridiculously simple.", "instruct": "Amused, reflective."}
-   RIGHT:
-     {"speaker": "NARRATOR", "text": "I could not help laughing at the ease with which he explained his process of deduction.", "instruct": "Neutral, even narration."}
-     {"speaker": "WATSON", "text": "When I hear you give your reasons, the thing always appears to me to be so ridiculously simple.", "instruct": "Amused, reflective."}
-   IMPORTANT: Copy the narration text EXACTLY as it appears — do NOT convert first person to third person. "I could not help laughing" stays as "I could not help laughing", NOT "Watson could not help laughing".
-   The key test: narration describes what happened (past tense reporting), dialogue is spoken to another character (present tense address). In the example above, "I could not help laughing at the ease..." is the narrator reporting what happened, while "When I hear you give your reasons..." is Watson speaking directly to Holmes.
-
-3. SPLIT DIALOGUE OUT OF NARRATOR ENTRIES
-   A NARRATOR entry must NOT contain quoted dialogue. If it does, extract the dialogue as a CHARACTER entry. ALL parts of the original text must be preserved — both the narration AND the dialogue must appear in the output, plus any trailing narration as a separate NARRATOR entry.
-   WRONG: {"speaker": "NARRATOR", "text": "He examined the paper carefully. \"The name of the maker, no doubt; or his monogram, rather.\" His eyes narrowed as he spoke.", "instruct": "Neutral, even narration."}
-   RIGHT:
-     {"speaker": "NARRATOR", "text": "He examined the paper carefully.", "instruct": "Neutral, even narration."}
-     {"speaker": "WATSON", "text": "The name of the maker, no doubt; or his monogram, rather.", "instruct": "Speculative, cautious."}
-     {"speaker": "NARRATOR", "text": "His eyes narrowed as he spoke.", "instruct": "Neutral, even narration."}
-   Use surrounding context (previous/next entries) to determine the correct speaker for extracted dialogue. Never drop trailing narration — if text follows the dialogue, it becomes its own NARRATOR entry.
-
-4. MERGE OVER-SPLIT NARRATOR ENTRIES
-   Consecutive NARRATOR entries that are short (under ~150 characters each) and cover the same continuous scene should be merged into a single entry. Short, choppy narrator lines cause inconsistent TTS delivery.
-   WRONG:
-     {"speaker": "NARRATOR", "text": "A slow and heavy step was heard upon the stairs.", "instruct": "Neutral, even narration."}
-     {"speaker": "NARRATOR", "text": "Then there was a loud and authoritative tap.", "instruct": "Neutral, even narration."}
-   RIGHT:
-     {"speaker": "NARRATOR", "text": "A slow and heavy step was heard upon the stairs. Then there was a loud and authoritative tap.", "instruct": "Neutral, even narration."}
-   Do NOT merge narrators if: (a) both entries are already long (over ~200 characters each), (b) a genuine tone shift occurs between them, or (c) either entry is NOT a full narrative sentence. Short fragments like book titles, author names, dedications, chapter numbers, chapter titles, section headings, or other front-matter/structural text must always remain as separate entries — they are distinct items, not choppy narration.
-   WRONG (merging structural text):
-     {"speaker": "NARRATOR", "text": "THE GREAT GATSBY BY F. SCOTT FITZGERALD To my wife. CHAPTER ONE", "instruct": "Neutral, even narration."}
-   RIGHT (kept separate):
-     {"speaker": "NARRATOR", "text": "THE GREAT GATSBY", "instruct": "Neutral, even narration."}
-     {"speaker": "NARRATOR", "text": "BY F. SCOTT FITZGERALD", "instruct": "Neutral, even narration."}
-     {"speaker": "NARRATOR", "text": "To my wife.", "instruct": "Neutral, even narration."}
-     {"speaker": "NARRATOR", "text": "CHAPTER ONE", "instruct": "Neutral, even narration."}
-   EXCEPTION: A bare chapter number and its chapter title, when split across two entries, SHOULD be merged into one entry so TTS reads them together naturally.
-   WRONG (split number and title):
-     {"speaker": "NARRATOR", "text": "1", "instruct": "Neutral, even narration."}
-     {"speaker": "NARRATOR", "text": "SPADE & ARCHER", "instruct": "Neutral, even narration."}
-   RIGHT (combined):
-     {"speaker": "NARRATOR", "text": "1 SPADE & ARCHER", "instruct": "Neutral, even narration."}
-
-5. VALIDATE INSTRUCT FIELDS
-   - NARRATOR: Must be "Neutral, even narration." or a single tonal variant matching the scene ("Tense, clipped narration.", "Quiet, somber narration.", "Wry, light narration."). Fix any narrator instruct that describes character emotions, physical actions, or reads like a character direction.
-     WRONG: "With a sense of foreboding and dread." → RIGHT: "Dark, heavy narration."
-     WRONG: "Neutral, even narration." during a tense chase scene → acceptable to leave as-is OR upgrade to "Tense, urgent narration." — but never downgrade a valid tonal variant back to neutral.
+2. INSTRUCT QUALITY
+   - NARRATOR: Should be "Neutral, even narration." or a single tonal variant matching the scene ("Tense, clipped narration.", "Quiet, somber narration.", "Wry, light narration."). Fix any narrator instruct that describes character emotions, physical actions, or reads like a character direction.
+     WRONG: "With a sense of foreboding and dread." -> RIGHT: "Dark, heavy narration."
    - CHARACTER: Instructs should describe the VOICE using emotion, delivery, and vocal quality (~8-15 words). Replace physical descriptions with vocal equivalents:
-     WRONG: "Trembling with shock." → RIGHT: "Shocked, voice cracking with disbelief."
-     WRONG: "Leaning forward eagerly." → RIGHT: "Eager, bright energy, words tumbling out."
-     WRONG: "He tries to sound casual." → RIGHT: "Forced casual tone, not quite selling it."
+     WRONG: "Trembling with shock." -> RIGHT: "Shocked, voice cracking with disbelief."
+     WRONG: "Leaning forward eagerly." -> RIGHT: "Eager, bright energy, words tumbling out."
+     WRONG: "He tries to sound casual." -> RIGHT: "Forced casual tone, not quite selling it."
    - Do NOT shorten or simplify instructs that are already valid voice descriptions. A rich instruct like "Cold fury, barely contained, voice tight" is correct and should not be reduced.
+   - Do NOT touch a correct instruct just to reword it stylistically. Only change instructs that are actually wrong per the guidance above.
 ---SEPARATOR---
 {context}
 
-Review the following batch of audiobook script entries. Fix any issues matching the 5 categories in your instructions. Return the corrected JSON array with ALL entries (both fixed and unchanged). Remember: NEVER change wording, person, tense, or punctuation. Every output entry MUST have all three fields (speaker, text, instruct). NEVER drop text — every sentence from the input must appear in exactly one output entry.
+Review the following batch of audiobook script entries. Check ONLY speaker attribution and instruct quality per your instructions — do not add, remove, split, merge, or rewrite any entry, and never edit "text". Return a JSON array with exactly the same number of entries, in the same order, as the input batch, each with all three fields.
 
 SCRIPT ENTRIES TO REVIEW:
 {batch}

--- a/tools/verify_attestation.py
+++ b/tools/verify_attestation.py
@@ -1,0 +1,287 @@
+"""Offline dry-run analyzer for speaker-label attestation.
+
+Speaker labels are the one field in the annotation schema the LLM still
+*generates* rather than selects, and it transcribes names imperfectly:
+systematic misreadings, invented names for unnamed speakers, and spelling
+drift that fragments one character across several roster entries and therefore
+across several voices.
+
+`speaker_canon.attest_speaker()` can tell the three cases apart by checking a
+label's core name tokens against the source text near that label's own
+entries. Turning that check into a GATE at annotation time -- rejecting a
+label the book does not support, so the line is narrated instead of claiming a
+fabricated voice -- is only safe if the real-world rejection rate is known.
+That number cannot be obtained from an offline property test, because it
+depends entirely on the book and the model. This script measures it.
+
+Read-only: it opens annotated_script.json and the source text, writes nothing,
+calls no LLM and touches no network. Run it before enabling any gate, and
+again after, to see what changed.
+
+Usage:
+    python tools/verify_attestation.py
+        Analyze the current project (annotated_script.json plus the source
+        pointed at by state.json) and print the would-be rejection rate.
+
+    python tools/verify_attestation.py --script PATH --source PATH
+        Analyze a specific pair, e.g. an archived script.
+
+    python tools/verify_attestation.py --list unattested
+        Also list every speaker with that verdict, worst (most entries)
+        first. Accepts: unattested, unverifiable, attested, all.
+
+Exit codes:
+    0  analysis completed (whatever it found -- this is a report, not a test)
+    2  inputs unavailable (no script, no source), with an explanation
+"""
+
+import argparse
+import json
+import os
+import sys
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+APP_DIR = os.path.join(ROOT_DIR, "app")
+if APP_DIR not in sys.path:
+    sys.path.insert(0, APP_DIR)
+
+from speaker_canon import (  # noqa: E402  (must follow the sys.path tweak)
+    ATTESTED,
+    UNATTESTED,
+    UNVERIFIABLE,
+    attest_speaker,
+    remember_in_roster,
+)
+
+# Deliberately mirrors app.py's _compute_label_flags so this dry run measures
+# what the endpoint (and a future gate) would actually see, rather than a
+# more-generous or more-punishing approximation. Overridable on the command
+# line to test the sensitivity of the result to the window size.
+DEFAULT_MAX_SAMPLED_ENTRIES = 20
+DEFAULT_WINDOW_RADIUS = 400
+
+NARRATOR = "NARRATOR"
+
+
+def load_source_text(explicit_path=None):
+    """Return (text, path, note). Applies the SAME mojibake fix generation
+    applied, because the entry texts in annotated_script.json were produced
+    from the fixed text -- comparing them against the raw file makes every
+    str.find() miss and reports a book with perfect labels as unattestable.
+    """
+    path = explicit_path
+    if path is None:
+        state_path = os.path.join(ROOT_DIR, "state.json")
+        if not os.path.exists(state_path):
+            return None, None, "no state.json; pass --source explicitly"
+        try:
+            with open(state_path, "r", encoding="utf-8") as handle:
+                state = json.load(handle)
+        except (json.JSONDecodeError, ValueError, OSError) as exc:
+            return None, None, f"state.json unreadable ({exc}); pass --source"
+        path = state.get("input_file_path")
+        if not path:
+            return None, None, "state.json has no input_file_path; pass --source"
+
+    if not os.path.exists(path):
+        return None, path, f"source file not found: {path}"
+
+    if path.lower().endswith(".epub"):
+        try:
+            from app import extract_epub_text  # noqa: PLC0415  (optional, heavy)
+        except Exception as exc:  # pragma: no cover - depends on env
+            return None, path, (
+                f"cannot import extract_epub_text from app.py ({exc}). "
+                "Install the server deps, or export the epub to .txt and pass "
+                "--source."
+            )
+        raw = extract_epub_text(path)
+    else:
+        with open(path, "r", encoding="utf-8") as handle:
+            raw = handle.read()
+
+    try:
+        from generate_script import fix_mojibake
+    except Exception as exc:  # pragma: no cover - depends on env
+        return raw, path, (
+            f"WARNING: could not import fix_mojibake ({exc}); comparing "
+            "against RAW source. Entry lookups may miss."
+        )
+    return fix_mojibake(raw), path, None
+
+
+def load_script(explicit_path=None):
+    path = explicit_path or os.path.join(ROOT_DIR, "annotated_script.json")
+    if not os.path.exists(path):
+        return None, path, f"no script at {path}"
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            return json.load(handle), path, None
+    except (json.JSONDecodeError, ValueError) as exc:
+        return None, path, f"script is not valid JSON ({exc})"
+
+
+def analyze(script_data, source_text, max_sampled, radius):
+    """Group entries by canonical speaker, build local windows, and return a
+    per-speaker report plus totals. Pure apart from reading its arguments.
+    """
+    roster_index = {}
+    by_speaker = {}
+    for entry in script_data:
+        raw_speaker = entry.get("speaker") or entry.get("type") or ""
+        canonical = remember_in_roster(roster_index, raw_speaker)
+        if not canonical or canonical == NARRATOR:
+            continue
+        by_speaker.setdefault(canonical, []).append(entry.get("text") or "")
+
+    report = []
+    for name, texts in by_speaker.items():
+        windows = []
+        located = 0
+        for text in texts[:max_sampled]:
+            if not text:
+                continue
+            found = source_text.find(text)
+            if found == -1:
+                continue
+            located += 1
+            start = max(0, found - radius)
+            end = min(len(source_text), found + len(text) + radius)
+            windows.append(source_text[start:end])
+
+        report.append({
+            "name": name,
+            "entry_count": len(texts),
+            "sampled": min(len(texts), max_sampled),
+            "located": located,
+            "verdict": attest_speaker(name, windows),
+        })
+
+    report.sort(key=lambda row: (-row["entry_count"], row["name"]))
+    return report
+
+
+def summarize(report, script_data):
+    total_entries = len(script_data)
+    dialogue_entries = sum(row["entry_count"] for row in report)
+    by_verdict = {ATTESTED: [], UNATTESTED: [], UNVERIFIABLE: []}
+    for row in report:
+        by_verdict[row["verdict"]].append(row)
+
+    def pct(part, whole):
+        return f"{(100.0 * part / whole):5.1f}%" if whole else "    --"
+
+    print("=" * 72)
+    print("Speaker-label attestation dry run")
+    print("=" * 72)
+    print(f"Script entries:              {total_entries}")
+    print(f"Non-narrator entries:        {dialogue_entries}")
+    print(f"Distinct speakers:           {len(report)}")
+
+    unlocated = [row for row in report if row["located"] == 0]
+    if unlocated:
+        print()
+        print(f"WARNING: {len(unlocated)} speaker(s) had NO entry text found in the")
+        print("  source at all. Their verdicts are meaningless -- this points at a")
+        print("  script/source mismatch (wrong book, or text transformed after")
+        print("  generation), not at bad labels. Fix that before trusting anything")
+        print("  below.")
+
+    print()
+    print("Verdict           speakers          entries")
+    print("-" * 72)
+    for verdict in (ATTESTED, UNVERIFIABLE, UNATTESTED):
+        rows = by_verdict[verdict]
+        entries = sum(row["entry_count"] for row in rows)
+        print(f"{verdict:<16}{len(rows):>6} {pct(len(rows), len(report))}"
+              f"{entries:>10} {pct(entries, dialogue_entries)}")
+    print("-" * 72)
+
+    rejected = by_verdict[UNATTESTED]
+    rejected_entries = sum(row["entry_count"] for row in rejected)
+    print()
+    print("If a gate rejected only UNATTESTED labels (the only verdict that is")
+    print("positive evidence a label is wrong), these lines would be narrated")
+    print("instead of getting a character voice:")
+    print(f"    {len(rejected)} of {len(report)} speakers "
+          f"({pct(len(rejected), len(report)).strip()})")
+    print(f"    {rejected_entries} of {dialogue_entries} non-narrator entries "
+          f"({pct(rejected_entries, dialogue_entries).strip()})")
+    print()
+    print("UNVERIFIABLE is never rejected: it means the check does not apply to")
+    print("this text (a title-only label, or a name present but not at a word")
+    print("boundary, as in unsegmented scripts). Those keep their voices.")
+    return by_verdict
+
+
+def list_rows(by_verdict, which):
+    wanted = ([ATTESTED, UNVERIFIABLE, UNATTESTED] if which == "all" else [which])
+    for verdict in wanted:
+        rows = by_verdict.get(verdict) or []
+        if not rows:
+            continue
+        print()
+        print(f"--- {verdict} ({len(rows)} speakers, most entries first) ---")
+        print(f"{'entries':>8}  {'located':>8}  name")
+        for row in rows:
+            print(f"{row['entry_count']:>8}  "
+                  f"{row['located']:>3}/{row['sampled']:<4}  {row['name']}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Offline dry run: how many speaker labels would an "
+                    "attestation gate reject on this book?")
+    parser.add_argument("--script", default=None,
+                        help="path to annotated_script.json "
+                             "(default: repo root)")
+    parser.add_argument("--source", default=None,
+                        help="path to the source .txt/.md/.epub "
+                             "(default: state.json's input_file_path)")
+    parser.add_argument("--list", dest="list_verdict", default=None,
+                        choices=[ATTESTED, UNVERIFIABLE, UNATTESTED, "all"],
+                        help="also list the speakers with this verdict")
+    parser.add_argument("--max-sampled", type=int,
+                        default=DEFAULT_MAX_SAMPLED_ENTRIES,
+                        help="entries sampled per speaker "
+                             f"(default {DEFAULT_MAX_SAMPLED_ENTRIES}, "
+                             "mirrors the label_flags endpoint)")
+    parser.add_argument("--radius", type=int, default=DEFAULT_WINDOW_RADIUS,
+                        help="source characters each side of a sampled entry "
+                             f"(default {DEFAULT_WINDOW_RADIUS})")
+    args = parser.parse_args()
+
+    script_data, script_path, script_note = load_script(args.script)
+    if script_data is None:
+        print(f"Cannot analyze: {script_note}")
+        print("Generate a script first, or pass --script.")
+        return 2
+    if not isinstance(script_data, list) or not script_data:
+        print(f"Cannot analyze: {script_path} contains no entries.")
+        return 2
+
+    source_text, source_path, source_note = load_source_text(args.source)
+    if source_text is None:
+        print(f"Cannot analyze: {source_note}")
+        return 2
+    if source_note:
+        print(source_note)
+        print()
+
+    print(f"Script: {script_path}")
+    print(f"Source: {source_path}")
+    print()
+
+    report = analyze(script_data, source_text, args.max_sampled, args.radius)
+    if not report:
+        print("No non-narrator speakers in this script; nothing to attest.")
+        return 0
+
+    by_verdict = summarize(report, script_data)
+    if args.list_verdict:
+        list_rows(by_verdict, args.list_verdict)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/verify_attestation.py
+++ b/tools/verify_attestation.py
@@ -14,6 +14,13 @@ fabricated voice -- is only safe if the real-world rejection rate is known.
 That number cannot be obtained from an offline property test, because it
 depends entirely on the book and the model. This script measures it.
 
+The gate does not simply reject every UNATTESTED label: a refuted spelling the
+book never uses, one edit from an established name that is present in the
+label's own window, is REPAIRED onto that name (speaker_canon.repair_speaker).
+This report mirrors that, so the "would be rejected" number stays the number a
+real run would produce -- and it itemizes the repairs separately, because a
+repair silently changes who a line is attributed to and deserves an audit.
+
 Read-only: it opens annotated_script.json and the source text, writes nothing,
 calls no LLM and touches no network. Run it before enabling any gate, and
 again after, to see what changed.
@@ -51,6 +58,8 @@ from speaker_canon import (  # noqa: E402  (must follow the sys.path tweak)
     UNVERIFIABLE,
     attest_speaker,
     remember_in_roster,
+    repair_speaker,
+    source_word_index,
 )
 
 # Deliberately mirrors app.py's _compute_label_flags so this dry run measures
@@ -134,6 +143,11 @@ def analyze(script_data, source_text, max_sampled, radius):
             continue
         by_speaker.setdefault(canonical, []).append(entry.get("text") or "")
 
+    # Book-wide word index and full roster, so the dry run can mirror the
+    # generation-time gate INCLUDING its bounded repair step. Without these two
+    # the dry run would over-report rejections relative to what a real run does.
+    source_words = source_word_index(source_text)
+
     report = []
     for name, texts in by_speaker.items():
         windows = []
@@ -149,12 +163,27 @@ def analyze(script_data, source_text, max_sampled, radius):
             end = min(len(source_text), found + len(text) + radius)
             windows.append(source_text[start:end])
 
+        # The roster this label would face at generation time is not knowable
+        # after the fact, so the dry run uses the FULL roster of the finished
+        # script -- an upper bound on what was established, and therefore an
+        # upper bound on both partial attestation and repair.
+        # The label itself is excluded from that roster: at generation time an
+        # established name skips the gate entirely, so leaving it in would make
+        # every label trivially attested and the report useless.
+        others = {key: value for key, value in roster_index.items()
+                  if value != name}
+        verdict = attest_speaker(name, windows, roster_index=others)
+        repaired = None
+        if verdict == UNATTESTED:
+            repaired = repair_speaker(name, windows, others, source_words)
+
         report.append({
             "name": name,
             "entry_count": len(texts),
             "sampled": min(len(texts), max_sampled),
             "located": located,
-            "verdict": attest_speaker(name, windows),
+            "verdict": verdict,
+            "repaired_to": repaired,
         })
 
     report.sort(key=lambda row: (-row["entry_count"], row["name"]))
@@ -197,7 +226,20 @@ def summarize(report, script_data):
               f"{entries:>10} {pct(entries, dialogue_entries)}")
     print("-" * 72)
 
-    rejected = by_verdict[UNATTESTED]
+    repairable = [row for row in by_verdict[UNATTESTED] if row["repaired_to"]]
+    if repairable:
+        repaired_entries = sum(row["entry_count"] for row in repairable)
+        print()
+        print("Of the UNATTESTED labels, these would NOT be rejected: bounded")
+        print("repair folds them onto an established spelling the book actually")
+        print("uses (speaker_canon.repair_speaker), so they keep a voice -- but")
+        print("under a name the model did not emit. Audit them:")
+        print(f"    {len(repairable)} speakers, {repaired_entries} entries")
+        for row in sorted(repairable, key=lambda r: -r["entry_count"]):
+            print(f"      {row['entry_count']:>6}  \"{row['name']}\" -> "
+                  f"\"{row['repaired_to']}\"")
+
+    rejected = [row for row in by_verdict[UNATTESTED] if not row["repaired_to"]]
     rejected_entries = sum(row["entry_count"] for row in rejected)
     print()
     print("If a gate rejected only UNATTESTED labels (the only verdict that is")
@@ -224,8 +266,10 @@ def list_rows(by_verdict, which):
         print(f"--- {verdict} ({len(rows)} speakers, most entries first) ---")
         print(f"{'entries':>8}  {'located':>8}  name")
         for row in rows:
+            suffix = (f"  -> repaired to \"{row['repaired_to']}\""
+                      if row.get("repaired_to") else "")
             print(f"{row['entry_count']:>8}  "
-                  f"{row['located']:>3}/{row['sampled']:<4}  {row['name']}")
+                  f"{row['located']:>3}/{row['sampled']:<4}  {row['name']}{suffix}")
 
 
 def main():

--- a/tools/verify_tts_normalization.py
+++ b/tools/verify_tts_normalization.py
@@ -1,0 +1,198 @@
+"""Empirical verification tool for the optional TTS text-normalization flag.
+
+Alexandria's audiobooks are verbatim by default: `config["tts"]
+["enable_nemo_normalization"]` defaults to False and the TTS engine sends
+narration text through unchanged (see app/tts_normalizer.py for the full
+design rationale, including the nemo -> wetext -> none backend chain).
+Whether turning normalization ON is worth it for a given book is an
+empirical question -- this script exists to answer it without guessing.
+
+Usage:
+    python tools/verify_tts_normalization.py
+        Text-only comparison: raw text vs. the active backend's
+        normalized text (nemo if available, else wetext, else
+        "unavailable") vs. pronunciation-dict-applied text. Works on any
+        machine -- on Windows nemo is normally unavailable but wetext has
+        prebuilt wheels, so this shows real normalized output there too.
+
+    python tools/verify_tts_normalization.py --synthesize
+        Additionally constructs a real TTSEngine from app/config.json and
+        renders the fixed test sentence to two wav files -- one with the
+        flag off, one with it on -- so you can listen to the difference.
+        Requires the TTS runtime deps (torch/numpy/soundfile/pydub) and at
+        least one configured voice in voice_config.json. On a dev machine
+        missing those deps this prints a clear message and exits 2 rather
+        than a traceback; on Linux/Colab (with deps + a configured voice)
+        it actually synthesizes.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+APP_DIR = os.path.join(ROOT_DIR, "app")
+if APP_DIR not in sys.path:
+    sys.path.insert(0, APP_DIR)
+
+import tts_normalizer  # noqa: E402  (must come after sys.path tweak above)
+
+FIXED_SENTENCE = "Dr. Halloway lived on Elm St."
+PRONUNCIATION_DICT_PATH = os.path.join(ROOT_DIR, "pronunciation_dict.json")
+
+
+def text_comparison():
+    """Compare raw / backend-normalized / dict-applied text. Works everywhere."""
+    print("=" * 70)
+    print("TTS normalization check -- text-only comparison")
+    print("=" * 70)
+    print(f"Raw text:             {FIXED_SENTENCE!r}")
+
+    normalizer_obj, backend_name = tts_normalizer._select_backend()
+    if normalizer_obj is None:
+        print("Normalized text:      <unavailable -- no backend>")
+        print(
+            "  Reason: neither nemo_text_processing nor wetext could be imported in\n"
+            "  this Python environment. Install one of:\n"
+            "      pip install nemo_text_processing   (Linux/Colab; highest fidelity)\n"
+            "      pip install wetext                 (Windows-friendly, prebuilt wheels)\n"
+            "  and re-run this script to see real normalized output."
+        )
+        backend_text = FIXED_SENTENCE
+    else:
+        backend_text = tts_normalizer._apply_backend_normalization(FIXED_SENTENCE)
+        print(f"Normalized text ({backend_name}): {backend_text!r}")
+        if backend_text != FIXED_SENTENCE:
+            print("  (differs from raw text)")
+        else:
+            print("  (identical to raw text)")
+        if backend_name == "wetext":
+            print(
+                "  Note: nemo_text_processing is unavailable in this environment (expected\n"
+                "  on Windows -- its pynini dependency has no prebuilt wheel), so wetext is\n"
+                "  carrying normalization here. wetext catches fewer cases than nemo (e.g. it\n"
+                "  won't expand \"St. Peter's\" -> \"Saint Peter's\") but never over-expands."
+            )
+
+    pdict = tts_normalizer.load_pronunciation_dict(PRONUNCIATION_DICT_PATH)
+    if pdict:
+        dict_applied = tts_normalizer._apply_pronunciation_dict(backend_text, pdict)
+        print(f"Pronunciation dict:   {PRONUNCIATION_DICT_PATH} ({len(pdict)} entries)")
+        print(f"Dict-applied text:    {dict_applied!r}")
+    else:
+        print(f"Pronunciation dict:   none found at {PRONUNCIATION_DICT_PATH!r} -- skipping this step.")
+
+    print("=" * 70)
+
+
+def _find_first_voice(voice_config):
+    for speaker, data in voice_config.items():
+        if isinstance(data, dict) and data.get("type"):
+            return speaker, data
+    return None, None
+
+
+def synthesize_comparison():
+    """Render the fixed sentence with the flag off and on via a real TTSEngine."""
+    config_path = os.environ.get("ALEXANDRIA_CONFIG_PATH") or os.path.join(APP_DIR, "config.json")
+    voice_config_path = os.path.join(ROOT_DIR, "voice_config.json")
+    out_dir = os.path.join(ROOT_DIR, "tools", "normalization_check")
+
+    print("\n" + "=" * 70)
+    print("TTS normalization check -- synthesis comparison")
+    print("=" * 70)
+
+    if not os.path.exists(config_path):
+        print(f"ERROR: config file not found at {config_path!r}. Cannot synthesize.")
+        print("(Set ALEXANDRIA_CONFIG_PATH, or create app/config.json, then re-run.)")
+        return 2
+    if not os.path.exists(voice_config_path):
+        print(f"ERROR: voice_config.json not found at {voice_config_path!r}. Cannot synthesize.")
+        print("(Configure at least one voice in the app first, then re-run.)")
+        return 2
+
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            config = json.load(f)
+        with open(voice_config_path, "r", encoding="utf-8") as f:
+            voice_config = json.load(f)
+    except Exception as exc:
+        print(f"ERROR: could not read config/voice_config JSON: {exc}")
+        return 2
+
+    speaker, _voice_data = _find_first_voice(voice_config)
+    if not speaker:
+        print(f"ERROR: no usable voice entries found in {voice_config_path!r}.")
+        print("Configure at least one voice before running --synthesize.")
+        return 2
+
+    try:
+        from tts import TTSEngine
+    except Exception as exc:
+        print(f"ERROR: could not import TTSEngine -- a TTS runtime dependency is missing\n"
+              f"in this Python environment (e.g. torch/numpy/soundfile/pydub): {exc}")
+        print("This is expected on a dev box without the TTS deps installed; "
+              "run --synthesize on Linux/Colab instead.")
+        return 2
+
+    os.makedirs(out_dir, exist_ok=True)
+    print(f"Using voice: {speaker!r}")
+    print(f"Output dir:  {out_dir}")
+
+    wrote_all = True
+    for flag_name, flag_value in (("flag_off", False), ("flag_on", True)):
+        cfg = dict(config)
+        tts_cfg = dict(cfg.get("tts", {}))
+        tts_cfg["enable_nemo_normalization"] = flag_value
+        cfg["tts"] = tts_cfg
+
+        print(f"\n--- {flag_name} (enable_nemo_normalization={flag_value}) ---")
+        try:
+            engine = TTSEngine(cfg)
+        except Exception as exc:
+            print(f"ERROR: could not construct TTSEngine: {exc}")
+            return 2
+
+        sent_text = engine._normalizer.normalize(FIXED_SENTENCE)
+        print(f"Text sent to engine: {sent_text!r}")
+
+        output_path = os.path.join(out_dir, f"{flag_name}.wav")
+        try:
+            success = engine.generate_voice(FIXED_SENTENCE, None, speaker, voice_config, output_path)
+        except Exception as exc:
+            print(f"ERROR during generation for {flag_name}: {exc}")
+            return 2
+
+        if success:
+            print(f"Wrote {output_path}")
+        else:
+            print(f"Generation reported failure for {flag_name} (speaker={speaker!r}).")
+            wrote_all = False
+
+    if not wrote_all:
+        print("\nNot all wavs were generated successfully -- see messages above.")
+        return 2
+
+    print(f"\nDone. Listen to and compare the wavs in {out_dir}")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Verify TTS text normalization output (text-only, or with --synthesize).")
+    parser.add_argument(
+        "--synthesize", action="store_true",
+        help="Also render audio via TTSEngine for flag off/on (needs torch/soundfile + a configured voice).",
+    )
+    args = parser.parse_args()
+
+    text_comparison()
+
+    if args.synthesize:
+        return synthesize_comparison()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)


### PR DESCRIPTION
# Verbatim audiobook pipeline: read the book, not a retelling of it

This changes the goal of the generation stage from "audio drama" to **industry-standard verbatim audiobook**. The author's text is read word for word, quoted dialogue gets character voices, and everything else — attribution tags, action beats, front matter — is read by the narrator.

The LLM becomes an **analytical classifier** and is never a generator of book text.

Everything below was measured against a full run of a real novel (790,543 characters, 281 chunks, ~8,100 script entries) and rendered to a finished 15-hour audiobook. Numbers are from that run unless stated.

---

## The core change

Previously the model was asked to rewrite the book into `{speaker, text, instruct}` objects. Any hallucination, truncation or "helpful" rephrasing became the audiobook, and the old review prompt actively instructed the model to strip attribution tags and expand abbreviations.

Now:

1. `span_tokenizer.py` splits each chunk into contiguous quoted/unquoted spans that tile the chunk exactly.
2. The model receives span **ids** plus their text and returns **labels only** — `{"id", "speaker", "role", "instruct"}`. The prompt explicitly forbids a `text` field.
3. Code rebuilds every entry as `source[span.start:span.end]`.

The consequence is structural rather than encouraged: **a truncated or hallucinating model costs labels, never prose.** Any span the model fails to label falls back to NARRATOR with its text intact.

Enforced by assertions that raise, not warnings:

- `span_tokenizer.validate_spans()` — spans tile the chunk with no gaps or overlaps
- `generate_script._assert_chunk_verbatim()` — each chunk's entries concatenate byte-for-byte back to the chunk
- `test_api.py::test_word_coverage_exact_one_across_failure_modes` — source-to-script word coverage is exactly 1.0
- Exit code `3` means "output written, but some spans fell back to NARRATOR" — degradation is counted, named by chunk and span, and surfaced in the UI

## Fidelity defects found and fixed

Each of these was silently corrupting output. All were found by auditing real runs, not by inspection.

**The extractor was injecting text into the book.** `HTMLParser` reports `<head><title>` through `handle_data`, and `SKIP_TAGS` covered only `style` and `script` — so every chapter's document title landed in the prose. On the test EPUB that is 22 occurrences of the string "Unknown", read aloud by the narrator. Skipping `title` (not `head` wholesale — this parser never implicitly closes `<head>`, so a document with an unclosed tag would lose a whole chapter) removes exactly 205 characters and adds nothing.

**`‘` opened unbounded quotations.** The left single quotation mark was exempt from all five tokenizer rules on the premise that it is unambiguous and therefore cannot run away. Measured against real ebook text that is false in two ways: converters emit a wrong-direction `‘` where an apostrophe belongs (`mochteroof‘s`), and an elided leading proper noun (`‘Mela`) is whitespace-preceded so no opener rule catches it. Result: 8 spans with a median length of 906 characters against 4,552 double-quoted spans with a median of 33, and **20,377 characters — 2.58% of the book — inside "quotations" that are narration**, offered to the classifier as dialogue. What that glyph guarantees is *direction*, not pairing, and rule 5 tests pairing. Applying rules 1 and 5 to it drops those spans to 2 (max 9 characters) and *raises* the double-quoted span count by 55, because dialogue buried inside the runaways now tokenizes normally.

**Chunking lost a paragraph break per seam.** The word-coverage test structurally could not see it, since `normalize_text` maps punctuation to spaces and every seam sits at punctuation. Added `test_chunking_is_byte_lossless_over_source`, which carries a copy of the old chunker as a counter-case.

**Misspelled schema keys cost delivery directions.** One run lost 31 `instruct` values across 13 spellings (`instructor`, `instruc`, `in instruct`, `instituct`…). A key is now folded onto a schema key when exactly one lies within a distance budget of `len(key)//4` — `instruct` 2, `speaker`/`role` 1, `id` 0, so `in` can never become `id`. Recovers 23 of the 31 observed losses; the rest stay reported. `text` is deliberately **not** a recovery target, so no spelling of it can admit model prose.

## Speaker identity

`speaker_canon.py` is a standalone module (stdlib + rapidfuzz) with a hard rule: **no fuzzy auto-merging of speaker names.** JON/JOHN and ELLA/BELLA are different people, and a wrongly merged roster entry cannot be split again — aliasing merges but never un-merges. Unification happens only on exact equality of `roster_key()`. `suggest_aliases()` exists but is advisory output for a human; nothing acts on it.

That rule earns its keep. A similarity matcher elsewhere in the codebase (persona generation, at 0.8) was silently merging `NITA → NITA'S DAD`, `KIT → KIT'S MOTHER` and `ROSHAUN → ROSHAUN'S FATHER` — a possessive relation scores high against the person it names while being a different character — and it was cyclic, so the winner depended on iteration order. Every merged speaker was **skipped**, leaving 28 of 65 speakers with no voice at all, one of them with 272 lines. Deleted in favour of exact-name matching.

**Attestation gate** (opt-in, `generation.require_attested_speakers`): a label is refused when the book does not support it near its own lines. Multi-token labels must appear as a **phrase**, adjacent and in order — token-set membership let the classifier invent a character by recombining words the prose supplies. On the test book that refused 5 fabricated labels, including a plausible full personal name assembled from two different characters' name parts, while keeping all 16 legitimate multi-token labels. Handling case, curly-vs-straight apostrophes, leading articles and possessive composition is not optional: one possessive-form label carried 50 correctly-attributed lines against only 5 occurrences of its phrase, so a naive check does far more damage than the bug.

**Adjacent attribution tags** (opt-in, `generation.check_attribution_tags`): the book states the answer next door and nothing read it. A quoted span labelled X, immediately followed by narration reading `Nita said.`, was never checked — 60 of 1,117 checkable pairs (5.4%) contradicted their own tag on a run that reported exit 0. A contradiction now joins the existing retry offenders and, if it survives, lands in the degradation report. **It detects; it never rewrites** — silently relabelling from nearby evidence is a separate mechanism already under scrutiny here. With it enabled, contradictions fell to 0.90%.

Recognizing a tag needs a speech verb, and any such list is English-fitted. It is confined to one named constant, contains nothing from any particular book, and is deliberately not config-exposed. On a non-English book the check **degrades to doing nothing** rather than misfiring — proven end-to-end with a French chunk carrying a deliberately wrong label on every line: zero detections, zero retries.

**Speaker repair** folds a refuted spelling onto an established name at edit distance 1. Its guards are all about spelling, none about who speaks, and empirically the model misspells names in exactly the chunks where it is also unsure who is talking. A repair contradicted by the adjacent tag is now refused and falls back to a real NARRATOR rejection. Validated against a known-bad repair from an earlier run, and honest about the limit: 63 of 89 repairs sit beside a pronoun tag or an action beat and no adjacent check can adjudicate them, so they are left alone and surfaced in an audit block.

## Review stage

Review can never touch text: `apply_positional_overlay()` re-imposes the original entry's `text` and takes only `speaker`/`instruct`.

Two defects made it worse than useless:

**Count is not alignment.** The overlay guarded only on entry count. A response with the right count but a duplicated entry and a dropped one shifted every later label one slot, filing correct labels against the wrong entries. Text stayed verbatim, so nothing caught it — `check_text_loss` compares accepted entries against the batch they were built *from*, a tautology. Measured: 34 misaligned slots in one run, 13 of them one contiguous run that demoted an entire conversation to NARRATOR. The overlay now compares each slot's echoed text (whitespace-normalized — models routinely add a leading space) and rejects the batch on a mismatch.

**The retry was unreachable for the only failure that occurs.** A valid-JSON-but-wrong-length array returned immediately. In one run, all 322 calls were attempt 1, every one `finish_reason=stop` with completions peaking at 2,966 of 4,096 tokens — no truncation, purely count mismatch, retried never, leaving 10.6% of the book unreviewed. Now it retries; 35 batches recovered in the next run.

With both fixed, review's own judgment is measurable, and **it does not help**: 129 changes moved misattribution from 5.37% to 5.33%, while handing narration to character voices 23 times and silencing quoted dialogue 20 times. Prompt tuning only redistributes the errors. The stage is left in place and correct, but this is worth knowing before running it.

## Rendering

**Narration no longer inherits a character's voice.** `build_entries` merged adjacent same-speaker spans with no awareness of span kind, so one entry could hold a quotation *and* the narration around it — and an entry gets one voice. 13,489 characters of narration, 2.53% of all narration, were spoken by characters; the worst single entry carried 961 characters of interior narration. Splitting alone fixes nothing (measured: exactly zero characters move, because the mislabelled tag keeps its label), so an unquoted span pressed directly against a quoted span with the **same** character label is handed back to NARRATOR. Result: 13,489 → 8,384 characters, and mixed-kind character entries 72 → 0, at a cost of 1.24% more entries.

Deliberately **not** done: a blanket "unquoted means narrator" rule. Books write telepathic and interior speech without quotation marks, and on the test book the largest quote-free character entries are exactly those. A blanket rule silences every one of them.

**Voice config no longer loses fields.** `VoiceConfigItem` declared no `alias_of` and had no `extra="allow"`, so `model_dump()` discarded it on every save: the UI's alias dropdown appeared to do nothing, and an alias set outside the UI was erased on the next autosave. This is the failure the other config models in the file already guard against.

**A speaker with no persona defaults to the narrator's voice** rather than falling through to whatever default the renderer has — as a *default*, not an alias, so it keeps its own entry and can be overridden. Reported loudly rather than applied silently.

**ffmpeg is found when installed but not on PATH.** pydub looks only on PATH; a conda-installed ffmpeg lives in the base environment's `Library/bin`, invisible from inside a venv. Both the converter and the prober are wired up by putting the directory on PATH — setting the documented attributes is not enough, because pydub calls its own `which()` when *loading* a file. That path is the merge step, so the failure would have landed only after every chunk was synthesized.

## Testing

Ten standalone suites (`python test_*.py`, not pytest), all offline — fake LLM clients, programmatically built EPUB fixtures, no server and no network. Tests assert **properties**, never fixtures from a particular book: exhaustive over every single edit of a schema key, over quote conventions, over synthesized rosters. New invariants include byte-lossless chunking, no character entry mixing quotation and narration, and word coverage exactly 1.0 across failure modes.

## Known limitations, stated rather than hidden

- **`MR SMITH` and `MRS SMITH` both canonicalize to `SMITH`**, merging a husband and wife into one voice. Needs a scoped fix plus a migration story for existing `voice_config.json` files.
- **Speaker repair has no second-book validation.** Its entire evidence base is one English, Latin-script novel with one dominant misspelling cluster. Its predicted failure mode — folding two genuinely similar names together — needs a dense name space (patronymics, transliterations) to test.
- **The `‘` fix is untested on a book that uses single quotes as its primary dialogue marks.** The test book has 8 such spans; British and Commonwealth typography exercises that path far harder, and only synthesized fixtures cover it here.
- **Descriptor labels can collide.** One label covered both an unnamed boy and, 5,000 entries later, a character the book names — one voice for two people. Detecting that needs coreference, not adjacency.
- **Roughly 34 standalone unquoted entries stay mis-voiced.** No purely structural rule separates mislabelled narration from authored unquoted speech.
- **Non-Western quote marks are unsupported.** `span_tokenizer` recognizes `" “ ” ' ‘ ’` only; guillemets and CJK brackets produce no quoted spans, so such dialogue is narrated. Safe — no text is lost — but a real gap.
- **NeMo normalization is unverifiable on Windows** (`pynini` ships source-only); `wetext` is the practical local fallback.

## Compatibility

- Verbatim reassembly and attestation are the default path; the attestation gate and the attribution-tag check are **opt-in** (`generation.require_attested_speakers`, `generation.check_attribution_tags`), both defaulting to false, because each spends retries and can turn a clean run into a degraded one.
- All config section models carry `extra="allow"`, so saving from the UI cannot drop keys the subprocesses read directly.
- Prompts are hot-reloaded from the root text files. A custom prompt saved before this change is rejected loudly (schema markers `span-labels-v1` / `verbatim-review-v1`) rather than used silently, since an old prompt asks the model to rewrite the book.
- `voice_config.json` carries a `_canon_version` stamp; `tts.resolve_voice` bridges generation 1 and 2 key spellings.

Happy to split this into smaller PRs if that is easier to review — the extractor, tokenizer, classifier and review changes are largely independent, and the commit history is organized that way.
